### PR TITLE
initialize disc v5.1 packet format

### DIFF
--- a/ddht/kademlia.py
+++ b/ddht/kademlia.py
@@ -7,7 +7,6 @@ import random
 import struct
 from typing import Any, Deque, Iterator, List, Optional, Tuple, Type, cast
 
-from cached_property import cached_property
 from eth_utils import big_endian_to_int, encode_hex
 
 from ddht.abc import AddressAPI, TAddress
@@ -63,7 +62,7 @@ class Address(AddressAPI):
     def ip(self) -> str:
         return str(self._ip)
 
-    @cached_property
+    @property
     def ip_packed(self) -> bytes:
         """The binary representation of this IP address."""
         return self._ip.packed

--- a/ddht/tools/driver/__init__.py
+++ b/ddht/tools/driver/__init__.py
@@ -1,0 +1,1 @@
+from .network import Network  # noqa: F401

--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -1,0 +1,95 @@
+from abc import ABC, abstractmethod
+from typing import NamedTuple
+
+from eth_keys import keys
+import trio
+
+from ddht.abc import NodeDBAPI
+from ddht.base_message import BaseMessage, IncomingMessage
+from ddht.endpoint import Endpoint
+from ddht.enr import ENR
+from ddht.typing import NodeID
+from ddht.v5_1.abc import SessionAPI
+from ddht.v5_1.envelope import IncomingEnvelope, OutgoingEnvelope
+from ddht.v5_1.packets import AnyPacket
+
+
+class NodeAPI(ABC):
+    enr: ENR
+    private_key: keys.PrivateKey
+    node_db: NodeDBAPI
+
+    @property
+    @abstractmethod
+    def endpoint(self) -> Endpoint:
+        ...
+
+    @property
+    @abstractmethod
+    def node_id(self) -> NodeID:
+        ...
+
+
+class SessionChannels(NamedTuple):
+    incoming_message_send_channel: trio.abc.SendChannel[IncomingMessage]
+    incoming_message_receive_channel: trio.abc.ReceiveChannel[IncomingMessage]
+    outgoing_envelope_send_channel: trio.abc.SendChannel[OutgoingEnvelope]
+    outgoing_envelope_receive_channel: trio.abc.ReceiveChannel[OutgoingEnvelope]
+
+    @classmethod
+    def init(cls) -> "SessionChannels":
+        (
+            incoming_message_send_channel,
+            incoming_message_receive_channel,
+        ) = trio.open_memory_channel[IncomingMessage](256)
+        (
+            outgoing_envelope_send_channel,
+            outgoing_envelope_receive_channel,
+        ) = trio.open_memory_channel[OutgoingEnvelope](256)
+        return cls(
+            incoming_message_send_channel,
+            incoming_message_receive_channel,
+            outgoing_envelope_send_channel,
+            outgoing_envelope_receive_channel,
+        )
+
+
+class SessionDriverAPI(ABC):
+    session: SessionAPI
+    channels: SessionChannels
+
+    @abstractmethod
+    async def send_message(self, message: BaseMessage) -> None:
+        ...
+
+    @abstractmethod
+    async def next_message(self) -> IncomingMessage:
+        ...
+
+
+class EnvelopePair(NamedTuple):
+    outgoing: OutgoingEnvelope
+    incoming: IncomingEnvelope
+
+    @property
+    def packet(self) -> AnyPacket:
+        return self.outgoing.packet
+
+
+class SessionPairAPI(ABC):
+    initiator: SessionDriverAPI
+    recipient: SessionDriverAPI
+
+    @abstractmethod
+    async def transmit_one(self, source: SessionDriverAPI) -> EnvelopePair:
+        ...
+
+
+class NetworkAPI(ABC):
+    @abstractmethod
+    def node(self) -> NodeAPI:
+        ...
+
+    @abstractmethod
+    def session_pair(self, initiator: NodeAPI, recipient: NodeAPI) -> SessionPairAPI:
+        ...

--- a/ddht/tools/driver/network.py
+++ b/ddht/tools/driver/network.py
@@ -1,0 +1,157 @@
+import functools
+from typing import Any, Callable, TypeVar, cast
+
+from eth_keys import keys
+import trio
+
+from ddht.abc import NodeDBAPI
+from ddht.base_message import BaseMessage, IncomingMessage, OutgoingMessage
+from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
+from ddht.endpoint import Endpoint
+from ddht.tools.driver.abc import (
+    EnvelopePair,
+    NetworkAPI,
+    NodeAPI,
+    SessionChannels,
+    SessionDriverAPI,
+    SessionPairAPI,
+)
+from ddht.tools.factories.discovery import EndpointFactory, ENRFactory
+from ddht.tools.factories.keys import PrivateKeyFactory
+from ddht.tools.factories.node_db import NodeDBFactory
+from ddht.typing import NodeID
+from ddht.v5_1.abc import SessionAPI
+from ddht.v5_1.envelope import IncomingEnvelope
+from ddht.v5_1.session import SessionInitiator, SessionRecipient
+
+
+class Node(NodeAPI):
+    def __init__(
+        self, private_key: keys.PrivateKey, endpoint: Endpoint, node_db: NodeDBAPI
+    ) -> None:
+        self.private_key = private_key
+        self.node_db = node_db
+        self.enr = ENRFactory(
+            private_key=private_key.to_bytes(),
+            address__ip=endpoint.ip_address,
+            address__udp_port=endpoint.port,
+        )
+        self.node_db.set_enr(self.enr)
+
+    @property
+    def endpoint(self) -> Endpoint:
+        return Endpoint(self.enr[IP_V4_ADDRESS_ENR_KEY], self.enr[UDP_PORT_ENR_KEY],)
+
+    @property
+    def node_id(self) -> NodeID:
+        return self.enr.node_id
+
+
+HANG_TIMEOUT = 10
+
+
+TCallable = TypeVar("TCallable", bound=Callable[..., Any])
+
+
+def no_hang(fn: TCallable) -> TCallable:
+    @functools.wraps(fn)
+    async def wrapper(*args: Any, **kwargs: Any) -> Any:
+        with trio.fail_after(HANG_TIMEOUT):
+            return await fn(*args, **kwargs)
+
+    return cast(TCallable, wrapper)
+
+
+class SessionDriver(SessionDriverAPI):
+    session: SessionAPI
+    channels: SessionChannels
+
+    def __init__(self, session: SessionAPI, channels: SessionChannels) -> None:
+        self.session = session
+        self.channels = channels
+
+    @no_hang
+    async def send_message(self, message: BaseMessage) -> None:
+        await self.session.handle_outgoing_message(
+            OutgoingMessage(
+                message=message,
+                receiver_endpoint=self.session.remote_endpoint,
+                receiver_node_id=self.session.remote_node_id,
+            )
+        )
+
+    @no_hang
+    async def next_message(self) -> IncomingMessage:
+        return await self.channels.incoming_message_receive_channel.receive()
+
+
+class SessionPair(SessionPairAPI):
+    def __init__(
+        self,
+        initiator: SessionAPI,
+        initiator_channels: SessionChannels,
+        recipient: SessionAPI,
+        recipient_channels: SessionChannels,
+    ) -> None:
+        self.initiator = SessionDriver(initiator, initiator_channels)
+        self.recipient = SessionDriver(recipient, recipient_channels)
+
+    @no_hang
+    async def transmit_one(self, source: SessionDriverAPI) -> EnvelopePair:
+        if source.session.id == self.initiator.session.id:
+            target = self.recipient
+        elif source.session.id == self.recipient.session.id:
+            target = self.initiator
+        else:
+            raise Exception(
+                f"Unrecognized source: {source}: Must be one of "
+                f"{self.initiator} or {self.recipient}"
+            )
+
+        outgoing_envelope = (
+            await source.channels.outgoing_envelope_receive_channel.receive()
+        )
+        incoming_envelope = IncomingEnvelope(
+            outgoing_envelope.packet, sender_endpoint=source.session.remote_endpoint,
+        )
+        await target.session.handle_incoming_envelope(incoming_envelope)
+        return EnvelopePair(outgoing_envelope, incoming_envelope)
+
+
+class Network(NetworkAPI):
+    def node(self) -> Node:
+        return Node(
+            private_key=PrivateKeyFactory(),
+            endpoint=EndpointFactory(),
+            node_db=NodeDBFactory(),
+        )
+
+    def session_pair(self, initiator: NodeAPI, recipient: NodeAPI) -> SessionPair:
+        initiator_channels = SessionChannels.init()
+        initiator_session = SessionInitiator(
+            local_private_key=initiator.private_key.to_bytes(),
+            local_node_id=initiator.node_id,
+            remote_endpoint=recipient.endpoint,
+            remote_node_id=recipient.node_id,
+            node_db=initiator.node_db,
+            incoming_message_send_channel=initiator_channels.incoming_message_send_channel,
+            outgoing_envelope_send_channel=initiator_channels.outgoing_envelope_send_channel,
+        )
+        # the initiator always needs to have the remote enr present in their database
+        initiator.node_db.set_enr(recipient.enr)
+
+        recipient_channels = SessionChannels.init()
+        recipient_session = SessionRecipient(
+            local_private_key=recipient.private_key.to_bytes(),
+            local_node_id=recipient.node_id,
+            remote_endpoint=initiator.endpoint,
+            node_db=recipient.node_db,
+            incoming_message_send_channel=recipient_channels.incoming_message_send_channel,
+            outgoing_envelope_send_channel=recipient_channels.outgoing_envelope_send_channel,
+        )
+        return SessionPair(
+            initiator=initiator_session,
+            initiator_channels=initiator_channels,
+            recipient=recipient_session,
+            recipient_channels=recipient_channels,
+        )

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+import uuid
+
+from ddht.abc import EventAPI
+from ddht.base_message import OutgoingMessage
+from ddht.endpoint import Endpoint
+from ddht.typing import NodeID, SessionKeys
+from ddht.v5_1.envelope import IncomingEnvelope
+
+
+class SessionAPI(ABC):
+    id: uuid.UUID
+    remote_endpoint: Endpoint
+
+    @property
+    @abstractmethod
+    def remote_node_id(self) -> NodeID:
+        ...
+
+    @property
+    @abstractmethod
+    def keys(self) -> SessionKeys:
+        ...
+
+    @abstractmethod
+    async def handle_outgoing_message(self, message: OutgoingMessage) -> None:
+        ...
+
+    @abstractmethod
+    async def handle_incoming_envelope(self, envelope: IncomingEnvelope) -> None:
+        ...
+
+
+class EventsAPI(ABC):
+    session_created: EventAPI[SessionAPI]

--- a/ddht/v5_1/envelope.py
+++ b/ddht/v5_1/envelope.py
@@ -1,0 +1,77 @@
+import logging
+from typing import NamedTuple
+
+from async_service import ManagerAPI, as_service
+from eth_utils import ValidationError
+from trio.abc import ReceiveChannel, SendChannel
+
+from ddht.datagram import IncomingDatagram, OutgoingDatagram
+from ddht.endpoint import Endpoint
+from ddht.typing import NodeID
+from ddht.v5_1.packets import AnyPacket, decode_packet
+
+
+#
+# Data structures
+#
+class IncomingEnvelope(NamedTuple):
+    packet: AnyPacket
+    sender_endpoint: Endpoint
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.packet.__class__.__name__}]"
+
+
+class OutgoingEnvelope(NamedTuple):
+    packet: AnyPacket
+    receiver_endpoint: Endpoint
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.packet.__class__.__name__}]"
+
+
+#
+# Packet encoding/decoding
+#
+@as_service
+async def PacketDecoder(
+    manager: ManagerAPI,
+    incoming_datagram_receive_channel: ReceiveChannel[IncomingDatagram],
+    incoming_packet_send_channel: SendChannel[IncomingEnvelope],
+    local_node_id: NodeID,
+) -> None:
+    """Decodes incoming datagrams to packet objects."""
+    logger = logging.getLogger("ddht.v5.channel_services.PacketDecoder")
+
+    async with incoming_datagram_receive_channel, incoming_packet_send_channel:
+        packet: AnyPacket
+        async for datagram, endpoint in incoming_datagram_receive_channel:
+            try:
+                packet = decode_packet(datagram, local_node_id)
+                logger.debug(
+                    f"Successfully decoded {packet.__class__.__name__} from {endpoint}"
+                )
+            except ValidationError:
+                logger.warning(
+                    f"Failed to decode a packet from {endpoint}", exc_info=True
+                )
+            else:
+                await incoming_packet_send_channel.send(
+                    IncomingEnvelope(packet, endpoint)
+                )
+
+
+@as_service
+async def PacketEncoder(
+    manager: ManagerAPI,
+    outgoing_packet_receive_channel: ReceiveChannel[OutgoingEnvelope],
+    outgoing_datagram_send_channel: SendChannel[OutgoingDatagram],
+) -> None:
+    """Encodes outgoing packets to datagrams."""
+    logger = logging.getLogger("ddht.v5.channel_services.PacketEncoder")
+
+    async with outgoing_packet_receive_channel, outgoing_datagram_send_channel:
+        async for packet, endpoint in outgoing_packet_receive_channel:
+            outgoing_datagram = OutgoingDatagram(packet.to_wire_bytes(), endpoint)
+            logger.debug(f"Encoded {packet.__class__.__name__} for {endpoint}")
+            await outgoing_datagram_send_channel.send(outgoing_datagram)

--- a/ddht/v5_1/events.py
+++ b/ddht/v5_1/events.py
@@ -1,0 +1,8 @@
+from ddht.abc import EventAPI
+from ddht.event import Event
+from ddht.v5_1.abc import EventsAPI, SessionAPI
+
+
+class Events(EventsAPI):
+    def __init__(self) -> None:
+        self.session_created: EventAPI[SessionAPI] = Event("session-created")

--- a/ddht/v5_1/messages.py
+++ b/ddht/v5_1/messages.py
@@ -1,0 +1,103 @@
+from rlp.sedes import Binary, CountableList, big_endian_int, binary
+
+from ddht.base_message import BaseMessage
+from ddht.enr import ENR, ENRSedes
+from ddht.message_registry import MessageTypeRegistry
+from ddht.sedes import ip_address_sedes
+from ddht.v5.constants import TOPIC_HASH_SIZE
+
+topic_sedes = Binary.fixed_length(TOPIC_HASH_SIZE)
+
+
+v51_registry = MessageTypeRegistry()
+
+
+#
+# Message types
+#
+@v51_registry.register
+class PingMessage(BaseMessage):
+    message_type = 1
+
+    fields = (("request_id", big_endian_int), ("enr_seq", big_endian_int))
+
+
+@v51_registry.register
+class PongMessage(BaseMessage):
+    message_type = 2
+
+    fields = (
+        ("request_id", big_endian_int),
+        ("enr_seq", big_endian_int),
+        ("packet_ip", ip_address_sedes),
+        ("packet_port", big_endian_int),
+    )
+
+
+@v51_registry.register
+class FindNodeMessage(BaseMessage):
+    message_type = 3
+
+    fields = (("request_id", big_endian_int), ("distance", big_endian_int))
+
+
+@v51_registry.register
+class NodesMessage(BaseMessage):
+    message_type = 4
+
+    fields = (
+        ("request_id", big_endian_int),
+        ("total", big_endian_int),
+        ("enrs", CountableList(ENR)),
+    )
+
+
+@v51_registry.register
+class TalkReqMessage(BaseMessage):
+    message_type = 5
+
+    fields = (("request_id", big_endian_int), ("protocol", binary), ("request", binary))
+
+
+@v51_registry.register
+class TalkRespMessage(BaseMessage):
+    message_type = 6
+
+    fields = (("request_id", big_endian_int), ("response", binary))
+
+
+@v51_registry.register
+class RegTopicMessage(BaseMessage):
+    message_type = 7
+
+    fields = (
+        ("request_id", big_endian_int),
+        ("topic", topic_sedes),
+        ("enr", ENRSedes),
+        ("ticket", binary),
+    )
+
+
+@v51_registry.register
+class TicketMessage(BaseMessage):
+    message_type = 8
+
+    fields = (
+        ("request_id", big_endian_int),
+        ("ticket", binary),
+        ("wait_time", big_endian_int),
+    )
+
+
+@v51_registry.register
+class RegConfirmationMessage(BaseMessage):
+    message_type = 9
+
+    fields = (("request_id", big_endian_int), ("topic", binary))
+
+
+@v51_registry.register
+class TopicQueryMessage(BaseMessage):
+    message_type = 10
+
+    fields = (("request_id", big_endian_int), ("topic", topic_sedes))

--- a/ddht/v5_1/packets.py
+++ b/ddht/v5_1/packets.py
@@ -1,0 +1,248 @@
+from dataclasses import dataclass, field
+from io import BytesIO
+import secrets
+import struct
+from typing import Generic, NamedTuple, Optional, TypeVar, Union, cast
+
+from eth_utils.toolz import take
+import rlp
+
+from ddht.base_message import BaseMessage
+from ddht.encryption import aesctr_decrypt_stream, aesctr_encrypt, aesgcm_encrypt
+from ddht.enr import ENR, ENRSedes
+from ddht.typing import AES128Key, IDNonce, NodeID, Nonce
+
+PROTOCOL_ID = b"discv5  "
+
+
+UINT8_TO_BYTES = {v: bytes([v]) for v in range(256)}
+
+
+@dataclass(frozen=True)
+class MessagePacket:
+    aes_gcm_nonce: Nonce  # 96 bit AES/GCM nonce
+
+    flag: int = field(init=False, repr=False, default=0)
+
+    def to_wire_bytes(self) -> bytes:
+        return self.aes_gcm_nonce
+
+    @classmethod
+    def from_wire_bytes(cls, data: bytes) -> "MessagePacket":
+        if len(data) != 12:
+            raise Exception("TODO")
+        return cls(cast(Nonce, data))
+
+
+@dataclass(frozen=True)
+class WhoAreYouPacket:
+    request_nonce: Nonce  # uint96
+    id_nonce: IDNonce  # uint256
+    enr_sequence_number: int  # uint64
+
+    flag: int = field(init=False, repr=False, default=1)
+
+    def to_wire_bytes(self) -> bytes:
+        return b"".join(
+            (
+                self.request_nonce,
+                self.id_nonce,
+                struct.pack(">Q", self.enr_sequence_number),
+            )
+        )
+
+    @classmethod
+    def from_wire_bytes(cls, data: bytes) -> "WhoAreYouPacket":
+        if len(data) != 52:
+            raise Exception("TODO")
+        stream = BytesIO(data)
+        request_nonce = cast(Nonce, stream.read(12))
+        id_nonce = cast(IDNonce, stream.read(32))
+        enr_sequence_number = int.from_bytes(stream.read(8), "big")
+        return cls(request_nonce, id_nonce, enr_sequence_number)
+
+
+class HandshakeHeader(NamedTuple):
+    version: int  # uint8  (1 for v4)
+    signature_size: int  # uint8  (64 for v4)
+    ephemeral_key_size: int  # uint8 (33 for v4)
+
+    def to_wire_bytes(self) -> bytes:
+        return b"".join(
+            (
+                UINT8_TO_BYTES[self.version],
+                UINT8_TO_BYTES[self.signature_size],
+                UINT8_TO_BYTES[self.ephemeral_key_size],
+            )
+        )
+
+    @classmethod
+    def v4_header(cls) -> "HandshakeHeader":
+        return cls(1, 64, 33)
+
+    @classmethod
+    def from_wire_bytes(cls, data: bytes) -> "HandshakeHeader":
+        if len(data) != 3:
+            raise Exception("TODO")
+        version = data[0]
+        signature_size = data[1]
+        ephemeral_key_size = data[2]
+        return cls(version, signature_size, ephemeral_key_size)
+
+
+@dataclass(frozen=True)
+class HandshakePacket:
+    auth_data_head: HandshakeHeader
+    id_signature: bytes
+    ephemeral_public_key: bytes
+    record: Optional[ENR]
+
+    flag: int = field(init=False, repr=False, default=2)
+
+    def to_wire_bytes(self) -> bytes:
+        return b"".join(
+            (
+                self.auth_data_head.to_wire_bytes(),
+                self.id_signature,
+                self.ephemeral_public_key,
+                (b"" if self.record is None else rlp.encode(self.record, ENRSedes)),
+            )
+        )
+
+    @classmethod
+    def from_wire_bytes(cls, data: bytes) -> "HandshakePacket":
+        stream = BytesIO(data)
+        auth_data_head = HandshakeHeader.from_wire_bytes(stream.read(3))
+        if (
+            len(data)
+            < 3 + auth_data_head.signature_size + auth_data_head.ephemeral_key_size
+        ):
+            raise Exception("TODO")
+        id_signature = stream.read(auth_data_head.signature_size)
+        ephemeral_public_key = stream.read(auth_data_head.ephemeral_key_size)
+        enr_bytes = stream.read()
+        if len(enr_bytes) > 0:
+            enr = rlp.decode(enr_bytes, sedes=ENRSedes)
+        else:
+            enr = None
+
+        return cls(auth_data_head, id_signature, ephemeral_public_key, enr,)
+
+
+class Header(NamedTuple):
+    protocol_id: bytes
+    source_node_id: NodeID
+    flag: int  # uint8
+    auth_data_size: int  # uint16
+
+    def to_wire_bytes(self) -> bytes:
+        return b"".join(
+            (
+                self.protocol_id,
+                self.source_node_id,
+                UINT8_TO_BYTES[self.flag],
+                self.auth_data_size.to_bytes(2, "big"),
+            )
+        )
+
+    @classmethod
+    def from_wire_bytes(cls, data: bytes) -> "Header":
+        protocol_id = data[:8]
+        remote_node_id = cast(NodeID, data[8:40])
+        flag = data[40]
+        auth_data_size = int.from_bytes(data[41:43], "big")
+        return cls(protocol_id, remote_node_id, flag, auth_data_size)
+
+
+AuthData = Union[MessagePacket, WhoAreYouPacket, HandshakePacket]
+TAuthData = TypeVar("TAuthData", bound=AuthData)
+
+
+@dataclass(frozen=True)
+class Packet(Generic[TAuthData]):
+    header: Header
+    auth_data: TAuthData
+    message_cipher_text: bytes
+    dest_node_id: NodeID
+
+    @property
+    def is_message(self) -> bool:
+        return type(self.auth_data) is MessagePacket
+
+    @property
+    def is_who_are_you(self) -> bool:
+        return type(self.auth_data) is WhoAreYouPacket
+
+    @property
+    def is_handshake(self) -> bool:
+        return type(self.auth_data) is HandshakePacket
+
+    @classmethod
+    def prepare(
+        cls,
+        *,
+        nonce: Nonce,
+        initiator_key: AES128Key,
+        message: BaseMessage,
+        auth_data: TAuthData,
+        source_node_id: NodeID,
+        dest_node_id: NodeID,
+        protocol_id: bytes = PROTOCOL_ID,
+    ) -> "Packet[TAuthData]":
+        auth_data_bytes = auth_data.to_wire_bytes()
+        auth_data_size = len(auth_data_bytes)
+        header = Header(protocol_id, source_node_id, auth_data.flag, auth_data_size,)
+        message_cipher_text = aesgcm_encrypt(
+            key=initiator_key,
+            nonce=nonce,
+            plain_text=message.to_bytes(),
+            authenticated_data=header.to_wire_bytes() + auth_data.to_wire_bytes(),
+        )
+        return cls(
+            header=header,
+            auth_data=auth_data,
+            message_cipher_text=message_cipher_text,
+            dest_node_id=dest_node_id,
+        )
+
+    def to_wire_bytes(self) -> bytes:
+        auth_data_bytes = self.auth_data.to_wire_bytes()
+        header_wire_bytes = self.header.to_wire_bytes()
+        plain_header = header_wire_bytes + auth_data_bytes
+        masking_key = cast(AES128Key, self.dest_node_id[:16])
+        masking_iv = secrets.token_bytes(16)
+        masked_header = aesctr_encrypt(masking_key, masking_iv, plain_header)
+        return b"".join((masking_iv, masked_header, self.message_cipher_text,))
+
+
+AnyPacket = Union[
+    Packet[MessagePacket], Packet[WhoAreYouPacket], Packet[HandshakePacket],
+]
+
+
+def decode_packet(data: bytes, local_node_id: NodeID,) -> AnyPacket:
+    iv = data[:16]
+    masking_key = cast(AES128Key, local_node_id[:16])
+    cipher_text_stream = aesctr_decrypt_stream(masking_key, iv, data[16:])
+
+    # Decode the header
+    header_bytes = bytes(take(43, cipher_text_stream))
+    header = Header.from_wire_bytes(header_bytes)
+
+    auth_data_bytes = bytes(take(header.auth_data_size, cipher_text_stream))
+    auth_data: Union[MessagePacket, WhoAreYouPacket, HandshakePacket]
+    if header.flag == 0:
+        auth_data = MessagePacket.from_wire_bytes(auth_data_bytes)
+    elif header.flag == 1:
+        auth_data = WhoAreYouPacket.from_wire_bytes(auth_data_bytes)
+    elif header.flag == 2:
+        auth_data = HandshakePacket.from_wire_bytes(auth_data_bytes)
+    else:
+        raise Exception("TODO")
+
+    message_cipher_text = data[16 + 43 + header.auth_data_size :]
+
+    return cast(
+        AnyPacket,
+        Packet(header, auth_data, message_cipher_text, dest_node_id=local_node_id),
+    )

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -1,0 +1,420 @@
+import enum
+import logging
+import secrets
+from typing import Tuple, cast
+import uuid
+
+from eth_keys import keys
+import rlp
+import trio
+
+from ddht.abc import NodeDBAPI
+from ddht.base_message import BaseMessage, IncomingMessage, OutgoingMessage
+from ddht.encryption import aesgcm_decrypt
+from ddht.endpoint import Endpoint
+from ddht.enr import ENR
+from ddht.message_registry import MessageTypeRegistry
+from ddht.typing import AES128Key, IDNonce, NodeID, Nonce, SessionKeys
+from ddht.v5_1.abc import EventsAPI, SessionAPI
+from ddht.v5_1.envelope import IncomingEnvelope, OutgoingEnvelope
+from ddht.v5_1.events import Events
+from ddht.v5_1.messages import v51_registry
+from ddht.v5_1.packets import (
+    HandshakeHeader,
+    HandshakePacket,
+    MessagePacket,
+    Packet,
+    WhoAreYouPacket,
+)
+
+RANDOM_ENCRYPTED_DATA_SIZE = 12
+
+
+class SessionStatus(enum.Enum):
+    BEFORE = enum.auto()
+    DURING = enum.auto()
+    AFTER = enum.auto()
+
+
+class BaseSession(SessionAPI):
+    _remote_node_id: NodeID
+    _keys: SessionKeys
+
+    logger = logging.getLogger("ddht.session.Session")
+
+    def __init__(
+        self,
+        local_private_key: bytes,
+        local_node_id: NodeID,
+        remote_endpoint: Endpoint,
+        node_db: NodeDBAPI,
+        incoming_message_send_channel: trio.abc.SendChannel[IncomingMessage],
+        outgoing_envelope_send_channel: trio.abc.SendChannel[OutgoingEnvelope],
+        message_type_registry: MessageTypeRegistry = v51_registry,
+        events: EventsAPI = None,
+    ) -> None:
+        self.id = uuid.uuid4()
+
+        if events is None:
+            events = Events()
+
+        self._events = events
+
+        self._local_private_key = local_private_key
+        self._local_node_id = local_node_id
+        self.remote_endpoint = remote_endpoint
+        self._node_db = node_db
+
+        self._message_type_registry = message_type_registry
+
+        self._status = SessionStatus.BEFORE
+
+        (
+            self._outgoing_message_buffer_send_channel,
+            self._outgoing_message_buffer_receive_channel,
+        ) = trio.open_memory_channel[BaseMessage](256)
+        (
+            self._incoming_envelope_buffer_send_channel,
+            self._incoming_envelope_buffer_receive_channel,
+        ) = trio.open_memory_channel[IncomingEnvelope](256)
+
+        self._incoming_message_send_channel = incoming_message_send_channel
+        self._outgoing_envelope_send_channel = outgoing_envelope_send_channel
+
+    @property
+    def is_before_handshake(self) -> bool:
+        return self._status is SessionStatus.BEFORE
+
+    @property
+    def is_during_handshake(self) -> bool:
+        return self._status is SessionStatus.DURING
+
+    @property
+    def is_after_handshake(self) -> bool:
+        return self._status is SessionStatus.AFTER
+
+    @property
+    def keys(self) -> SessionKeys:
+        if self.is_after_handshake:
+            return self._keys
+        raise AttributeError(
+            "Session keys are not available until after the handshake has completed"
+        )
+
+    async def _process_message_buffers(self) -> None:
+        if not self.is_after_handshake:
+            raise Exception("TODO")
+        await self._incoming_envelope_buffer_send_channel.aclose()
+        async with self._incoming_envelope_buffer_receive_channel:
+            async for envelope in self._incoming_envelope_buffer_receive_channel:
+                await self.handle_incoming_envelope(envelope)
+
+        await self._outgoing_message_buffer_send_channel.aclose()
+        async with self._outgoing_message_buffer_receive_channel:
+            async for message in self._outgoing_message_buffer_receive_channel:
+                await self.handle_outgoing_message(message)
+
+
+class RandomMessage(BaseMessage):
+    def __init__(self) -> None:
+        self.random_data = secrets.token_bytes(RANDOM_ENCRYPTED_DATA_SIZE)
+
+    def to_bytes(self) -> bytes:
+        return self.random_data
+
+
+class EmptyMessage(BaseMessage):
+    def to_bytes(self) -> bytes:
+        return b""
+
+
+#
+# Initiator
+#
+class SessionInitiator(BaseSession):
+    is_initiator = True
+
+    def __init__(
+        self,
+        local_private_key: bytes,
+        local_node_id: NodeID,
+        remote_node_id: NodeID,
+        remote_endpoint: Endpoint,
+        node_db: NodeDBAPI,
+        incoming_message_send_channel: trio.abc.SendChannel[IncomingMessage],
+        outgoing_envelope_send_channel: trio.abc.SendChannel[OutgoingEnvelope],
+        message_type_registry: MessageTypeRegistry = v51_registry,
+    ) -> None:
+        super().__init__(
+            local_private_key=local_private_key,
+            local_node_id=local_node_id,
+            remote_endpoint=remote_endpoint,
+            node_db=node_db,
+            incoming_message_send_channel=incoming_message_send_channel,
+            outgoing_envelope_send_channel=outgoing_envelope_send_channel,
+            message_type_registry=message_type_registry,
+        )
+        self._remote_node_id = remote_node_id
+
+    @property
+    def remote_node_id(self) -> NodeID:
+        return self._remote_node_id
+
+    @property
+    def remote_enr(self) -> ENR:
+        return self._node_db.get_enr(self.remote_node_id)
+
+    async def handle_outgoing_message(self, message: OutgoingMessage) -> None:
+        if self.is_after_handshake:
+            raise NotImplementedError
+        elif self.is_during_handshake:
+            raise NotImplementedError
+        elif self.is_before_handshake:
+            self.logger.debug(
+                "%s: outgoing message triggered handshake initiation: %s",
+                self,
+                message,
+            )
+            self._initial_message = message
+            self._status = SessionStatus.DURING
+            await self._send_handshake_initiation()
+        else:
+            raise Exception("Invariant: All states handled")
+
+    async def handle_incoming_envelope(self, envelope: IncomingEnvelope) -> None:
+        if self.is_after_handshake:
+            raise NotImplementedError
+        elif self.is_during_handshake:
+            if envelope.packet.is_who_are_you:
+                (
+                    self._keys,
+                    ephemeral_public_key,
+                ) = await self._receive_handshake_response(
+                    cast(Packet[WhoAreYouPacket], envelope.packet)
+                )
+                self._status = SessionStatus.AFTER
+
+                await self._send_handshake_completion(
+                    self._keys,
+                    ephemeral_public_key,
+                    cast(Packet[WhoAreYouPacket], envelope.packet),
+                )
+                await self._process_message_buffers()
+            else:
+                self.logger.debug(
+                    "%s: expected who-are-you packet.  got %s", self, envelope
+                )
+                self._incoming_envelope_buffer_send_channel.send_nowait(envelope)
+        elif self.is_before_handshake:
+            # Likely that both nodes are handshaking with each other at the
+            # same time...
+            self._incoming_envelope_buffer_send_channel.send_nowait(envelope)
+        else:
+            raise Exception("Invariant: All states handled")
+
+    async def _send_handshake_initiation(self) -> None:
+        self._initiating_packet = Packet.prepare(
+            nonce=cast(Nonce, secrets.token_bytes(12)),
+            initiator_key=cast(AES128Key, secrets.token_bytes(16)),
+            message=RandomMessage(),
+            auth_data=MessagePacket(aes_gcm_nonce=cast(Nonce, secrets.token_bytes(12))),
+            source_node_id=self._local_node_id,
+            dest_node_id=self.remote_node_id,
+        )
+        await self._outgoing_envelope_send_channel.send(
+            OutgoingEnvelope(
+                packet=self._initiating_packet, receiver_endpoint=self.remote_endpoint,
+            )
+        )
+
+    async def _receive_handshake_response(
+        self, packet: Packet[WhoAreYouPacket],
+    ) -> Tuple[SessionKeys, bytes]:
+        self.logger.debug("%s: receiving handshake response", self)
+
+        # compute session keys
+        ephemeral_private_key = keys.PrivateKey(secrets.token_bytes(32))
+
+        remote_enr = self.remote_enr
+        session_keys = remote_enr.identity_scheme.compute_session_keys(
+            local_private_key=ephemeral_private_key.to_bytes(),
+            remote_public_key=remote_enr.public_key,
+            local_node_id=self._local_node_id,
+            remote_node_id=self.remote_node_id,
+            id_nonce=packet.auth_data.id_nonce,
+            is_locally_initiated=True,
+        )
+
+        return session_keys, ephemeral_private_key.public_key.to_compressed_bytes()
+
+    async def _send_handshake_completion(
+        self,
+        session_keys: SessionKeys,
+        ephemeral_public_key: bytes,
+        packet: Packet[WhoAreYouPacket],
+    ) -> None:
+        self.logger.debug("%s: sending handshake completion", self)
+
+        local_enr = self._node_db.get_enr(self._local_node_id)
+
+        # prepare response packet
+        id_nonce_signature = local_enr.identity_scheme.create_id_nonce_signature(
+            id_nonce=packet.auth_data.id_nonce,
+            ephemeral_public_key=ephemeral_public_key,
+            private_key=self._local_private_key,
+        )
+
+        auth_data = HandshakePacket(
+            auth_data_head=HandshakeHeader.v4_header(),
+            id_signature=id_nonce_signature,
+            ephemeral_public_key=ephemeral_public_key,
+            record=(
+                local_enr
+                if packet.auth_data.enr_sequence_number < local_enr.sequence_number
+                else None
+            ),
+        )
+        handshake_packet = Packet.prepare(
+            nonce=packet.auth_data.request_nonce,
+            initiator_key=self.keys.encryption_key,
+            message=self._initial_message.message,
+            auth_data=auth_data,
+            source_node_id=self._local_node_id,
+            dest_node_id=self._remote_node_id,
+        )
+
+        await self._outgoing_envelope_send_channel.send(
+            OutgoingEnvelope(
+                packet=handshake_packet, receiver_endpoint=self.remote_endpoint,
+            )
+        )
+
+
+class SessionRecipient(BaseSession):
+    is_initiator = False
+
+    @property
+    def remote_node_id(self) -> NodeID:
+        if self.is_before_handshake:
+            raise AttributeError("NodeID for remote not yet known")
+        return self._remote_node_id
+
+    async def handle_outgoing_message(self, message: OutgoingMessage) -> None:
+        if self.is_after_handshake:
+            raise NotImplementedError
+        elif self.is_during_handshake:
+            raise NotImplementedError
+        elif self.is_before_handshake:
+            raise NotImplementedError
+        else:
+            raise Exception("Invariant: All states handled")
+
+    async def handle_incoming_envelope(self, envelope: IncomingEnvelope) -> None:
+        if self.is_after_handshake:
+            raise NotImplementedError
+        elif self.is_during_handshake:
+            if envelope.packet.is_handshake:
+                self._keys = await self._receive_handshake_completion(
+                    cast(Packet[HandshakePacket], envelope.packet),
+                )
+                self._status = SessionStatus.AFTER
+            else:
+                self.logger.error(
+                    "%s: received unexpected message during handshake: %s", envelope
+                )
+                self._incoming_envelope_buffer_send_channel.send_nowait(envelope)
+        elif self.is_before_handshake:
+            if envelope.packet.is_message:
+                self.logger.debug("%s: received handshake initiation", self)
+                self._status = SessionStatus.DURING
+                self._remote_node_id = envelope.packet.header.source_node_id
+                await self._send_handshake_response(
+                    cast(Packet[MessagePacket], envelope.packet),
+                    envelope.sender_endpoint,
+                )
+            else:
+                self.logger.error(
+                    "%s: received unexpected message before handshake: %s", envelope
+                )
+                # TODO: full buffer handling
+                # TODO: manage buffer...
+                self._incoming_envelope_buffer_send_channel.send_nowait(envelope)
+        else:
+            raise Exception("Invariant: All states handled")
+
+    async def _send_handshake_response(
+        self, packet: Packet[MessagePacket], sender_endpoint: Endpoint
+    ) -> None:
+        self.logger.debug("%s: sending handshake response", self)
+        try:
+            remote_enr = self._node_db.get_enr(packet.header.source_node_id)
+        except KeyError:
+            enr_sequence_number = 0
+        else:
+            enr_sequence_number = remote_enr.sequence_number
+
+        auth_data = WhoAreYouPacket(
+            request_nonce=packet.auth_data.aes_gcm_nonce,
+            id_nonce=cast(IDNonce, secrets.token_bytes(32)),
+            enr_sequence_number=enr_sequence_number,
+        )
+
+        self.handshake_response_packet = Packet.prepare(
+            nonce=cast(Nonce, secrets.token_bytes(12)),
+            initiator_key=cast(AES128Key, secrets.token_bytes(16)),
+            message=EmptyMessage(),
+            auth_data=auth_data,
+            source_node_id=self._local_node_id,
+            dest_node_id=packet.header.source_node_id,
+        )
+        await self._outgoing_envelope_send_channel.send(
+            OutgoingEnvelope(
+                packet=self.handshake_response_packet,
+                receiver_endpoint=sender_endpoint,
+            )
+        )
+
+    async def _receive_handshake_completion(
+        self, packet: Packet[HandshakePacket]
+    ) -> SessionKeys:
+        self.logger.debug("%s: received handshake completion", self)
+
+        if not isinstance(packet.auth_data, HandshakePacket):
+            raise Exception(f"Invalid packet type: {type(packet.auth_data)}")
+
+        if packet.auth_data.record is not None:
+            remote_enr = packet.auth_data.record
+            self._node_db.set_enr(remote_enr)
+        else:
+            remote_enr = self._node_db.get_enr(self.remote_node_id)
+
+        session_keys = remote_enr.identity_scheme.compute_session_keys(
+            local_private_key=self._local_private_key,
+            remote_public_key=packet.auth_data.ephemeral_public_key,
+            local_node_id=self._local_node_id,
+            remote_node_id=self.remote_node_id,
+            id_nonce=self.handshake_response_packet.auth_data.id_nonce,
+            is_locally_initiated=False,
+        )
+
+        authenticated_data = (
+            packet.header.to_wire_bytes() + packet.auth_data.to_wire_bytes()
+        )
+        message_plain_text = aesgcm_decrypt(
+            key=session_keys.decryption_key,
+            nonce=self.handshake_response_packet.auth_data.request_nonce,
+            cipher_text=packet.message_cipher_text,
+            authenticated_data=authenticated_data,
+        )
+        message_type = message_plain_text[0]
+        message_sedes = self._message_type_registry[message_type]
+        message = rlp.decode(message_plain_text[1:], sedes=message_sedes)
+
+        await self._incoming_message_send_channel.send(
+            IncomingMessage(
+                message=message,
+                sender_endpoint=self.remote_endpoint,
+                sender_node_id=self.remote_node_id,
+            )
+        )
+        return session_keys

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 
+mypy_path = "stubs"
 check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True

--- a/tests/core/v5_1/test_packet_encoding.py
+++ b/tests/core/v5_1/test_packet_encoding.py
@@ -1,0 +1,90 @@
+import pytest
+
+from ddht.tools.factories.discovery import ENRFactory
+from ddht.v5_1.messages import PingMessage
+from ddht.v5_1.packets import (
+    HandshakeHeader,
+    HandshakePacket,
+    MessagePacket,
+    Packet,
+    WhoAreYouPacket,
+    decode_packet,
+)
+
+
+def test_message_packet_encoding():
+    initiator_key = b"\x01" * 16
+    nonce = b"\x02" * 12
+    source_node_id = b"\x03" * 32
+    dest_node_id = b"\x04" * 32
+    message = PingMessage(1, 0)
+    auth_data = MessagePacket(b"\x05" * 12)
+
+    packet = Packet.prepare(
+        nonce=nonce,
+        initiator_key=initiator_key,
+        message=message,
+        auth_data=auth_data,
+        source_node_id=source_node_id,
+        dest_node_id=dest_node_id,
+    )
+    packet_wire_bytes = packet.to_wire_bytes()
+    result = decode_packet(packet_wire_bytes, dest_node_id)
+
+    assert result == packet
+
+
+def test_who_are_you_packet_encoding():
+    initiator_key = b"\x01" * 16
+    nonce = b"\x02" * 12
+    source_node_id = b"\x03" * 32
+    dest_node_id = b"\x04" * 32
+    message = PingMessage(1, 0)
+    auth_data = WhoAreYouPacket(
+        request_nonce=b"\x05" * 12, id_nonce=b"\x06" * 32, enr_sequence_number=0x07
+    )
+
+    packet = Packet.prepare(
+        nonce=nonce,
+        initiator_key=initiator_key,
+        message=message,
+        auth_data=auth_data,
+        source_node_id=source_node_id,
+        dest_node_id=dest_node_id,
+    )
+    packet_wire_bytes = packet.to_wire_bytes()
+    result = decode_packet(packet_wire_bytes, dest_node_id)
+
+    assert result == packet
+
+
+@pytest.mark.parametrize(
+    "enr", (None, ENRFactory(),),
+)
+def test_handshake_packet_encoding(enr):
+    initiator_key = b"\x01" * 16
+    nonce = b"\x02" * 12
+    source_node_id = b"\x03" * 32
+    dest_node_id = b"\x04" * 32
+    message = PingMessage(1, 0)
+    auth_data = HandshakePacket(
+        auth_data_head=HandshakeHeader(
+            version=1, signature_size=64, ephemeral_key_size=33,
+        ),
+        id_signature=b"\x05" * 64,
+        ephemeral_public_key=b"\x06" * 33,
+        record=enr,
+    )
+
+    packet = Packet.prepare(
+        nonce=nonce,
+        initiator_key=initiator_key,
+        message=message,
+        auth_data=auth_data,
+        source_node_id=source_node_id,
+        dest_node_id=dest_node_id,
+    )
+    packet_wire_bytes = packet.to_wire_bytes()
+    result = decode_packet(packet_wire_bytes, dest_node_id)
+
+    assert result == packet

--- a/tests/core/v5_1/test_session.py
+++ b/tests/core/v5_1/test_session.py
@@ -1,0 +1,61 @@
+import pytest
+import trio
+
+from ddht.tools.driver import Network
+from ddht.v5_1.messages import PingMessage
+
+INITIATOR_PRIVATE_KEY = b"\x01" * 32
+RECIPIENT_PRIVATE_KEY = b"\x02" * 32
+
+
+@pytest.mark.trio
+async def test_session_handshake_process():
+    network = Network()
+    initiator = network.node()
+    recipient = network.node()
+
+    driver = network.session_pair(initiator, recipient)
+
+    assert driver.initiator.session.is_before_handshake
+    assert driver.initiator.session.remote_node_id == recipient.node_id
+    with pytest.raises(AttributeError, match="Session keys are not available"):
+        driver.initiator.session.keys
+
+    assert driver.recipient.session.is_before_handshake
+    with pytest.raises(AttributeError, match="NodeID for remote not yet known"):
+        driver.recipient.session.remote_node_id
+    with pytest.raises(AttributeError, match="Session keys are not available"):
+        driver.recipient.session.keys
+
+    ping_message = PingMessage(1234, initiator.enr.sequence_number)
+
+    await driver.initiator.send_message(ping_message),
+
+    assert driver.initiator.session.is_during_handshake
+    assert driver.recipient.session.is_before_handshake
+
+    # transmit and process the queued messages from initiator -> recipient
+    initiation_packet = await driver.transmit_one(driver.initiator)
+    assert initiation_packet.packet.is_message
+
+    assert driver.initiator.session.is_during_handshake
+    assert driver.recipient.session.is_during_handshake
+    assert driver.recipient.session.remote_node_id == initiator.node_id
+
+    # let the receipient respond with the `WhoAreYouPacket`
+    who_are_you = await driver.transmit_one(driver.recipient)
+    assert who_are_you.packet.is_who_are_you
+
+    assert driver.initiator.session.is_after_handshake
+    assert driver.recipient.session.is_during_handshake
+
+    handshake = await driver.transmit_one(driver.initiator)
+    assert handshake.packet.is_handshake
+
+    assert driver.initiator.session.is_after_handshake
+    assert driver.recipient.session.is_after_handshake
+
+    with trio.fail_after(1):
+        message = await driver.recipient.next_message()
+
+    assert message.message == ping_message


### PR DESCRIPTION
## What was wrong?

The discovery v5 protocol specification is being updated with a new wire protocol:

https://github.com/ethereum/devp2p/pull/157/

## How was it fixed?

Implemented the new protocol in `ddht.v5_1`

Preservation of the current `v5` implementation has been kept in place since there is currently a live network of nodes (mostly from the beacon chain?) for which we may still want to be able to interact with.

Currently this only implements the low level messaging and doesn't implement the overall application structure (like populating and managing a routing table).

#### Cute Animal Picture

![Funny-Animal-Face-Big-Crazy-Eyes](https://user-images.githubusercontent.com/824194/89829429-cb507580-db17-11ea-954f-f485aabefdb2.jpg)
