### PR TITLE
add humanize_node_id

### DIFF
--- a/ddht/_utils.py
+++ b/ddht/_utils.py
@@ -16,7 +16,14 @@ from typing import (
 )
 
 from eth_keys import keys
+from eth_utils import humanize_hash
 import trio
+
+from ddht.typing import NodeID
+
+
+def humanize_node_id(node_id: NodeID) -> str:
+    return humanize_hash(node_id)  # type: ignore
 
 
 def sxor(s1: bytes, s2: bytes) -> bytes:


### PR DESCRIPTION
## What was wrong?

Need a way to display node ids in a friendly way in logs.

## How was it fixed?

Add `humanize_node_id` which just proxies to `eth_utils.humanize_hash`

#### Cute Animal Picture

![o-CYCLOPS-GOAT-facebook](https://user-images.githubusercontent.com/824194/90424223-fd635980-e07a-11ea-8324-2f99ac6b29ab.jpg)

