### PR TITLE
Add Event.subscribe_and_wait API

### DIFF
--- a/ddht/event.py
+++ b/ddht/event.py
@@ -43,6 +43,12 @@ class Event(EventAPI[TEventPayload]):
             async with self._lock:
                 self._channels.remove(send_channel)
 
+    @asynccontextmanager
+    async def subscribe_and_wait(self) -> AsyncIterator[None]:
+        async with self.subscribe() as subscription:
+            yield
+            await subscription.receive()
+
     async def wait(self) -> TEventPayload:
         async with self.subscribe() as subscription:
             result = await subscription.receive()

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -75,3 +75,13 @@ async def test_event_wait_without_explicit_subscription():
 
         with trio.fail_after(1):
             await got_it.wait()
+
+
+@pytest.mark.trio
+async def test_event_subscribe_and_wait():
+    event = Event("test")
+
+    with trio.fail_after(1):
+        async with trio.open_nursery() as nursery:
+            async with event.subscribe_and_wait():
+                nursery.start_soon(event.trigger, 1234)


### PR DESCRIPTION
## What was wrong?

In cases where we just want to wait for a single event, the current `ddht.Event` API left a little to be desired.  In testing this was often the case.

## How was it fixed?

Added `EventAPI.subscribe_and_wait`

```python
with event.subscribe_and_wait():
    # subscription active within the context block
    ...
    # blocks on exit of the context block until one event is received
```


#### Cute Animal Picture

![animals (24)](https://user-images.githubusercontent.com/824194/90069381-747da400-dcaf-11ea-89dd-d143cc8848d3.jpg)

