### PR TITLE
Graceful handling of invalid RLP in messages

### DIFF
--- a/ddht/v5/packer.py
+++ b/ddht/v5/packer.py
@@ -235,8 +235,9 @@ class PeerPacker(Service):
                 self.reset_handshake_state()
                 await self.handle_incoming_packet_pre_handshake(incoming_packet)
             except ValidationError as validation_error:
-                self.logger.warning("Received invalid packet: %s", validation_error)
-                raise  # let the service fail
+                self.logger.debug("Received invalid packet: %s", validation_error)
+                self.manager.cancel()
+                return
             else:
                 incoming_message = IncomingMessage(
                     message, incoming_packet.sender_endpoint, self.remote_node_id

--- a/ddht/v5/packets.py
+++ b/ddht/v5/packets.py
@@ -499,7 +499,7 @@ def _decrypt_message(
 
     try:
         message = rlp.decode(plain_text[1:], message_class)
-    except DecodingError as error:
+    except (DecodingError, DeserializationError) as error:
         raise ValidationError("Encrypted message does not contain valid RLP") from error
 
     return message  # type: ignore


### PR DESCRIPTION
fixes #12 

## What was wrong?

Invalid RLP in a message as well as invalid encoding of a `request_id` would crash the whole node.

## How was it fixed?

Basic exception handling.

#### Cute Animal Picture

![Unwanted-Rooster](https://user-images.githubusercontent.com/824194/88940085-95241380-d244-11ea-9806-f91fa8ecd0bc.jpg)

