### PR TITLE
Graceful handling of old ENR sequence numbers

### DIFF
--- a/ddht/app.py
+++ b/ddht/app.py
@@ -12,6 +12,7 @@ from ddht.abc import NodeDBAPI
 from ddht.boot_info import BootInfo
 from ddht.constants import NUM_ROUTING_TABLE_BUCKETS
 from ddht.enr import ENR, UnsignedENR
+from ddht.exceptions import OldSequenceNumber
 from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.kademlia import KademliaRoutingTable
 from ddht.node_db import NodeDB
@@ -104,7 +105,10 @@ class Application(Service):
 
         node_db.set_enr(local_enr)
         for enr in self._boot_info.bootnodes:
-            node_db.set_enr(enr)
+            try:
+                node_db.set_enr(enr)
+            except OldSequenceNumber:
+                pass
             routing_table.update(enr.node_id)
 
         port = self._boot_info.port

--- a/ddht/exceptions.py
+++ b/ddht/exceptions.py
@@ -28,3 +28,12 @@ class UnexpectedMessage(BaseDDHTError):
     """
 
     pass
+
+
+class OldSequenceNumber(Exception):
+    """
+    Raised when trying to update an ENR record with a sequence number that is
+    older than the latest sequence number we have seen
+    """
+
+    pass

--- a/ddht/node_db.py
+++ b/ddht/node_db.py
@@ -7,6 +7,7 @@ import rlp
 
 from ddht.abc import NodeDBAPI
 from ddht.enr import ENR
+from ddht.exceptions import OldSequenceNumber
 from ddht.identity_schemes import IdentitySchemeRegistry
 from ddht.typing import NodeID
 
@@ -46,7 +47,7 @@ class NodeDB(NodeDBAPI):
         except KeyError:
             existing_enr = None
         if existing_enr and existing_enr.sequence_number > enr.sequence_number:
-            raise ValueError(
+            raise OldSequenceNumber(
                 f"Cannot overwrite existing ENR ({existing_enr.sequence_number}) with old one "
                 f"({enr.sequence_number})"
             )


### PR DESCRIPTION
## What was wrong?

In some cases we will try to insert ENR records that have outdated sequence numbers.  This will happen with bootnodes as well as certain race conditions when a nodes ENR record has been updated recently.  We need to be able to reliably detect this and handle it.

## How was it fixed?

Added `OldSequenceNumber` exception that is raised by `node_db.set_enr` and added handling for this in the places I found it problematic.


#### Cute Animal Picture

![o-CHICKEN-facebook](https://user-images.githubusercontent.com/824194/88934685-28a61600-d23e-11ea-9f2d-8d5743480a3e.jpg)

