### PR TITLE
Make SessionAPI.__str__ more useful

### DIFF
--- a/ddht/_utils.py
+++ b/ddht/_utils.py
@@ -16,7 +16,14 @@ from typing import (
 )
 
 from eth_keys import keys
+from eth_utils import humanize_hash
 import trio
+
+from ddht.typing import NodeID
+
+
+def humanize_node_id(node_id: NodeID) -> str:
+    return humanize_hash(node_id)  # type: ignore
 
 
 def sxor(s1: bytes, s2: bytes) -> bytes:

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -15,6 +15,7 @@ class SessionAPI(ABC):
     remote_endpoint: Endpoint
     events: "EventsAPI"
     logger: logging.Logger
+    is_initiator: bool
 
     @property
     @abstractmethod

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -10,6 +10,7 @@ from eth_keys import keys
 import rlp
 import trio
 
+from ddht._utils import humanize_node_id
 from ddht.abc import NodeDBAPI
 from ddht.base_message import BaseMessage, InboundMessage, OutboundMessage
 from ddht.encryption import aesgcm_decrypt
@@ -36,9 +37,9 @@ RANDOM_ENCRYPTED_DATA_SIZE = 12
 
 
 class SessionStatus(enum.Enum):
-    BEFORE = enum.auto()
-    DURING = enum.auto()
-    AFTER = enum.auto()
+    BEFORE = "|"
+    DURING = "~"
+    AFTER = "-"
 
 
 class BaseSession(SessionAPI):
@@ -82,6 +83,27 @@ class BaseSession(SessionAPI):
 
         self._inbound_message_send_channel = inbound_message_send_channel
         self._outbound_envelope_send_channel = outbound_envelope_send_channel
+
+    def __str__(self) -> str:
+        if self.is_initiator:
+            connector = f"-{self._status.value}->"
+        else:
+            connector = f"<-{self._status.value}-"
+
+        if self.is_after_handshake:
+            remote_display = (
+                f"{humanize_node_id(self.remote_node_id)}@{self.remote_endpoint}"
+            )
+        else:
+            remote_display = f"UNKNOWN@{self.remote_endpoint}"
+
+        return (
+            "Session["
+            f"{humanize_node_id(self._local_node_id)}"
+            f"{connector}"
+            f"{remote_display}"
+            "]"
+        )
 
     @property
     def is_before_handshake(self) -> bool:


### PR DESCRIPTION
builds on #38 

## What was wrong?

The `SessionAPI.__str__` representation wasn't useful

## How was it fixed?

Adjusted it to contain:

- current stage of handshake (before, during, after)
- local node id and endpoint
- remote node id (if known) and endpoint

#### Cute Animal Picture


![Wild-Animal-Eye-Retinas-8](https://user-images.githubusercontent.com/824194/90427561-f0953480-e07f-11ea-8a89-1449ce212a68.jpg)
