### PR TITLE
Add EventAPI.trigger_nowait

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -97,11 +97,19 @@ class EventAPI(Generic[TEventPayload]):
         ...
 
     @abstractmethod
+    def trigger_nowait(self, payload: TEventPayload) -> None:
+        ...
+
+    @abstractmethod
     def subscribe(self) -> AsyncContextManager[trio.abc.ReceiveChannel[TEventPayload]]:
         ...
 
     @abstractmethod
     def subscribe_and_wait(self) -> AsyncContextManager[None]:
+        ...
+
+    @abstractmethod
+    async def wait(self) -> TEventPayload:
         ...
 
 

--- a/tests/core/test_event.py
+++ b/tests/core/test_event.py
@@ -12,6 +12,13 @@ async def test_event_trigger_with_no_subscriptions():
 
 
 @pytest.mark.trio
+async def test_event_trigger_nowait_with_no_subscriptions():
+    event = Event("test")
+
+    await event.trigger(None)
+
+
+@pytest.mark.trio
 async def test_event_trigger_with_single_subscription():
     event = Event("test")
 
@@ -20,6 +27,25 @@ async def test_event_trigger_with_single_subscription():
             subscription.receive_nowait()
 
         await event.trigger(1234)
+
+        result = await subscription.receive()
+        assert result == 1234
+
+    with pytest.raises(trio.ClosedResourceError):
+        subscription.receive_nowait()
+    with pytest.raises(trio.ClosedResourceError):
+        await subscription.receive()
+
+
+@pytest.mark.trio
+async def test_event_trigger_nowait_with_single_subscription():
+    event = Event("test")
+
+    async with event.subscribe() as subscription:
+        with pytest.raises(trio.WouldBlock):
+            subscription.receive_nowait()
+
+        event.trigger_nowait(1234)
 
         result = await subscription.receive()
         assert result == 1234
@@ -55,6 +81,30 @@ async def test_event_trigger_with_multiple_subscriptions():
 
 
 @pytest.mark.trio
+async def test_event_trigger_nowait_with_multiple_subscriptions():
+    event = Event("test")
+
+    async with event.subscribe() as subscription_a:
+        event.trigger_nowait(1234)
+
+        async with event.subscribe() as subscription_b:
+            event.trigger_nowait(4321)
+
+            result_a_1 = subscription_a.receive_nowait()
+            result_a_2 = subscription_a.receive_nowait()
+            result_b_1 = subscription_b.receive_nowait()
+
+            assert result_a_1 == 1234
+            assert result_a_2 == 4321
+            assert result_b_1 == 4321
+
+            with pytest.raises(trio.WouldBlock):
+                subscription_a.receive_nowait()
+            with pytest.raises(trio.WouldBlock):
+                subscription_b.receive_nowait()
+
+
+@pytest.mark.trio
 async def test_event_wait_without_explicit_subscription():
     event = Event("test")
 
@@ -67,6 +117,10 @@ async def test_event_wait_without_explicit_subscription():
             got_it.set()
 
         nursery.start_soon(wait_for_it)
+        # give the wait_for_it task a moment to initiate the subscription
+        await trio.hazmat.checkpoint()
+        await trio.hazmat.checkpoint()
+        await trio.hazmat.checkpoint()
         # trigger a few times just in case the subscription isn't setup yet....
         await event.trigger(1234)
         await event.trigger(1234)


### PR DESCRIPTION
## What was wrong?

It was useful to be able to trigger an event outside of an async context.

## How was it fixed?

Added `EventAPI.trigger_nowait`

#### Cute Animal Picture

![ba129ee2bfb04103544cb71afa46dc65](https://user-images.githubusercontent.com/824194/90424815-f852da00-e07b-11ea-9953-77583562f63f.jpg)

