### PR TITLE
Separate ENRFactory, EndpointFactory, NodeIDFactory

### DIFF
--- a/ddht/tools/driver/network.py
+++ b/ddht/tools/driver/network.py
@@ -18,7 +18,8 @@ from ddht.tools.driver.abc import (
     SessionDriverAPI,
     SessionPairAPI,
 )
-from ddht.tools.factories.discovery import EndpointFactory, ENRFactory
+from ddht.tools.factories.endpoint import EndpointFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 from ddht.tools.factories.node_db import NodeDBFactory
 from ddht.typing import NodeID

--- a/ddht/tools/factories/discovery.py
+++ b/ddht/tools/factories/discovery.py
@@ -1,18 +1,7 @@
-import random
-import socket
-from typing import Any, Dict, Tuple
-
-from eth_keys import keys
-from eth_utils import big_endian_to_int, int_to_big_endian
-from eth_utils.toolz import merge, reduce
 import factory
 
 from ddht.base_message import InboundMessage
-from ddht.endpoint import Endpoint
-from ddht.enr import ENR, UnsignedENR
 from ddht.identity_schemes import V4IdentityScheme
-from ddht.kademlia import compute_log_distance
-from ddht.typing import NodeID
 from ddht.v5.channel_services import InboundPacket
 from ddht.v5.constants import (
     AUTH_SCHEME_NAME,
@@ -27,7 +16,9 @@ from ddht.v5.messages import FindNodeMessage, PingMessage
 from ddht.v5.packets import AuthHeader, AuthHeaderPacket, AuthTagPacket, WhoAreYouPacket
 from ddht.v5.typing import Topic
 
-from .kademlia import AddressFactory
+from .endpoint import EndpointFactory
+from .enr import ENRFactory
+from .node_id import NodeIDFactory
 
 
 class AuthTagPacketFactory(factory.Factory):  # type: ignore
@@ -69,16 +60,6 @@ class WhoAreYouPacketFactory(factory.Factory):  # type: ignore
     enr_sequence_number = 0
 
 
-class EndpointFactory(factory.Factory):  # type: ignore
-    class Meta:
-        model = Endpoint
-
-    ip_address = factory.LazyFunction(
-        lambda: socket.inet_aton(factory.Faker("ipv4").generate({}))
-    )
-    port = factory.Faker("pyint", min_value=0, max_value=65535)
-
-
 class EndpointVoteFactory(factory.Factory):  # type: ignore
     class Meta:
         model = EndpointVote
@@ -94,95 +75,6 @@ class InboundPacketFactory(factory.Factory):  # type: ignore
 
     packet = factory.SubFactory(AuthTagPacketFactory)
     sender_endpoint = factory.SubFactory(EndpointFactory)
-
-
-class NodeIDFactory(factory.Factory):  # type: ignore
-    class Meta:
-        model = NodeID
-        inline_args = ("node_id",)
-
-    node_id = factory.Faker("binary", length=32)
-
-    @classmethod
-    def at_log_distance(cls, reference: NodeID, log_distance: int) -> NodeID:
-        num_bits = len(reference) * 8
-
-        if log_distance > num_bits:
-            raise ValueError(
-                "Log distance must not be greater than number of bits in the node id"
-            )
-        elif log_distance < 0:
-            raise ValueError("Log distance cannot be negative")
-
-        num_common_bits = num_bits - log_distance
-        flipped_bit_index = num_common_bits
-        num_random_bits = num_bits - num_common_bits - 1
-
-        reference_bits = bytes_to_bits(reference)
-
-        shared_bits = reference_bits[:num_common_bits]
-        flipped_bit = not reference_bits[flipped_bit_index]
-        random_bits = [
-            bool(random.randint(0, 1))
-            for _ in range(
-                flipped_bit_index + 1, flipped_bit_index + 1 + num_random_bits
-            )
-        ]
-
-        result_bits = tuple(list(shared_bits) + [flipped_bit] + random_bits)
-        result = NodeID(bits_to_bytes(result_bits))
-
-        assert compute_log_distance(result, reference) == log_distance
-        return result
-
-
-def bytes_to_bits(input_bytes: bytes) -> Tuple[bool, ...]:
-    num_bits = len(input_bytes) * 8
-    as_int = big_endian_to_int(input_bytes)
-    as_bits = tuple(bool(as_int & (1 << index)) for index in range(num_bits))[::-1]
-    return as_bits
-
-
-def bits_to_bytes(input_bits: Tuple[bool, ...]) -> bytes:
-    if len(input_bits) % 8 != 0:
-        raise ValueError("Number of input bits must be a multiple of 8")
-    num_bytes = len(input_bits) // 8
-
-    as_int = reduce(lambda rest, bit: rest * 2 + bit, input_bits)
-    as_bytes_unpadded = int_to_big_endian(as_int)
-    padding = b"\x00" * (num_bytes - len(as_bytes_unpadded))
-    return padding + as_bytes_unpadded
-
-
-class ENRFactory(factory.Factory):  # type: ignore
-    class Meta:
-        model = ENR
-
-    sequence_number = factory.Faker("pyint", min_value=0, max_value=100)
-    kv_pairs = factory.LazyAttribute(
-        lambda o: merge(
-            {
-                b"id": b"v4",
-                b"secp256k1": keys.PrivateKey(
-                    o.private_key
-                ).public_key.to_compressed_bytes(),
-                b"ip": o.address.ip_packed,
-                b"udp": o.address.udp_port,
-                b"tcp": o.address.tcp_port,
-            },
-            o.custom_kv_pairs,
-        )
-    )
-    signature = factory.LazyAttribute(
-        lambda o: UnsignedENR(o.sequence_number, o.kv_pairs)
-        .to_signed_enr(o.private_key)
-        .signature
-    )
-
-    class Params:
-        private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
-        address = factory.SubFactory(AddressFactory)
-        custom_kv_pairs: Dict[bytes, Any] = {}
 
 
 class PingMessageFactory(factory.Factory):  # type: ignore

--- a/ddht/tools/factories/endpoint.py
+++ b/ddht/tools/factories/endpoint.py
@@ -1,0 +1,22 @@
+import socket
+from typing import Any
+
+import factory
+
+from ddht.endpoint import Endpoint
+
+LOCALHOST = socket.inet_aton("127.0.0.1")
+
+
+class EndpointFactory(factory.Factory):  # type: ignore
+    class Meta:
+        model = Endpoint
+
+    ip_address = factory.LazyFunction(
+        lambda: socket.inet_aton(factory.Faker("ipv4").generate({}))
+    )
+    port = factory.Faker("pyint", min_value=0, max_value=65535)
+
+    @classmethod
+    def localhost(cls, *args: Any, **kwargs: Any) -> Endpoint:
+        return cls(*args, ip_address=LOCALHOST, **kwargs)

--- a/ddht/tools/factories/enr.py
+++ b/ddht/tools/factories/enr.py
@@ -1,0 +1,41 @@
+from typing import Any, Dict
+
+from eth_keys import keys
+from eth_utils.toolz import merge
+import factory
+
+from ddht.enr import ENR, UnsignedENR
+from ddht.identity_schemes import V4IdentityScheme
+
+from .kademlia import AddressFactory
+
+
+class ENRFactory(factory.Factory):  # type: ignore
+    class Meta:
+        model = ENR
+
+    sequence_number = factory.Faker("pyint", min_value=0, max_value=100)
+    kv_pairs = factory.LazyAttribute(
+        lambda o: merge(
+            {
+                b"id": b"v4",
+                b"secp256k1": keys.PrivateKey(
+                    o.private_key
+                ).public_key.to_compressed_bytes(),
+                b"ip": o.address.ip_packed,
+                b"udp": o.address.udp_port,
+                b"tcp": o.address.tcp_port,
+            },
+            o.custom_kv_pairs,
+        )
+    )
+    signature = factory.LazyAttribute(
+        lambda o: UnsignedENR(o.sequence_number, o.kv_pairs)
+        .to_signed_enr(o.private_key)
+        .signature
+    )
+
+    class Params:
+        private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
+        address = factory.SubFactory(AddressFactory)
+        custom_kv_pairs: Dict[bytes, Any] = {}

--- a/ddht/tools/factories/node_id.py
+++ b/ddht/tools/factories/node_id.py
@@ -1,0 +1,67 @@
+import random
+from typing import Tuple
+
+from eth_utils import big_endian_to_int, int_to_big_endian
+from eth_utils.toolz import reduce
+import factory
+
+from ddht.kademlia import compute_log_distance
+from ddht.typing import NodeID
+
+
+def bytes_to_bits(input_bytes: bytes) -> Tuple[bool, ...]:
+    num_bits = len(input_bytes) * 8
+    as_int = big_endian_to_int(input_bytes)
+    as_bits = tuple(bool(as_int & (1 << index)) for index in range(num_bits))[::-1]
+    return as_bits
+
+
+def bits_to_bytes(input_bits: Tuple[bool, ...]) -> bytes:
+    if len(input_bits) % 8 != 0:
+        raise ValueError("Number of input bits must be a multiple of 8")
+    num_bytes = len(input_bits) // 8
+
+    as_int = reduce(lambda rest, bit: rest * 2 + bit, input_bits)
+    as_bytes_unpadded = int_to_big_endian(as_int)
+    padding = b"\x00" * (num_bytes - len(as_bytes_unpadded))
+    return padding + as_bytes_unpadded
+
+
+class NodeIDFactory(factory.Factory):  # type: ignore
+    class Meta:
+        model = NodeID
+        inline_args = ("node_id",)
+
+    node_id = factory.Faker("binary", length=32)
+
+    @classmethod
+    def at_log_distance(cls, reference: NodeID, log_distance: int) -> NodeID:
+        num_bits = len(reference) * 8
+
+        if log_distance > num_bits:
+            raise ValueError(
+                "Log distance must not be greater than number of bits in the node id"
+            )
+        elif log_distance < 0:
+            raise ValueError("Log distance cannot be negative")
+
+        num_common_bits = num_bits - log_distance
+        flipped_bit_index = num_common_bits
+        num_random_bits = num_bits - num_common_bits - 1
+
+        reference_bits = bytes_to_bits(reference)
+
+        shared_bits = reference_bits[:num_common_bits]
+        flipped_bit = not reference_bits[flipped_bit_index]
+        random_bits = [
+            bool(random.randint(0, 1))
+            for _ in range(
+                flipped_bit_index + 1, flipped_bit_index + 1 + num_random_bits
+            )
+        ]
+
+        result_bits = tuple(list(shared_bits) + [flipped_bit] + random_bits)
+        result = NodeID(bits_to_bytes(result_bits))
+
+        assert compute_log_distance(result, reference) == log_distance
+        return result

--- a/tests/core/test_enr_manager.py
+++ b/tests/core/test_enr_manager.py
@@ -6,7 +6,7 @@ import trio
 from ddht.enr_manager import ENRManager
 from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.node_db import NodeDB
-from ddht.tools.factories.discovery import ENRFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 
 

--- a/tests/core/test_node_db.py
+++ b/tests/core/test_node_db.py
@@ -9,7 +9,7 @@ from ddht.identity_schemes import (
     default_identity_scheme_registry,
 )
 from ddht.node_db import NodeDB
-from ddht.tools.factories.discovery import ENRFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 
 

--- a/tests/core/v5/test_channel_services.py
+++ b/tests/core/v5/test_channel_services.py
@@ -2,7 +2,8 @@ from async_service import background_trio_service
 import pytest
 import trio
 
-from ddht.tools.factories.discovery import AuthTagPacketFactory, EndpointFactory
+from ddht.tools.factories.discovery import AuthTagPacketFactory
+from ddht.tools.factories.endpoint import EndpointFactory
 from ddht.v5.channel_services import (
     InboundDatagram,
     OutboundPacket,

--- a/tests/core/v5/test_endpoint_tracker.py
+++ b/tests/core/v5/test_endpoint_tracker.py
@@ -8,11 +8,9 @@ from trio.testing import wait_all_tasks_blocked
 from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
 from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.node_db import NodeDB
-from ddht.tools.factories.discovery import (
-    EndpointFactory,
-    EndpointVoteFactory,
-    ENRFactory,
-)
+from ddht.tools.factories.discovery import EndpointVoteFactory
+from ddht.tools.factories.endpoint import EndpointFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 from ddht.v5.endpoint_tracker import EndpointTracker
 

--- a/tests/core/v5/test_flat_routing_table.py
+++ b/tests/core/v5/test_flat_routing_table.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ddht.tools.factories.discovery import NodeIDFactory
+from ddht.tools.factories.node_id import NodeIDFactory
 from ddht.v5.routing_table import FlatRoutingTable
 
 

--- a/tests/core/v5/test_handshake.py
+++ b/tests/core/v5/test_handshake.py
@@ -2,12 +2,12 @@ from eth_utils import keccak
 
 from ddht.tools.factories.discovery import (
     AuthTagPacketFactory,
-    ENRFactory,
     HandshakeInitiatorFactory,
     HandshakeRecipientFactory,
     PingMessageFactory,
     WhoAreYouPacketFactory,
 )
+from ddht.tools.factories.enr import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 
 

--- a/tests/core/v5/test_kademlia_routing_table.py
+++ b/tests/core/v5/test_kademlia_routing_table.py
@@ -3,7 +3,7 @@ import itertools
 import pytest
 
 from ddht.kademlia import KademliaRoutingTable, compute_distance, compute_log_distance
-from ddht.tools.factories.discovery import NodeIDFactory
+from ddht.tools.factories.node_id import NodeIDFactory
 
 
 @pytest.fixture

--- a/tests/core/v5/test_message_dispatcher.py
+++ b/tests/core/v5/test_message_dispatcher.py
@@ -7,11 +7,9 @@ import trio
 from ddht.base_message import InboundMessage
 from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.node_db import NodeDB
-from ddht.tools.factories.discovery import (
-    EndpointFactory,
-    ENRFactory,
-    PingMessageFactory,
-)
+from ddht.tools.factories.discovery import PingMessageFactory
+from ddht.tools.factories.endpoint import EndpointFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 from ddht.v5.message_dispatcher import MessageDispatcher
 from ddht.v5.messages import FindNodeMessage, NodesMessage, PingMessage

--- a/tests/core/v5/test_packer.py
+++ b/tests/core/v5/test_packer.py
@@ -9,11 +9,11 @@ from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.node_db import NodeDB
 from ddht.tools.factories.discovery import (
     AuthTagPacketFactory,
-    EndpointFactory,
-    ENRFactory,
     HandshakeRecipientFactory,
     PingMessageFactory,
 )
+from ddht.tools.factories.endpoint import EndpointFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 from ddht.v5.channel_services import InboundPacket
 from ddht.v5.messages import v5_registry

--- a/tests/core/v5/test_routing_table_manager.py
+++ b/tests/core/v5/test_routing_table_manager.py
@@ -13,13 +13,13 @@ from ddht.identity_schemes import default_identity_scheme_registry
 from ddht.kademlia import KademliaRoutingTable, compute_distance, compute_log_distance
 from ddht.node_db import NodeDB
 from ddht.tools.factories.discovery import (
-    EndpointFactory,
-    ENRFactory,
     FindNodeMessageFactory,
     InboundMessageFactory,
-    NodeIDFactory,
     PingMessageFactory,
 )
+from ddht.tools.factories.endpoint import EndpointFactory
+from ddht.tools.factories.enr import ENRFactory
+from ddht.tools.factories.node_id import NodeIDFactory
 from ddht.v5.constants import ROUTING_TABLE_PING_INTERVAL
 from ddht.v5.message_dispatcher import MessageDispatcher
 from ddht.v5.messages import FindNodeMessage, NodesMessage, PingMessage, PongMessage

--- a/tests/core/v5/test_topic_table.py
+++ b/tests/core/v5/test_topic_table.py
@@ -1,6 +1,7 @@
 import pytest
 
-from ddht.tools.factories.discovery import ENRFactory, TopicFactory
+from ddht.tools.factories.discovery import TopicFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.v5.topic_table import TopicTable
 
 

--- a/tests/core/v5_1/test_packet_encoding.py
+++ b/tests/core/v5_1/test_packet_encoding.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ddht.tools.factories.discovery import ENRFactory
+from ddht.tools.factories.enr import ENRFactory
 from ddht.v5_1.messages import PingMessage
 from ddht.v5_1.packets import (
     HandshakeHeader,


### PR DESCRIPTION
## What was wrong?

Some of the factories were still in `ddht.tools.factories.discovery` when they belonged on their own.

## How was it fixed?

Moved `EndpointFactory`, `ENRFactory` and `NodeIDFactory` to their own modules.wsfragments/README.md)

#### Cute Animal Picture

![dog-cupcake](https://user-images.githubusercontent.com/824194/90429336-c2fdba80-e082-11ea-9154-1cd3523d6924.jpg)

