### PR TITLE
Piper/message type registry api

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
+from collections import UserDict
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncContextManager,
     Generic,
@@ -11,6 +13,7 @@ from typing import (
 
 import trio
 
+from ddht.base_message import BaseMessage
 from ddht.enr import ENR
 from ddht.identity_schemes import IdentitySchemeRegistry
 from ddht.typing import ENR_KV, NodeID
@@ -153,4 +156,21 @@ class ENRManagerAPI(ABC):
 
     @abstractmethod
     def update(self, *kv_pairs: ENR_KV) -> ENR:
+        ...
+
+
+# https://github.com/python/mypy/issues/5264#issuecomment-399407428
+if TYPE_CHECKING:
+    MessageTypeRegistryBaseType = UserDict[int, Type[BaseMessage]]
+else:
+    MessageTypeRegistryBaseType = UserDict
+
+
+class MessageTypeRegistryAPI(MessageTypeRegistryBaseType):
+    @abstractmethod
+    def register(self, message_data_class: Type[BaseMessage]) -> Type[BaseMessage]:
+        ...
+
+    @abstractmethod
+    def get_message_id(self, message_data_class: Type[BaseMessage]) -> int:
         ...

--- a/ddht/message_registry.py
+++ b/ddht/message_registry.py
@@ -1,16 +1,10 @@
-from collections import UserDict
-from typing import TYPE_CHECKING, Type
+from typing import Type
 
+from ddht.abc import MessageTypeRegistryAPI
 from ddht.base_message import BaseMessage
 
-# https://github.com/python/mypy/issues/5264#issuecomment-399407428
-if TYPE_CHECKING:
-    MessageTypeRegistryBaseType = UserDict[int, Type[BaseMessage]]
-else:
-    MessageTypeRegistryBaseType = UserDict
 
-
-class MessageTypeRegistry(MessageTypeRegistryBaseType):
+class MessageTypeRegistry(MessageTypeRegistryAPI):
     def register(self, message_data_class: Type[BaseMessage]) -> Type[BaseMessage]:
         """Class Decorator to register BaseMessage classes."""
         message_type = message_data_class.message_type
@@ -33,3 +27,10 @@ class MessageTypeRegistry(MessageTypeRegistryBaseType):
         self[message_type] = message_data_class
 
         return message_data_class
+
+    def get_message_id(self, message_data_class: Type[BaseMessage]) -> int:
+        for message_id, message_type in self.items():
+            if message_data_class is message_type:
+                return message_id
+        else:
+            raise KeyError(message_data_class)

--- a/ddht/v5/packer.py
+++ b/ddht/v5/packer.py
@@ -6,7 +6,7 @@ from eth_utils import ValidationError, encode_hex
 import trio
 from trio.abc import ReceiveChannel, SendChannel
 
-from ddht.abc import NodeDBAPI
+from ddht.abc import MessageTypeRegistryAPI, NodeDBAPI
 from ddht.base_message import InboundMessage, OutboundMessage
 from ddht.endpoint import Endpoint
 from ddht.enr import ENR
@@ -16,7 +16,7 @@ from ddht.v5.abc import HandshakeParticipantAPI
 from ddht.v5.channel_services import InboundPacket, OutboundPacket
 from ddht.v5.constants import HANDSHAKE_TIMEOUT
 from ddht.v5.handshake import HandshakeInitiator, HandshakeRecipient
-from ddht.v5.messages import BaseMessage, MessageTypeRegistry
+from ddht.v5.messages import BaseMessage
 from ddht.v5.packets import AuthTagPacket, get_random_auth_tag
 from ddht.v5.tags import compute_tag, recover_source_id_from_tag
 
@@ -33,7 +33,7 @@ class PeerPacker(Service):
         local_node_id: NodeID,
         remote_node_id: NodeID,
         node_db: NodeDBAPI,
-        message_type_registry: MessageTypeRegistry,
+        message_type_registry: MessageTypeRegistryAPI,
         inbound_packet_receive_channel: ReceiveChannel[InboundPacket],
         inbound_message_send_channel: SendChannel[InboundMessage],
         outbound_message_receive_channel: ReceiveChannel[OutboundMessage],
@@ -438,7 +438,7 @@ class Packer(Service):
         local_private_key: bytes,
         local_node_id: NodeID,
         node_db: NodeDBAPI,
-        message_type_registry: MessageTypeRegistry,
+        message_type_registry: MessageTypeRegistryAPI,
         inbound_packet_receive_channel: ReceiveChannel[InboundPacket],
         inbound_message_send_channel: SendChannel[InboundMessage],
         outbound_message_receive_channel: ReceiveChannel[OutboundMessage],

--- a/ddht/v5/packets.py
+++ b/ddht/v5/packets.py
@@ -15,11 +15,11 @@ from rlp.codec import consume_length_prefix
 from rlp.exceptions import DecodingError, DeserializationError
 from rlp.sedes import big_endian_int
 
+from ddht.abc import MessageTypeRegistryAPI
 from ddht.base_message import BaseMessage
 from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
 from ddht.encryption import aesgcm_decrypt, aesgcm_encrypt, validate_nonce
 from ddht.enr import ENR
-from ddht.message_registry import MessageTypeRegistry
 from ddht.typing import AES128Key, IDNonce, NodeID, Nonce
 from ddht.v5.constants import (
     AUTH_RESPONSE_VERSION,
@@ -153,7 +153,9 @@ class AuthHeaderPacket(NamedTuple):
         return id_nonce_signature, enr
 
     def decrypt_message(
-        self, key: AES128Key, message_type_registry: MessageTypeRegistry = v5_registry,
+        self,
+        key: AES128Key,
+        message_type_registry: MessageTypeRegistryAPI = v5_registry,
     ) -> BaseMessage:
         return _decrypt_message(
             key=key,
@@ -192,7 +194,9 @@ class AuthTagPacket(NamedTuple):
         return cls(tag=tag, auth_tag=auth_tag, encrypted_message=random_data)
 
     def decrypt_message(
-        self, key: AES128Key, message_type_registry: MessageTypeRegistry = v5_registry,
+        self,
+        key: AES128Key,
+        message_type_registry: MessageTypeRegistryAPI = v5_registry,
     ) -> BaseMessage:
         return _decrypt_message(
             key=key,
@@ -472,7 +476,7 @@ def _decrypt_message(
     auth_tag: Nonce,
     encrypted_message: bytes,
     authenticated_data: bytes,
-    message_type_registry: MessageTypeRegistry,
+    message_type_registry: MessageTypeRegistryAPI,
 ) -> BaseMessage:
     plain_text = aesgcm_decrypt(
         key=key,


### PR DESCRIPTION
## What was wrong?

The `MessageTypeRegistry` didn't have an interface type

## How was it fixed?

Implemented `MessageTypeRegistryAPI`

#### Cute Animal Picture

![Aye-Aye](https://user-images.githubusercontent.com/824194/90428230-e6c00100-e080-11ea-9392-a81f6d504be9.jpg)

