### PR TITLE
Parse bootnode ENRs in cli parser

### DIFF
--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -1,9 +1,11 @@
 import argparse
 import ipaddress
 import pathlib
+from typing import Any
 
 from ddht import __version__
 from ddht.cli_commands import do_main
+from ddht.enr import ENR
 
 parser = argparse.ArgumentParser(description="Discovery V5 DHT")
 parser.set_defaults(func=do_main)
@@ -40,13 +42,41 @@ logging_parser.add_argument(
     help=("Configure the logging level. "),
 )
 
+
 #
 # Network
 #
+class NormalizeAndAppendENR(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        value: Any,
+        option_string: str = None,
+    ) -> None:
+        if value is None:
+            return
+
+        enr = ENR.from_repr(value)
+
+        if getattr(namespace, self.dest) is None:
+            setattr(namespace, self.dest, ())
+
+        enr_list = getattr(namespace, self.dest)
+        enr_list += (enr,)
+
+        setattr(namespace, self.dest, enr_list)
+
+
 network_parser.add_argument(
     "--port", type=int, help="Port number for the discovery service"
 )
 network_parser.add_argument(
     "--listen-address", type=ipaddress.ip_address, help="IP address to listen on"
 )
-network_parser.add_argument("--bootnodes", help="IP address to listen on")
+network_parser.add_argument(
+    "--bootnode",
+    action=NormalizeAndAppendENR,
+    help="IP address to listen on",
+    dest="bootnodes",
+)

--- a/tests/core/test_cli_parsing_to_boot_info.py
+++ b/tests/core/test_cli_parsing_to_boot_info.py
@@ -6,11 +6,16 @@ import pytest
 
 from ddht.boot_info import BootInfo
 from ddht.tools.factories.boot_info import BootInfoFactory
+from ddht.tools.factories.discovery import ENRFactory
 
 KEY_RAW = b"unicornsrainbowsunicornsrainbows"
 KEY_HEX = KEY_RAW.hex()
 KEY_HEX_PREFIXED = "0x" + KEY_HEX
 KEY = keys.PrivateKey(KEY_RAW)
+
+
+ENR_A = ENRFactory()
+ENR_B = ENRFactory()
 
 
 @pytest.mark.parametrize(
@@ -31,6 +36,11 @@ KEY = keys.PrivateKey(KEY_RAW)
             dict(base_dir=pathlib.Path("./../test-relative-gets-resolved").resolve()),
         ),
         (("--private-key", KEY_HEX), dict(private_key=KEY)),
+        (("--bootnode", repr(ENR_A)), (dict(bootnodes=(ENR_A,))),),
+        (
+            ("--bootnode", repr(ENR_A), "--bootnode", repr(ENR_B)),
+            (dict(bootnodes=(ENR_A, ENR_B))),
+        ),
     ),
 )
 def test_cli_args_to_boot_info(args, factory_kwargs):


### PR DESCRIPTION
## What was wrong?

Bootnodes passed in via the CLI were not being parsed to their ENR representation.

## How was it fixed?

Added parsing to the cli parser and tests.

#### Cute Animal Picture

![hredirect2 php](https://user-images.githubusercontent.com/824194/88943417-ac650000-d248-11ea-9baa-9ae3a8a35624.jpeg)

