### PR TITLE
Move around common data classes

### DIFF
--- a/ddht/app.py
+++ b/ddht/app.py
@@ -7,11 +7,18 @@ from eth_utils import encode_hex
 import trio
 
 from ddht._utils import generate_node_key_file, read_node_key_file
+from ddht.base_message import IncomingMessage, OutgoingMessage
 from ddht.boot_info import BootInfo
 from ddht.constants import (
     DEFAULT_LISTEN,
     IP_V4_ADDRESS_ENR_KEY,
     NUM_ROUTING_TABLE_BUCKETS,
+)
+from ddht.datagram import (
+    DatagramReceiver,
+    DatagramSender,
+    IncomingDatagram,
+    OutgoingDatagram,
 )
 from ddht.enr_manager import ENRManager
 from ddht.exceptions import OldSequenceNumber
@@ -21,13 +28,7 @@ from ddht.node_db import NodeDB
 from ddht.typing import AnyIPAddress
 from ddht.upnp import UPnPService
 from ddht.v5.channel_services import (
-    DatagramReceiver,
-    DatagramSender,
-    IncomingDatagram,
-    IncomingMessage,
     IncomingPacket,
-    OutgoingDatagram,
-    OutgoingMessage,
     OutgoingPacket,
     PacketDecoder,
     PacketEncoder,

--- a/ddht/base_message.py
+++ b/ddht/base_message.py
@@ -1,5 +1,10 @@
+from typing import NamedTuple
+
 from eth_utils import int_to_big_endian
 import rlp
+
+from ddht.endpoint import Endpoint
+from ddht.typing import NodeID
 
 
 class BaseMessage(rlp.Serializable):  # type: ignore
@@ -7,3 +12,28 @@ class BaseMessage(rlp.Serializable):  # type: ignore
 
     def to_bytes(self) -> bytes:
         return b"".join((int_to_big_endian(self.message_type), rlp.encode(self)))
+
+
+class IncomingMessage(NamedTuple):
+    message: BaseMessage
+    sender_endpoint: Endpoint
+    sender_node_id: NodeID
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"
+
+    def to_response(self, response_message: BaseMessage) -> "OutgoingMessage":
+        return OutgoingMessage(
+            message=response_message,
+            receiver_endpoint=self.sender_endpoint,
+            receiver_node_id=self.sender_node_id,
+        )
+
+
+class OutgoingMessage(NamedTuple):
+    message: BaseMessage
+    receiver_endpoint: Endpoint
+    receiver_node_id: NodeID
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"

--- a/ddht/datagram.py
+++ b/ddht/datagram.py
@@ -1,0 +1,63 @@
+import logging
+from socket import inet_aton, inet_ntoa
+from typing import NamedTuple
+
+from async_service import ManagerAPI, as_service
+from trio.abc import ReceiveChannel, SendChannel
+from trio.socket import SocketType
+
+from ddht.constants import DISCOVERY_DATAGRAM_BUFFER_SIZE
+from ddht.endpoint import Endpoint
+
+
+#
+# Data structures
+#
+class IncomingDatagram(NamedTuple):
+    datagram: bytes
+    sender_endpoint: Endpoint
+
+
+class OutgoingDatagram(NamedTuple):
+    datagram: bytes
+    receiver_endpoint: Endpoint
+
+
+#
+# UDP
+#
+@as_service
+async def DatagramReceiver(
+    manager: ManagerAPI,
+    socket: SocketType,
+    incoming_datagram_send_channel: SendChannel[IncomingDatagram],
+) -> None:
+    """Read datagrams from a socket and send them to a channel."""
+    logger = logging.getLogger("ddht.v5.channel_services.DatagramReceiver")
+
+    async with incoming_datagram_send_channel:
+        while manager.is_running:
+            datagram, (ip_address, port) = await socket.recvfrom(
+                DISCOVERY_DATAGRAM_BUFFER_SIZE
+            )
+            endpoint = Endpoint(inet_aton(ip_address), port)
+            logger.debug(f"Received {len(datagram)} bytes from {endpoint}")
+            incoming_datagram = IncomingDatagram(datagram, endpoint)
+            await incoming_datagram_send_channel.send(incoming_datagram)
+
+
+@as_service
+async def DatagramSender(
+    manager: ManagerAPI,
+    outgoing_datagram_receive_channel: ReceiveChannel[OutgoingDatagram],
+    socket: SocketType,
+) -> None:
+    """Take datagrams from a channel and send them via a socket to their designated receivers."""
+    logger = logging.getLogger("ddht.v5.channel_services.DatagramSender")
+
+    async with outgoing_datagram_receive_channel:
+        async for datagram, endpoint in outgoing_datagram_receive_channel:
+            logger.debug(f"Sending {len(datagram)} bytes to {endpoint}")
+            await socket.sendto(
+                datagram, (inet_ntoa(endpoint.ip_address), endpoint.port)
+            )

--- a/ddht/identity_schemes.py
+++ b/ddht/identity_schemes.py
@@ -147,7 +147,10 @@ def ecdh_agree(private_key: bytes, public_key: bytes) -> bytes:
     """
     # We cannot use `cryptography.hazmat.primitives.asymmetric.ec.ECDH only gives us the x
     # component of the shared secret point, but we need both x and y.
-    public_key_eth_keys = PublicKey(public_key)
+    if len(public_key) == 33:
+        public_key_eth_keys = PublicKey.from_compressed_bytes(public_key)
+    else:
+        public_key_eth_keys = PublicKey(public_key)
     public_key_compressed = public_key_eth_keys.to_compressed_bytes()
     public_key_coincurve = coincurve.keys.PublicKey(public_key_compressed)
     secret_coincurve = public_key_coincurve.multiply(private_key)

--- a/ddht/tools/factories/discovery.py
+++ b/ddht/tools/factories/discovery.py
@@ -7,11 +7,13 @@ from eth_utils import big_endian_to_int, int_to_big_endian
 from eth_utils.toolz import merge, reduce
 import factory
 
+from ddht.base_message import IncomingMessage
+from ddht.endpoint import Endpoint
 from ddht.enr import ENR, UnsignedENR
 from ddht.identity_schemes import V4IdentityScheme
 from ddht.kademlia import compute_log_distance
 from ddht.typing import NodeID
-from ddht.v5.channel_services import Endpoint, IncomingMessage, IncomingPacket
+from ddht.v5.channel_services import IncomingPacket
 from ddht.v5.constants import (
     AUTH_SCHEME_NAME,
     ID_NONCE_SIZE,

--- a/ddht/tools/factories/node_db.py
+++ b/ddht/tools/factories/node_db.py
@@ -1,0 +1,13 @@
+from eth.db.backends.memory import MemoryDB
+import factory
+
+from ddht.identity_schemes import default_identity_scheme_registry
+from ddht.node_db import NodeDB
+
+
+class NodeDBFactory(factory.Factory):  # type: ignore
+    class Meta:
+        model = NodeDB
+
+    identity_scheme_registry = default_identity_scheme_registry
+    db = factory.LazyFunction(lambda: MemoryDB())

--- a/ddht/v5/abc.py
+++ b/ddht/v5/abc.py
@@ -9,11 +9,11 @@ from typing import (
     TypeVar,
 )
 
+from ddht.base_message import BaseMessage, IncomingMessage
+from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.identity_schemes import IdentityScheme
 from ddht.typing import NodeID
-from ddht.v5.channel_services import Endpoint, IncomingMessage
-from ddht.v5.messages import BaseMessage
 from ddht.v5.packets import Packet
 from ddht.v5.typing import HandshakeResult, Tag
 

--- a/ddht/v5/channel_services.py
+++ b/ddht/v5/channel_services.py
@@ -1,32 +1,18 @@
 import logging
-from socket import inet_aton, inet_ntoa
 from typing import NamedTuple
 
 from async_service import ManagerAPI, as_service
 from eth_utils import ValidationError
 from trio.abc import ReceiveChannel, SendChannel
-from trio.socket import SocketType
 
-from ddht.constants import DISCOVERY_DATAGRAM_BUFFER_SIZE
+from ddht.datagram import IncomingDatagram, OutgoingDatagram
 from ddht.endpoint import Endpoint
-from ddht.typing import NodeID
-from ddht.v5.messages import BaseMessage
 from ddht.v5.packets import Packet, decode_packet
 
 
 #
 # Data structures
 #
-class IncomingDatagram(NamedTuple):
-    datagram: bytes
-    sender_endpoint: Endpoint
-
-
-class OutgoingDatagram(NamedTuple):
-    datagram: bytes
-    receiver_endpoint: Endpoint
-
-
 class IncomingPacket(NamedTuple):
     packet: Packet
     sender_endpoint: Endpoint
@@ -41,71 +27,6 @@ class OutgoingPacket(NamedTuple):
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}[{self.packet.__class__.__name__}]"
-
-
-class IncomingMessage(NamedTuple):
-    message: BaseMessage
-    sender_endpoint: Endpoint
-    sender_node_id: NodeID
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"
-
-    def to_response(self, response_message: BaseMessage) -> "OutgoingMessage":
-        return OutgoingMessage(
-            message=response_message,
-            receiver_endpoint=self.sender_endpoint,
-            receiver_node_id=self.sender_node_id,
-        )
-
-
-class OutgoingMessage(NamedTuple):
-    message: BaseMessage
-    receiver_endpoint: Endpoint
-    receiver_node_id: NodeID
-
-    def __str__(self) -> str:
-        return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"
-
-
-#
-# UDP
-#
-@as_service
-async def DatagramReceiver(
-    manager: ManagerAPI,
-    socket: SocketType,
-    incoming_datagram_send_channel: SendChannel[IncomingDatagram],
-) -> None:
-    """Read datagrams from a socket and send them to a channel."""
-    logger = logging.getLogger("ddht.v5.channel_services.DatagramReceiver")
-
-    async with incoming_datagram_send_channel:
-        while manager.is_running:
-            datagram, (ip_address, port) = await socket.recvfrom(
-                DISCOVERY_DATAGRAM_BUFFER_SIZE
-            )
-            endpoint = Endpoint(inet_aton(ip_address), port)
-            logger.debug(f"Received {len(datagram)} bytes from {endpoint}")
-            incoming_datagram = IncomingDatagram(datagram, endpoint)
-            await incoming_datagram_send_channel.send(incoming_datagram)
-
-
-@as_service
-async def DatagramSender(
-    manager: ManagerAPI,
-    outgoing_datagram_receive_channel: ReceiveChannel[OutgoingDatagram],
-    socket: SocketType,
-) -> None:
-    """Take datagrams from a channel and send them via a socket to their designated receivers."""
-    logger = logging.getLogger("ddht.v5.channel_services.DatagramSender")
-
-    async with outgoing_datagram_receive_channel:
-        async for datagram, endpoint in outgoing_datagram_receive_channel:
-            logger.debug(f"Sending {len(datagram)} bytes to {endpoint}")
-            await socket.sendto(
-                datagram, (inet_ntoa(endpoint.ip_address), endpoint.port)
-            )
 
 
 #

--- a/ddht/v5/endpoint_tracker.py
+++ b/ddht/v5/endpoint_tracker.py
@@ -8,10 +8,10 @@ from trio.abc import ReceiveChannel
 
 from ddht.abc import NodeDBAPI
 from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
+from ddht.endpoint import Endpoint
 from ddht.enr import UnsignedENR
 from ddht.identity_schemes import IdentitySchemeRegistry
 from ddht.typing import NodeID
-from ddht.v5.channel_services import Endpoint
 
 
 class EndpointVote(NamedTuple):

--- a/ddht/v5/message_dispatcher.py
+++ b/ddht/v5/message_dispatcher.py
@@ -20,11 +20,12 @@ from trio.abc import ReceiveChannel, SendChannel
 from trio.hazmat import checkpoint
 
 from ddht.abc import NodeDBAPI
+from ddht.base_message import IncomingMessage, OutgoingMessage
 from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
+from ddht.endpoint import Endpoint
 from ddht.exceptions import UnexpectedMessage
 from ddht.typing import NodeID
 from ddht.v5.abc import ChannelHandlerSubscriptionAPI, MessageDispatcherAPI
-from ddht.v5.channel_services import Endpoint, IncomingMessage, OutgoingMessage
 from ddht.v5.constants import (
     MAX_NODES_MESSAGE_TOTAL,
     MAX_REQUEST_ID,

--- a/ddht/v5/packer.py
+++ b/ddht/v5/packer.py
@@ -7,17 +7,13 @@ import trio
 from trio.abc import ReceiveChannel, SendChannel
 
 from ddht.abc import NodeDBAPI
+from ddht.base_message import IncomingMessage, OutgoingMessage
+from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.exceptions import DecryptionError, HandshakeFailure
 from ddht.typing import NodeID, Nonce, SessionKeys
 from ddht.v5.abc import HandshakeParticipantAPI
-from ddht.v5.channel_services import (
-    Endpoint,
-    IncomingMessage,
-    IncomingPacket,
-    OutgoingMessage,
-    OutgoingPacket,
-)
+from ddht.v5.channel_services import IncomingPacket, OutgoingPacket
 from ddht.v5.constants import HANDSHAKE_TIMEOUT
 from ddht.v5.handshake import HandshakeInitiator, HandshakeRecipient
 from ddht.v5.messages import BaseMessage, MessageTypeRegistry

--- a/ddht/v5/routing_table_manager.py
+++ b/ddht/v5/routing_table_manager.py
@@ -15,12 +15,13 @@ from trio.abc import SendChannel
 
 from ddht._utils import every
 from ddht.abc import NodeDBAPI
+from ddht.base_message import IncomingMessage, OutgoingMessage
+from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.exceptions import OldSequenceNumber, UnexpectedMessage
 from ddht.kademlia import KademliaRoutingTable, compute_distance, compute_log_distance
 from ddht.typing import NodeID
 from ddht.v5.abc import MessageDispatcherAPI
-from ddht.v5.channel_services import Endpoint, IncomingMessage, OutgoingMessage
 from ddht.v5.constants import (
     FIND_NODE_RESPONSE_TIMEOUT,
     LOOKUP_PARALLELIZATION_FACTOR,

--- a/ddht/v5/typing.py
+++ b/ddht/v5/typing.py
@@ -2,11 +2,11 @@ from typing import TYPE_CHECKING, NamedTuple, NewType, Optional
 
 from eth_typing import Hash32
 
+from ddht.base_message import BaseMessage
+from ddht.enr import ENR
 from ddht.typing import SessionKeys
 
 if TYPE_CHECKING:
-    from ddht.enr import ENR  # noqa: F401
-    from ddht.v5.messages import BaseMessage  # noqa: F401
     from ddht.v5.packets import AuthHeaderPacket  # noqa: F401
 
 Tag = NewType("Tag", bytes)
@@ -16,6 +16,6 @@ Topic = NewType("Topic", Hash32)
 
 class HandshakeResult(NamedTuple):
     session_keys: SessionKeys
-    enr: Optional["ENR"]
-    message: Optional["BaseMessage"]
+    enr: Optional[ENR]
+    message: Optional[BaseMessage]
     auth_header_packet: Optional["AuthHeaderPacket"]

--- a/tests/core/test_datagram_services.py
+++ b/tests/core/test_datagram_services.py
@@ -1,0 +1,51 @@
+from socket import inet_aton
+
+from async_service import background_trio_service
+import pytest
+import trio
+
+from ddht.datagram import DatagramReceiver, DatagramSender, OutgoingDatagram
+from ddht.endpoint import Endpoint
+
+
+@pytest.mark.trio
+async def test_datagram_receiver(socket_pair):
+    sending_socket, receiving_socket = socket_pair
+    receiver_address = receiving_socket.getsockname()
+    sender_address = sending_socket.getsockname()
+
+    send_channel, receive_channel = trio.open_memory_channel(1)
+    async with background_trio_service(
+        DatagramReceiver(receiving_socket, send_channel)
+    ):
+        data = b"some packet"
+
+        await sending_socket.sendto(data, receiver_address)
+        with trio.fail_after(0.5):
+            received_datagram = await receive_channel.receive()
+
+        assert received_datagram.datagram == data
+        assert received_datagram.sender_endpoint.ip_address == inet_aton(
+            sender_address[0]
+        )
+        assert received_datagram.sender_endpoint.port == sender_address[1]
+
+
+@pytest.mark.trio
+async def test_datagram_sender(socket_pair):
+    sending_socket, receiving_socket = socket_pair
+    receiver_endpoint = receiving_socket.getsockname()
+    sender_endpoint = sending_socket.getsockname()
+
+    send_channel, receive_channel = trio.open_memory_channel(1)
+    async with background_trio_service(DatagramSender(receive_channel, sending_socket)):
+        outgoing_datagram = OutgoingDatagram(
+            b"some packet",
+            Endpoint(inet_aton(receiver_endpoint[0]), receiver_endpoint[1]),
+        )
+        await send_channel.send(outgoing_datagram)
+
+        with trio.fail_after(0.5):
+            data, sender = await receiving_socket.recvfrom(1024)
+        assert data == outgoing_datagram.datagram
+        assert sender == sender_endpoint

--- a/tests/core/v5/test_channel_services.py
+++ b/tests/core/v5/test_channel_services.py
@@ -1,63 +1,14 @@
-from socket import inet_aton
-
 from async_service import background_trio_service
 import pytest
 import trio
 
 from ddht.tools.factories.discovery import AuthTagPacketFactory, EndpointFactory
 from ddht.v5.channel_services import (
-    DatagramReceiver,
-    DatagramSender,
-    Endpoint,
     IncomingDatagram,
-    OutgoingDatagram,
     OutgoingPacket,
     PacketDecoder,
     PacketEncoder,
 )
-
-
-@pytest.mark.trio
-async def test_datagram_receiver(socket_pair):
-    sending_socket, receiving_socket = socket_pair
-    receiver_address = receiving_socket.getsockname()
-    sender_address = sending_socket.getsockname()
-
-    send_channel, receive_channel = trio.open_memory_channel(1)
-    async with background_trio_service(
-        DatagramReceiver(receiving_socket, send_channel)
-    ):
-        data = b"some packet"
-
-        await sending_socket.sendto(data, receiver_address)
-        with trio.fail_after(0.5):
-            received_datagram = await receive_channel.receive()
-
-        assert received_datagram.datagram == data
-        assert received_datagram.sender_endpoint.ip_address == inet_aton(
-            sender_address[0]
-        )
-        assert received_datagram.sender_endpoint.port == sender_address[1]
-
-
-@pytest.mark.trio
-async def test_datagram_sender(socket_pair):
-    sending_socket, receiving_socket = socket_pair
-    receiver_endpoint = receiving_socket.getsockname()
-    sender_endpoint = sending_socket.getsockname()
-
-    send_channel, receive_channel = trio.open_memory_channel(1)
-    async with background_trio_service(DatagramSender(receive_channel, sending_socket)):
-        outgoing_datagram = OutgoingDatagram(
-            b"some packet",
-            Endpoint(inet_aton(receiver_endpoint[0]), receiver_endpoint[1]),
-        )
-        await send_channel.send(outgoing_datagram)
-
-        with trio.fail_after(0.5):
-            data, sender = await receiving_socket.recvfrom(1024)
-        assert data == outgoing_datagram.datagram
-        assert sender == sender_endpoint
 
 
 @pytest.mark.trio

--- a/tests/core/v5/test_message_dispatcher.py
+++ b/tests/core/v5/test_message_dispatcher.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_trio
 import trio
 
+from ddht.base_message import IncomingMessage
 from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.node_db import NodeDB
 from ddht.tools.factories.discovery import (
@@ -12,7 +13,6 @@ from ddht.tools.factories.discovery import (
     PingMessageFactory,
 )
 from ddht.tools.factories.keys import PrivateKeyFactory
-from ddht.v5.channel_services import IncomingMessage
 from ddht.v5.message_dispatcher import MessageDispatcher
 from ddht.v5.messages import FindNodeMessage, NodesMessage, PingMessage
 

--- a/tests/core/v5/test_packer.py
+++ b/tests/core/v5/test_packer.py
@@ -4,6 +4,7 @@ import pytest
 import pytest_trio
 import trio
 
+from ddht.base_message import OutgoingMessage
 from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.node_db import NodeDB
 from ddht.tools.factories.discovery import (
@@ -14,7 +15,7 @@ from ddht.tools.factories.discovery import (
     PingMessageFactory,
 )
 from ddht.tools.factories.keys import PrivateKeyFactory
-from ddht.v5.channel_services import IncomingPacket, OutgoingMessage
+from ddht.v5.channel_services import IncomingPacket
 from ddht.v5.messages import v5_registry
 from ddht.v5.packer import Packer, PeerPacker
 from ddht.v5.packets import AuthHeaderPacket, AuthTagPacket, WhoAreYouPacket

--- a/tests/core/v5/test_routing_table_manager.py
+++ b/tests/core/v5/test_routing_table_manager.py
@@ -8,6 +8,7 @@ import pytest_trio
 import trio
 from trio.testing import wait_all_tasks_blocked
 
+from ddht.base_message import IncomingMessage
 from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.kademlia import KademliaRoutingTable, compute_distance, compute_log_distance
 from ddht.node_db import NodeDB
@@ -19,7 +20,6 @@ from ddht.tools.factories.discovery import (
     NodeIDFactory,
     PingMessageFactory,
 )
-from ddht.v5.channel_services import IncomingMessage
 from ddht.v5.constants import ROUTING_TABLE_PING_INTERVAL
 from ddht.v5.message_dispatcher import MessageDispatcher
 from ddht.v5.messages import FindNodeMessage, NodesMessage, PingMessage, PongMessage

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ line_length=88
 [flake8]
 max-line-length= 100
 exclude= venv*,.tox,docs,build
-ignore=W503
+ignore=W503,E203
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
## What was wrong?

More code that is easy to share across the v5 and v5.1 implementations.

## How was it fixed?

Moved things into top level library locations.

#### Cute Animal Picture

![05acp216mb006_001](https://user-images.githubusercontent.com/824194/89685537-c55d5900-d8b9-11ea-8fb8-33385c58631e.jpg)

