### PR TITLE
Graceful handling of new ENR fields not found in old local ENR record

### DIFF
--- a/ddht/app.py
+++ b/ddht/app.py
@@ -70,7 +70,10 @@ def get_local_enr(
         logger.info(f"No Node for {encode_hex(node_id)} found, creating new one")
         return minimal_enr
     else:
-        if any(base_enr[key] != value for key, value in minimal_enr.items()):
+        if any(
+            key not in base_enr or base_enr[key] != value
+            for key, value in minimal_enr.items()
+        ):
             logger.debug("Updating local ENR")
             return UnsignedENR(
                 sequence_number=base_enr.sequence_number + 1,


### PR DESCRIPTION
## What was wrong?

On application startup we generate a "minimal ENR" with basic data like the `port` and identity scheme version.  Then we load our own ENR from the node database and merge anything extra in from previous versions.

If the ENR in our database doesn't contain all of the the fields in our generated ENR then we currently get a `KeyError` exception.

## How was it fixed?

Change the merge code to check if the key is present before checking if the value matches.


#### Cute Animal Picture

![o-CHICKEN-facebook](https://user-images.githubusercontent.com/824194/88934685-28a61600-d23e-11ea-9f2d-8d5743480a3e.jpg)

