### PR TITLE
Envelope services now class based

### DIFF
--- a/ddht/v5_1/envelope.py
+++ b/ddht/v5_1/envelope.py
@@ -1,7 +1,7 @@
 import logging
 from typing import NamedTuple
 
-from async_service import ManagerAPI, as_service
+from async_service import Service
 from eth_utils import ValidationError
 from trio.abc import ReceiveChannel, SendChannel
 
@@ -37,47 +37,64 @@ class OutboundEnvelope(NamedTuple):
 
 
 #
-# Packet encoding/decoding
+# Envelope encoding/decoding
 #
-@as_service
-async def PacketDecoder(
-    manager: ManagerAPI,
-    inbound_datagram_receive_channel: ReceiveChannel[InboundDatagram],
-    inbound_packet_send_channel: SendChannel[InboundEnvelope],
-    local_node_id: NodeID,
-) -> None:
+class EnvelopeDecoder(Service):
     """Decodes inbound datagrams to packet objects."""
-    logger = logging.getLogger("ddht.v5.channel_services.PacketDecoder")
 
-    async with inbound_datagram_receive_channel, inbound_packet_send_channel:
-        packet: AnyPacket
-        async for datagram, endpoint in inbound_datagram_receive_channel:
-            try:
-                packet = decode_packet(datagram, local_node_id)
-                logger.debug(
-                    f"Successfully decoded {packet.__class__.__name__} from {endpoint}"
-                )
-            except ValidationError:
-                logger.warning(
-                    f"Failed to decode a packet from {endpoint}", exc_info=True
-                )
-            else:
-                await inbound_packet_send_channel.send(
-                    InboundEnvelope(packet, endpoint)
-                )
+    logger = logging.getLogger("ddht.EnvelopeDecoder")
+
+    def __init__(
+        self,
+        inbound_datagram_receive_channel: ReceiveChannel[InboundDatagram],
+        inbound_envelope_send_channel: SendChannel[InboundEnvelope],
+        local_node_id: NodeID,
+    ) -> None:
+        self._inbound_datagram_receive_channel = inbound_datagram_receive_channel
+        self._inbound_envelope_send_channel = inbound_envelope_send_channel
+        self._local_node_id = local_node_id
+
+    async def run(self) -> None:
+        async with self._inbound_datagram_receive_channel:
+            async with self._inbound_envelope_send_channel:
+                packet: AnyPacket
+                async for datagram, endpoint in self._inbound_datagram_receive_channel:
+                    try:
+                        packet = decode_packet(datagram, self._local_node_id)
+                        self.logger.debug(
+                            f"Successfully decoded {packet.__class__.__name__} from {endpoint}"
+                        )
+                    except ValidationError:
+                        self.logger.warning(
+                            f"Failed to decode a packet from {endpoint}", exc_info=True
+                        )
+                    else:
+                        await self._inbound_envelope_send_channel.send(
+                            InboundEnvelope(packet, endpoint)
+                        )
 
 
-@as_service
-async def PacketEncoder(
-    manager: ManagerAPI,
-    outbound_packet_receive_channel: ReceiveChannel[OutboundEnvelope],
-    outbound_datagram_send_channel: SendChannel[OutboundDatagram],
-) -> None:
+class EnvelopeEncoder(Service):
     """Encodes outbound packets to datagrams."""
-    logger = logging.getLogger("ddht.v5.channel_services.PacketEncoder")
 
-    async with outbound_packet_receive_channel, outbound_datagram_send_channel:
-        async for packet, endpoint in outbound_packet_receive_channel:
-            outbound_datagram = OutboundDatagram(packet.to_wire_bytes(), endpoint)
-            logger.debug(f"Encoded {packet.__class__.__name__} for {endpoint}")
-            await outbound_datagram_send_channel.send(outbound_datagram)
+    logger = logging.getLogger("ddht.EnvelopeEncoder")
+
+    def __init__(
+        self,
+        outbound_envelope_receive_channel: ReceiveChannel[OutboundEnvelope],
+        outbound_datagram_send_channel: SendChannel[OutboundDatagram],
+    ) -> None:
+        self._outbound_envelope_receive_channel = outbound_envelope_receive_channel
+        self._outbound_datagram_send_channel = outbound_datagram_send_channel
+
+    async def run(self) -> None:
+        async with self._outbound_envelope_receive_channel:
+            async with self._outbound_datagram_send_channel:
+                async for packet, endpoint in self._outbound_envelope_receive_channel:
+                    outbound_datagram = OutboundDatagram(
+                        packet.to_wire_bytes(), endpoint
+                    )
+                    self.logger.debug(
+                        f"Encoded {packet.__class__.__name__} for {endpoint}"
+                    )
+                    await self._outbound_datagram_send_channel.send(outbound_datagram)


### PR DESCRIPTION
## What was wrong?

The `as_service` decorator from `async_service` doesn't lend itself well to strongly typed constructor arguments, requiring a `# type: ignore` or something similar.

## How was it fixed?

Converted them to just be class based.

#### Cute Animal Picture

![Animal-Fractals-Leopard-Design-Wallpaper-Aqua-Eyes-1920x1080](https://user-images.githubusercontent.com/824194/90427871-626d7e00-e080-11ea-9486-64f1dc0bb922.jpg)

