### PR TITLE
MessageGenerics

### DIFF
--- a/ddht/app.py
+++ b/ddht/app.py
@@ -7,7 +7,7 @@ from eth_utils import encode_hex
 import trio
 
 from ddht._utils import generate_node_key_file, read_node_key_file
-from ddht.base_message import InboundMessage, OutboundMessage
+from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
 from ddht.boot_info import BootInfo
 from ddht.constants import (
     DEFAULT_LISTEN,
@@ -126,8 +126,8 @@ class Application(Service):
         inbound_datagram_channels = trio.open_memory_channel[InboundDatagram](0)
         outbound_packet_channels = trio.open_memory_channel[OutboundPacket](0)
         inbound_packet_channels = trio.open_memory_channel[InboundPacket](0)
-        outbound_message_channels = trio.open_memory_channel[OutboundMessage](0)
-        inbound_message_channels = trio.open_memory_channel[InboundMessage](0)
+        outbound_message_channels = trio.open_memory_channel[AnyOutboundMessage](0)
+        inbound_message_channels = trio.open_memory_channel[AnyInboundMessage](0)
         endpoint_vote_channels = trio.open_memory_channel[EndpointVote](0)
 
         # types ignored due to https://github.com/ethereum/async-service/issues/5

--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -5,7 +5,7 @@ from eth_keys import keys
 import trio
 
 from ddht.abc import NodeDBAPI
-from ddht.base_message import BaseMessage, InboundMessage
+from ddht.base_message import AnyInboundMessage, BaseMessage
 from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.typing import NodeID
@@ -32,8 +32,8 @@ class NodeAPI(ABC):
 
 
 class SessionChannels(NamedTuple):
-    inbound_message_send_channel: trio.abc.SendChannel[InboundMessage]
-    inbound_message_receive_channel: trio.abc.ReceiveChannel[InboundMessage]
+    inbound_message_send_channel: trio.abc.SendChannel[AnyInboundMessage]
+    inbound_message_receive_channel: trio.abc.ReceiveChannel[AnyInboundMessage]
     outbound_envelope_send_channel: trio.abc.SendChannel[OutboundEnvelope]
     outbound_envelope_receive_channel: trio.abc.ReceiveChannel[OutboundEnvelope]
 
@@ -42,7 +42,7 @@ class SessionChannels(NamedTuple):
         (
             inbound_message_send_channel,
             inbound_message_receive_channel,
-        ) = trio.open_memory_channel[InboundMessage](256)
+        ) = trio.open_memory_channel[AnyInboundMessage](256)
         (
             outbound_envelope_send_channel,
             outbound_envelope_receive_channel,
@@ -65,7 +65,7 @@ class SessionDriverAPI(ABC):
         ...
 
     @abstractmethod
-    async def next_message(self) -> InboundMessage:
+    async def next_message(self) -> AnyInboundMessage:
         ...
 
     @abstractmethod

--- a/ddht/tools/driver/network.py
+++ b/ddht/tools/driver/network.py
@@ -7,7 +7,7 @@ from eth_keys import keys
 import trio
 
 from ddht.abc import NodeDBAPI
-from ddht.base_message import BaseMessage, InboundMessage, OutboundMessage
+from ddht.base_message import AnyInboundMessage, AnyOutboundMessage, BaseMessage
 from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
 from ddht.endpoint import Endpoint
 from ddht.tools.driver.abc import (
@@ -86,7 +86,7 @@ class SessionDriver(SessionDriverAPI):
     async def send_message(self, message: BaseMessage) -> None:
         self.session.logger.info("SENDING: %s", message)
         await self.session.handle_outbound_message(
-            OutboundMessage(
+            AnyOutboundMessage(
                 message=message,
                 receiver_endpoint=self.session.remote_endpoint,
                 receiver_node_id=self.session.remote_node_id,
@@ -94,7 +94,7 @@ class SessionDriver(SessionDriverAPI):
         )
 
     @no_hang
-    async def next_message(self) -> InboundMessage:
+    async def next_message(self) -> AnyInboundMessage:
         return await self.channels.inbound_message_receive_channel.receive()
 
     @no_hang

--- a/ddht/v5/abc.py
+++ b/ddht/v5/abc.py
@@ -9,7 +9,7 @@ from typing import (
     TypeVar,
 )
 
-from ddht.base_message import BaseMessage, InboundMessage
+from ddht.base_message import AnyInboundMessage, BaseMessage, InboundMessage, TMessage
 from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.identity_schemes import IdentityScheme
@@ -120,7 +120,7 @@ class MessageDispatcherAPI(ABC):
         receiver_node_id: NodeID,
         message: BaseMessage,
         endpoint: Optional[Endpoint] = None,
-    ) -> InboundMessage:
+    ) -> AnyInboundMessage:
         """
         Send a request to the given peer and return the response.
 
@@ -141,7 +141,7 @@ class MessageDispatcherAPI(ABC):
         receiver_node_id: NodeID,
         message: BaseMessage,
         endpoint: Optional[Endpoint] = None,
-    ) -> Tuple[InboundMessage, ...]:
+    ) -> Tuple[AnyInboundMessage, ...]:
         """
         Send a request to the given peer and return the collection of Nodes responses.
 
@@ -153,8 +153,8 @@ class MessageDispatcherAPI(ABC):
 
     @abstractmethod
     def add_request_handler(
-        self, message_class: Type[BaseMessage]
-    ) -> ChannelHandlerSubscriptionAPI[InboundMessage]:
+        self, message_class: Type[TMessage]
+    ) -> ChannelHandlerSubscriptionAPI[InboundMessage[TMessage]]:
         """
         Add a request handler for messages of a given type.
 
@@ -165,7 +165,7 @@ class MessageDispatcherAPI(ABC):
     @abstractmethod
     def add_response_handler(
         self, remote_node_id: NodeID, request_id: int
-    ) -> ChannelHandlerSubscriptionAPI[InboundMessage]:
+    ) -> ChannelHandlerSubscriptionAPI[AnyInboundMessage]:
         """
         Add a response handler.
 

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -4,7 +4,7 @@ from typing import Tuple
 import uuid
 
 from ddht.abc import EventAPI
-from ddht.base_message import OutboundMessage
+from ddht.base_message import AnyOutboundMessage
 from ddht.endpoint import Endpoint
 from ddht.typing import NodeID, SessionKeys
 from ddht.v5_1.envelope import InboundEnvelope
@@ -50,7 +50,7 @@ class SessionAPI(ABC):
         ...
 
     @abstractmethod
-    async def handle_outbound_message(self, message: OutboundMessage) -> None:
+    async def handle_outbound_message(self, message: AnyOutboundMessage) -> None:
         ...
 
     @abstractmethod


### PR DESCRIPTION
## What was wrong?

The `InboundMessage` and `OutboundMessage` classes contain a message payload.  There are cases where we want these wrappers to have a strongly typed payload.

## How was it fixed?

Changed the classes to be `typing.Generic` with a `TMessage` parameter that can be used to type the inner `message` type.

#### Cute Animal Picture

![73875](https://user-images.githubusercontent.com/824194/90430537-d90c7a80-e084-11ea-82ba-735149f7e902.jpg)

