### PR TITLE
Demote ENRManager from being a service

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -13,7 +13,7 @@ import trio
 
 from ddht.enr import ENR
 from ddht.identity_schemes import IdentitySchemeRegistry
-from ddht.typing import NodeID
+from ddht.typing import ENR_KV, NodeID
 
 TAddress = TypeVar("TAddress", bound="AddressAPI")
 
@@ -134,4 +134,15 @@ class NodeDBAPI(ABC):
 
     @abstractmethod
     def delete_last_pong_time(self, node_id: NodeID) -> None:
+        ...
+
+
+class ENRManagerAPI(ABC):
+    @property
+    @abstractmethod
+    def enr(self) -> ENR:
+        ...
+
+    @abstractmethod
+    def update(self, *kv_pairs: ENR_KV) -> ENR:
         ...

--- a/ddht/app.py
+++ b/ddht/app.py
@@ -70,11 +70,11 @@ class Application(Service):
 
         with trio.move_on_after(10):
             _, external_ip = await upnp_service.get_ip_addresses()
-            await enr_manager.async_update((IP_V4_ADDRESS_ENR_KEY, external_ip.packed))
+            enr_manager.update((IP_V4_ADDRESS_ENR_KEY, external_ip.packed))
 
         while self.manager.is_running:
             _, external_ip = await upnp_service.wait_ip_changed()
-            await enr_manager.async_update((IP_V4_ADDRESS_ENR_KEY, external_ip.packed))
+            enr_manager.update((IP_V4_ADDRESS_ENR_KEY, external_ip.packed))
 
     async def run(self) -> None:
         identity_scheme_registry = default_identity_scheme_registry
@@ -87,7 +87,6 @@ class Application(Service):
         local_private_key = get_local_private_key(self._boot_info)
 
         enr_manager = ENRManager(node_db=node_db, private_key=local_private_key,)
-        self.manager.run_daemon_child_service(enr_manager)
 
         port = self._boot_info.port
 

--- a/tests/core/test_enr_manager.py
+++ b/tests/core/test_enr_manager.py
@@ -1,7 +1,5 @@
-from async_service import background_trio_service
 from eth.db.backends.memory import MemoryDB
 import pytest
-import trio
 
 from ddht.enr_manager import ENRManager
 from ddht.identity_schemes import default_identity_scheme_registry
@@ -65,18 +63,3 @@ def test_enr_manager_update_api(node_db):
     assert enr_b.sequence_number == enr_a.sequence_number + 1
 
     assert enr_manager.enr[b"unicorns"] == b"cupcakes"
-
-
-@pytest.mark.trio
-async def test_enr_manager_update_via_queue(node_db):
-    enr_manager = ENRManager(node_db, PrivateKeyFactory())
-    async with background_trio_service(enr_manager):
-        assert b"unicorns" not in enr_manager.enr
-        await enr_manager.async_update((b"unicorns", b"rainbows"))
-
-    for _ in range(10):
-        await trio.hazmat.checkpoint()
-        if enr_manager.enr[b"unicorns"] == b"rainbows":
-            break
-    else:
-        assert enr_manager.enr[b"unicorns"] == b"rainbows"


### PR DESCRIPTION
## What was wrong?

The `ENRManager` didn't need to be a service and it didn't need `async` API entry points, and it needed an `ENRManagerAPI` definition.

## How was it fixed?

Did those things

#### Cute Animal Picture

![external-content duckduckgo com](https://user-images.githubusercontent.com/824194/90425116-7616e580-e07c-11ea-99ac-4959e3696f5e.jpeg)

