### PR TITLE
Add event API

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -1,5 +1,15 @@
 from abc import ABC, abstractmethod
-from typing import Any, List, MutableMapping, Type, TypeVar
+from typing import (
+    Any,
+    AsyncContextManager,
+    Generic,
+    List,
+    MutableMapping,
+    Type,
+    TypeVar,
+)
+
+import trio
 
 from ddht.enr import ENR
 from ddht.identity_schemes import IdentitySchemeRegistry
@@ -73,6 +83,21 @@ class DatabaseAPI(MutableMapping[bytes, bytes], ABC):
 
     @abstractmethod
     def delete(self, key: bytes) -> None:
+        ...
+
+
+TEventPayload = TypeVar("TEventPayload")
+
+
+class EventAPI(Generic[TEventPayload]):
+    name: str
+
+    @abstractmethod
+    async def trigger(self, payload: TEventPayload) -> None:
+        ...
+
+    @abstractmethod
+    def subscribe(self) -> AsyncContextManager[trio.abc.ReceiveChannel[TEventPayload]]:
         ...
 
 

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -1,0 +1,77 @@
+import pytest
+import trio
+
+from ddht.event import Event
+
+
+@pytest.mark.trio
+async def test_event_trigger_with_no_subscriptions():
+    event = Event("test")
+
+    await event.trigger(None)
+
+
+@pytest.mark.trio
+async def test_event_trigger_with_single_subscription():
+    event = Event("test")
+
+    async with event.subscribe() as subscription:
+        with pytest.raises(trio.WouldBlock):
+            subscription.receive_nowait()
+
+        await event.trigger(1234)
+
+        result = await subscription.receive()
+        assert result == 1234
+
+    with pytest.raises(trio.ClosedResourceError):
+        subscription.receive_nowait()
+    with pytest.raises(trio.ClosedResourceError):
+        await subscription.receive()
+
+
+@pytest.mark.trio
+async def test_event_trigger_with_multiple_subscriptions():
+    event = Event("test")
+
+    async with event.subscribe() as subscription_a:
+        await event.trigger(1234)
+
+        async with event.subscribe() as subscription_b:
+            await event.trigger(4321)
+
+            result_a_1 = subscription_a.receive_nowait()
+            result_a_2 = subscription_a.receive_nowait()
+            result_b_1 = subscription_b.receive_nowait()
+
+            assert result_a_1 == 1234
+            assert result_a_2 == 4321
+            assert result_b_1 == 4321
+
+            with pytest.raises(trio.WouldBlock):
+                subscription_a.receive_nowait()
+            with pytest.raises(trio.WouldBlock):
+                subscription_b.receive_nowait()
+
+
+@pytest.mark.trio
+async def test_event_wait_without_explicit_subscription():
+    event = Event("test")
+
+    async with trio.open_nursery() as nursery:
+        got_it = trio.Event()
+
+        async def wait_for_it():
+            result = await event.wait()
+            assert result == 1234
+            got_it.set()
+
+        nursery.start_soon(wait_for_it)
+        # trigger a few times just in case the subscription isn't setup yet....
+        await event.trigger(1234)
+        await event.trigger(1234)
+        await event.trigger(1234)
+        await event.trigger(1234)
+
+        with trio.fail_after(1):
+            await got_it.wait()


### PR DESCRIPTION
## What was wrong?

When creating the alexandria prototype I came up with a simple framework to allow various disparate code paths to signal that some sort of "event" occured, often tied to a piece of data.  These events can then be awaited or streamed in other places.  Highly useful for both testing and monitoring.

## How was it fixed?

Ported over the simple framework.

#### Cute Animal Picture

![1200px-Silver-Spangled_Hamburg_Sam_dinner](https://user-images.githubusercontent.com/824194/89686078-dfe40200-d8ba-11ea-8b8e-26895fa35f40.jpg)

