### PR TITLE
Piper/local enr handler

### DIFF
--- a/ddht/app.py
+++ b/ddht/app.py
@@ -66,14 +66,7 @@ class Application(Service):
 
         local_private_key = get_local_private_key(self._boot_info)
 
-        enr_manager = ENRManager(
-            node_db=node_db,
-            private_key=local_private_key,
-            base_kv_pairs={
-                b"id": b"v4",
-                b"secp256k1": local_private_key.public_key.to_compressed_bytes,
-            },
-        )
+        enr_manager = ENRManager(node_db=node_db, private_key=local_private_key,)
         self.manager.run_daemon_child_service(enr_manager)
 
         routing_table = KademliaRoutingTable(

--- a/ddht/enr_manager.py
+++ b/ddht/enr_manager.py
@@ -1,0 +1,58 @@
+from async_service import Service
+
+from ddht.abc import NodeDBAPI
+from ddht.enr import ENR
+from ddht.exceptions import OldSequenceNumber
+
+def get_local_enr(
+    boot_info: BootInfo,
+    node_db: NodeDBAPI,
+    local_private_key: keys.PrivateKey,
+    local_ip_address: Optional[AnyIPAddress],
+) -> ENR:
+    kv_pairs = {
+        b"id": b"v4",
+        b"secp256k1": local_private_key.public_key.to_compressed_bytes(),
+        b"udp": boot_info.port,
+    }
+    if local_ip_address is not None:
+        kv_pairs[IP_V4_ADDRESS_ENR_KEY] = local_ip_address.packed
+    minimal_enr = UnsignedENR(
+        sequence_number=1,
+        kv_pairs=kv_pairs,
+        identity_scheme_registry=default_identity_scheme_registry,
+    ).to_signed_enr(local_private_key.to_bytes())
+    node_id = minimal_enr.node_id
+
+    try:
+        base_enr = node_db.get_enr(node_id)
+    except KeyError:
+        logger.info(f"No Node for {encode_hex(node_id)} found, creating new one")
+        return minimal_enr
+    else:
+        if any(
+            key not in base_enr or base_enr[key] != value
+            for key, value in minimal_enr.items()
+        ):
+            logger.debug("Updating local ENR")
+            return UnsignedENR(
+                sequence_number=base_enr.sequence_number + 1,
+                kv_pairs=merge(dict(base_enr), dict(minimal_enr)),
+                identity_scheme_registry=default_identity_scheme_registry,
+            ).to_signed_enr(local_private_key.to_bytes())
+        else:
+            return base_enr
+
+class ENRManager(Service):
+    _node_db: NodeDBAPI
+    _enr: ENR
+
+    def __init__(self,
+                 node_db: NodeDBAPI,
+                 base_enr: ENR) -> None:
+        self._node_db = node_db
+
+        try:
+            self._node_db.set_enr(base_enr)
+
+    def update(self, *kv_pair: Tuple[bytes, bytes]) ->

--- a/ddht/enr_manager.py
+++ b/ddht/enr_manager.py
@@ -43,7 +43,7 @@ class ENRManager(Service):
         if kv_pairs is None:
             kv_pairs = {}
 
-        if b'id' in kv_pairs:
+        if b"id" in kv_pairs:
             identity_kv_pairs = {}
         else:
             identity_kv_pairs = {

--- a/tests/core/test_enr_manager.py
+++ b/tests/core/test_enr_manager.py
@@ -3,10 +3,8 @@ from eth.db.backends.memory import MemoryDB
 import pytest
 import trio
 
-from ddht.identity_schemes import (
-    default_identity_scheme_registry,
-)
 from ddht.enr_manager import ENRManager
+from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.node_db import NodeDB
 from ddht.tools.factories.discovery import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
@@ -40,45 +38,45 @@ def test_enr_manager_updates_existing_enr(node_db):
     enr = ENRFactory(
         private_key=private_key.to_bytes(),
         sequence_number=0,
-        custom_kv_pairs={b'unicorns': b'rainbows'},
+        custom_kv_pairs={b"unicorns": b"rainbows"},
     )
-    assert enr[b'unicorns'] == b'rainbows'
+    assert enr[b"unicorns"] == b"rainbows"
     node_db.set_enr(enr)
 
-    enr_manager = ENRManager(node_db, private_key, kv_pairs={b'unicorns': b'cupcakes'})
+    enr_manager = ENRManager(node_db, private_key, kv_pairs={b"unicorns": b"cupcakes"})
     assert enr_manager.enr != enr
     assert enr_manager.enr.sequence_number == enr.sequence_number + 1
-    assert enr_manager.enr[b'unicorns'] == b'cupcakes'
+    assert enr_manager.enr[b"unicorns"] == b"cupcakes"
 
     assert node_db.get_enr(enr_manager.enr.node_id) == enr_manager.enr
 
 
 def test_enr_manager_update_api(node_db):
     enr_manager = ENRManager(node_db, PrivateKeyFactory())
-    assert b'unicorns' not in enr_manager.enr
+    assert b"unicorns" not in enr_manager.enr
     base_enr = enr_manager.enr
 
-    enr_a = enr_manager.update((b'unicorns', b'rainbows'))
+    enr_a = enr_manager.update((b"unicorns", b"rainbows"))
     assert enr_a.sequence_number == base_enr.sequence_number + 1
 
-    assert enr_manager.enr[b'unicorns'] == b'rainbows'
+    assert enr_manager.enr[b"unicorns"] == b"rainbows"
 
-    enr_b = enr_manager.update((b'unicorns', b'cupcakes'))
+    enr_b = enr_manager.update((b"unicorns", b"cupcakes"))
     assert enr_b.sequence_number == enr_a.sequence_number + 1
 
-    assert enr_manager.enr[b'unicorns'] == b'cupcakes'
+    assert enr_manager.enr[b"unicorns"] == b"cupcakes"
 
 
 @pytest.mark.trio
 async def test_enr_manager_update_via_queue(node_db):
     enr_manager = ENRManager(node_db, PrivateKeyFactory())
     async with background_trio_service(enr_manager):
-        assert b'unicorns' not in enr_manager.enr
-        await enr_manager.async_update((b'unicorns', b'rainbows'))
+        assert b"unicorns" not in enr_manager.enr
+        await enr_manager.async_update((b"unicorns", b"rainbows"))
 
     for _ in range(10):
         await trio.hazmat.checkpoint()
-        if enr_manager.enr[b'unicorns'] == b'rainbows':
+        if enr_manager.enr[b"unicorns"] == b"rainbows":
             break
     else:
-        assert enr_manager.enr[b'unicorns'] == b'rainbows'
+        assert enr_manager.enr[b"unicorns"] == b"rainbows"

--- a/tests/core/test_enr_manager.py
+++ b/tests/core/test_enr_manager.py
@@ -1,0 +1,84 @@
+from async_service import background_trio_service
+from eth.db.backends.memory import MemoryDB
+import pytest
+import trio
+
+from ddht.identity_schemes import (
+    default_identity_scheme_registry,
+)
+from ddht.enr_manager import ENRManager
+from ddht.node_db import NodeDB
+from ddht.tools.factories.discovery import ENRFactory
+from ddht.tools.factories.keys import PrivateKeyFactory
+
+
+@pytest.fixture
+def node_db():
+    return NodeDB(default_identity_scheme_registry, MemoryDB())
+
+
+def test_enr_manager_creates_enr_if_not_present(node_db):
+    enr_manager = ENRManager(node_db, PrivateKeyFactory())
+    assert enr_manager.enr
+
+    assert node_db.get_enr(enr_manager.enr.node_id) == enr_manager.enr
+
+
+def test_enr_manager_handles_existing_enr(node_db):
+    private_key = PrivateKeyFactory()
+    enr = ENRFactory(private_key=private_key.to_bytes(), sequence_number=0)
+    node_db.set_enr(enr)
+
+    enr_manager = ENRManager(node_db, private_key)
+    assert enr_manager.enr == enr
+
+    assert node_db.get_enr(enr_manager.enr.node_id) == enr_manager.enr
+
+
+def test_enr_manager_updates_existing_enr(node_db):
+    private_key = PrivateKeyFactory()
+    enr = ENRFactory(
+        private_key=private_key.to_bytes(),
+        sequence_number=0,
+        custom_kv_pairs={b'unicorns': b'rainbows'},
+    )
+    assert enr[b'unicorns'] == b'rainbows'
+    node_db.set_enr(enr)
+
+    enr_manager = ENRManager(node_db, private_key, kv_pairs={b'unicorns': b'cupcakes'})
+    assert enr_manager.enr != enr
+    assert enr_manager.enr.sequence_number == enr.sequence_number + 1
+    assert enr_manager.enr[b'unicorns'] == b'cupcakes'
+
+    assert node_db.get_enr(enr_manager.enr.node_id) == enr_manager.enr
+
+
+def test_enr_manager_update_api(node_db):
+    enr_manager = ENRManager(node_db, PrivateKeyFactory())
+    assert b'unicorns' not in enr_manager.enr
+    base_enr = enr_manager.enr
+
+    enr_a = enr_manager.update((b'unicorns', b'rainbows'))
+    assert enr_a.sequence_number == base_enr.sequence_number + 1
+
+    assert enr_manager.enr[b'unicorns'] == b'rainbows'
+
+    enr_b = enr_manager.update((b'unicorns', b'cupcakes'))
+    assert enr_b.sequence_number == enr_a.sequence_number + 1
+
+    assert enr_manager.enr[b'unicorns'] == b'cupcakes'
+
+
+@pytest.mark.trio
+async def test_enr_manager_update_via_queue(node_db):
+    enr_manager = ENRManager(node_db, PrivateKeyFactory())
+    async with background_trio_service(enr_manager):
+        assert b'unicorns' not in enr_manager.enr
+        await enr_manager.async_update((b'unicorns', b'rainbows'))
+
+    for _ in range(10):
+        await trio.hazmat.checkpoint()
+        if enr_manager.enr[b'unicorns'] == b'rainbows':
+            break
+    else:
+        assert enr_manager.enr[b'unicorns'] == b'rainbows'


### PR DESCRIPTION
## What was wrong?

With UPnP coming, which will dynamically change the ENR record based on external IP discovered by UPnP we need a way to manage our local ENR record.  This will also come into play once we start counting votes from `PONG` messages about what our external IP address is.

## How was it fixed?

New very simple service that currently doesn't do much beyond lift the ENR initialization and merging logic out of the `Application` class and exposes an external API for updating the ENR.

#### Cute Animal Picture

![o-MEAN-CHICKEN-facebook](https://user-images.githubusercontent.com/824194/89067645-f0313580-d32c-11ea-957e-808abad12205.jpg)

