### PR TITLE
Implement ClientAPI message sending

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -9,7 +9,7 @@ from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.tools.factories.v5_1 import SessionChannels
 from ddht.typing import NodeID
-from ddht.v5_1.abc import DispatcherAPI, EventsAPI, PoolAPI, SessionAPI
+from ddht.v5_1.abc import ClientAPI, DispatcherAPI, EventsAPI, PoolAPI, SessionAPI
 from ddht.v5_1.envelope import InboundEnvelope, OutboundEnvelope
 from ddht.v5_1.messages import PingMessage, PongMessage
 from ddht.v5_1.packets import AnyPacket
@@ -35,6 +35,10 @@ class NodeAPI(ABC):
     @property
     @abstractmethod
     def node_id(self) -> NodeID:
+        ...
+
+    @abstractmethod
+    def client(self) -> AsyncContextManager[ClientAPI]:
         ...
 
 

--- a/ddht/tools/factories/endpoint.py
+++ b/ddht/tools/factories/endpoint.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import factory
 
+from ddht._utils import get_open_port
 from ddht.endpoint import Endpoint
 
 LOCALHOST = socket.inet_aton("127.0.0.1")
@@ -15,7 +16,7 @@ class EndpointFactory(factory.Factory):  # type: ignore
     ip_address = factory.LazyFunction(
         lambda: socket.inet_aton(factory.Faker("ipv4").generate({}))
     )
-    port = factory.Faker("pyint", min_value=1024, max_value=65535)
+    port = factory.LazyFunction(get_open_port)
 
     @classmethod
     def localhost(cls, *args: Any, **kwargs: Any) -> Endpoint:

--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -1,0 +1,346 @@
+from contextlib import contextmanager, nullcontext
+import logging
+import socket
+from typing import Iterator, Optional, Sequence
+
+from async_service import Service
+from eth_keys import keys
+import trio
+
+from ddht.abc import NodeDBAPI
+from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
+from ddht.datagram import (
+    DatagramReceiver,
+    DatagramSender,
+    InboundDatagram,
+    OutboundDatagram,
+)
+from ddht.endpoint import Endpoint
+from ddht.enr import ENR, partition_enrs
+from ddht.enr_manager import ENRManager
+from ddht.message_registry import MessageTypeRegistry
+from ddht.typing import NodeID
+from ddht.v5_1.abc import ClientAPI, EventsAPI
+from ddht.v5_1.constants import FOUND_NODES_MAX_PAYLOAD_SIZE
+from ddht.v5_1.dispatcher import Dispatcher
+from ddht.v5_1.envelope import (
+    EnvelopeDecoder,
+    EnvelopeEncoder,
+    InboundEnvelope,
+    OutboundEnvelope,
+)
+from ddht.v5_1.events import Events
+from ddht.v5_1.messages import (
+    FindNodeMessage,
+    FoundNodesMessage,
+    PingMessage,
+    PongMessage,
+    RegisterTopicMessage,
+    RegistrationConfirmationMessage,
+    TalkRequestMessage,
+    TalkResponseMessage,
+    TicketMessage,
+    TopicQueryMessage,
+    v51_registry,
+)
+from ddht.v5_1.pool import Pool
+
+
+class Client(Service, ClientAPI):
+    logger = logging.getLogger("ddht.Client")
+
+    def __init__(
+        self,
+        local_private_key: keys.PrivateKey,
+        listen_on: Endpoint,
+        node_db: NodeDBAPI,
+        events: EventsAPI = None,
+        message_type_registry: MessageTypeRegistry = v51_registry,
+    ) -> None:
+        self._local_private_key = local_private_key
+
+        self.listen_on = listen_on
+        self._listening = trio.Event()
+
+        self.enr_manager = ENRManager(node_db=node_db, private_key=local_private_key,)
+        self._node_db = node_db
+        self._registry = message_type_registry
+
+        # Datagrams
+        (
+            self._outbound_datagram_send_channel,
+            self._outbound_datagram_receive_channel,
+        ) = trio.open_memory_channel[OutboundDatagram](256)
+        (
+            self._inbound_datagram_send_channel,
+            self._inbound_datagram_receive_channel,
+        ) = trio.open_memory_channel[InboundDatagram](256)
+
+        # EnvelopePair
+        (
+            self._outbound_envelope_send_channel,
+            self._outbound_envelope_receive_channel,
+        ) = trio.open_memory_channel[OutboundEnvelope](256)
+        (
+            self._inbound_envelope_send_channel,
+            self._inbound_envelope_receive_channel,
+        ) = trio.open_memory_channel[InboundEnvelope](256)
+
+        # Messages
+        (
+            self._outbound_message_send_channel,
+            self._outbound_message_receive_channel,
+        ) = trio.open_memory_channel[AnyOutboundMessage](256)
+        (
+            self._inbound_message_send_channel,
+            self._inbound_message_receive_channel,
+        ) = trio.open_memory_channel[AnyInboundMessage](256)
+
+        if events is None:
+            events = Events()
+        self.events = events
+
+        self.pool = Pool(
+            local_private_key=self._local_private_key,
+            local_node_id=self.enr_manager.enr.node_id,
+            node_db=self._node_db,
+            outbound_envelope_send_channel=self._outbound_envelope_send_channel,
+            inbound_message_send_channel=self._inbound_message_send_channel,
+            message_type_registry=self._registry,
+            events=self.events,
+        )
+
+        self.message_dispatcher = Dispatcher(
+            self._inbound_envelope_receive_channel,
+            self._inbound_message_receive_channel,
+            self.pool,
+            self._node_db,
+            self._registry,
+            self.events,
+        )
+        self.envelope_decoder = EnvelopeEncoder(
+            self._outbound_envelope_receive_channel,
+            self._outbound_datagram_send_channel,
+        )
+        self.envelope_encoder = EnvelopeDecoder(
+            self._inbound_datagram_receive_channel,
+            self._inbound_envelope_send_channel,
+            self.enr_manager.enr.node_id,
+        )
+
+        self._ready = trio.Event()
+
+    async def run(self) -> None:
+        self.manager.run_daemon_child_service(self.message_dispatcher)
+
+        self.manager.run_daemon_child_service(self.envelope_decoder)
+        self.manager.run_daemon_child_service(self.envelope_encoder)
+
+        self.manager.run_daemon_task(self._do_listen, self.listen_on)
+
+        await self.manager.wait_finished()
+
+    async def wait_listening(self) -> None:
+        await self._listening.wait()
+
+    async def _do_listen(self, listen_on: Endpoint) -> None:
+        sock = trio.socket.socket(
+            family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM,
+        )
+        ip_address, port = listen_on
+        await sock.bind((socket.inet_ntoa(ip_address), port))
+
+        self._listening.set()
+        await self.events.listening.trigger(listen_on)
+
+        self.logger.debug("Network connection listening on %s", listen_on)
+
+        # TODO: the datagram services need to use the `EventsAPI`
+        datagram_sender = DatagramSender(self._outbound_datagram_receive_channel, sock)  # type: ignore  # noqa: E501
+        self.manager.run_daemon_child_service(datagram_sender)
+
+        datagram_receiver = DatagramReceiver(sock, self._inbound_datagram_send_channel)  # type: ignore  # noqa: E501
+        self.manager.run_daemon_child_service(datagram_receiver)
+
+        await self.manager.wait_finished()
+
+    #
+    # Message API
+    #
+    @contextmanager
+    def get_request_id(
+        self, node_id: NodeID, request_id: Optional[int] = None
+    ) -> Iterator[int]:
+        if request_id is None:
+            request_id_context = self.message_dispatcher.reserve_request_id(node_id)
+        else:
+            request_id_context = nullcontext(request_id)
+
+        with request_id_context as message_request_id:
+            yield message_request_id
+
+    async def send_ping(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        request_id: Optional[int] = None,
+    ) -> int:
+        with self.get_request_id(dest_node_id, request_id) as message_request_id:
+            message = AnyOutboundMessage(
+                PingMessage(message_request_id, self.enr_manager.enr.sequence_number),
+                dest_endpoint,
+                dest_node_id,
+            )
+            await self.message_dispatcher.send_message(message)
+
+        return message_request_id
+
+    async def send_pong(
+        self, dest_endpoint: Endpoint, dest_node_id: NodeID, *, request_id: int,
+    ) -> None:
+        message = AnyOutboundMessage(
+            PongMessage(
+                request_id,
+                self.enr_manager.enr.sequence_number,
+                dest_endpoint.ip_address,
+                dest_endpoint.port,
+            ),
+            dest_endpoint,
+            dest_node_id,
+        )
+        await self.message_dispatcher.send_message(message)
+
+    async def send_find_nodes(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        distance: int,
+        request_id: Optional[int] = None,
+    ) -> int:
+        with self.get_request_id(dest_node_id, request_id) as message_request_id:
+            message = AnyOutboundMessage(
+                FindNodeMessage(message_request_id, distance),
+                dest_endpoint,
+                dest_node_id,
+            )
+            await self.message_dispatcher.send_message(message)
+
+        return message_request_id
+
+    async def send_found_nodes(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        enrs: Sequence[ENR],
+        request_id: int,
+    ) -> int:
+        enr_batches = partition_enrs(
+            enrs, max_payload_size=FOUND_NODES_MAX_PAYLOAD_SIZE
+        )
+        num_batches = len(enr_batches)
+        for batch in enr_batches:
+            message = AnyOutboundMessage(
+                FoundNodesMessage(request_id, num_batches, batch,),
+                dest_endpoint,
+                dest_node_id,
+            )
+            await self.message_dispatcher.send_message(message)
+
+        return num_batches
+
+    async def send_talk_request(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        protocol: bytes,
+        request: bytes,
+        request_id: Optional[int] = None,
+    ) -> int:
+        with self.get_request_id(dest_node_id, request_id) as message_request_id:
+            message = AnyOutboundMessage(
+                TalkRequestMessage(message_request_id, protocol, request),
+                dest_endpoint,
+                dest_node_id,
+            )
+            await self.message_dispatcher.send_message(message)
+
+        return message_request_id
+
+    async def send_talk_response(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        response: bytes,
+        request_id: int,
+    ) -> None:
+        message = AnyOutboundMessage(
+            TalkResponseMessage(request_id, response,), dest_endpoint, dest_node_id,
+        )
+        await self.message_dispatcher.send_message(message)
+
+    async def send_register_topic(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        topic: bytes,
+        enr: ENR,
+        ticket: bytes = b"",
+        request_id: Optional[int] = None,
+    ) -> int:
+        with self.get_request_id(dest_node_id, request_id) as message_request_id:
+            message = AnyOutboundMessage(
+                RegisterTopicMessage(message_request_id, topic, enr, ticket),
+                dest_endpoint,
+                dest_node_id,
+            )
+            await self.message_dispatcher.send_message(message)
+
+        return message_request_id
+
+    async def send_ticket(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        ticket: bytes,
+        wait_time: int,
+        request_id: int,
+    ) -> None:
+        message = AnyOutboundMessage(
+            TicketMessage(request_id, ticket, wait_time), dest_endpoint, dest_node_id,
+        )
+        await self.message_dispatcher.send_message(message)
+
+    async def send_registration_confirmation(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        topic: bytes,
+        request_id: int,
+    ) -> None:
+        message = AnyOutboundMessage(
+            RegistrationConfirmationMessage(request_id, topic),
+            dest_endpoint,
+            dest_node_id,
+        )
+        await self.message_dispatcher.send_message(message)
+
+    async def send_topic_query(
+        self,
+        dest_endpoint: Endpoint,
+        dest_node_id: NodeID,
+        *,
+        topic: bytes,
+        request_id: int,
+    ) -> None:
+        message = AnyOutboundMessage(
+            TopicQueryMessage(request_id, topic), dest_endpoint, dest_node_id,
+        )
+        await self.message_dispatcher.send_message(message)

--- a/ddht/v5_1/constants.py
+++ b/ddht/v5_1/constants.py
@@ -1,3 +1,8 @@
+from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
+
 SESSION_IDLE_TIMEOUT = 60
 
 REQUEST_RESPONSE_TIMEOUT = 10
+
+# safe upper bound on the size of the ENR list in a nodes message
+FOUND_NODES_MAX_PAYLOAD_SIZE = DISCOVERY_MAX_PACKET_SIZE - 200

--- a/ddht/v5_1/dispatcher.py
+++ b/ddht/v5_1/dispatcher.py
@@ -333,6 +333,8 @@ class Dispatcher(Service, DispatcherAPI):
     # Message Sending
     #
     async def send_message(self, message: AnyOutboundMessage) -> None:
+        if message.receiver_node_id == self._pool.local_node_id:
+            raise Exception("Cannot send message to self")
         await self._outbound_message_send_channel.send(message)
 
     #

--- a/tests/core/v5_1/test_client.py
+++ b/tests/core/v5_1/test_client.py
@@ -1,0 +1,162 @@
+import itertools
+
+import pytest
+import trio
+
+from ddht.tools.factories.enr import ENRFactory
+
+
+@pytest.fixture
+async def alice_client(alice, bob):
+    alice.node_db.set_enr(bob.enr)
+    async with alice.client() as alice_client:
+        yield alice_client
+
+
+@pytest.fixture
+async def bob_client(alice, bob):
+    bob.node_db.set_enr(alice.enr)
+    async with bob.client() as bob_client:
+        yield bob_client
+
+
+@pytest.mark.trio
+async def test_client_send_ping(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.ping_sent.subscribe_and_wait():
+            async with bob.events.ping_received.subscribe_and_wait():
+                await alice_client.send_ping(bob.endpoint, bob.node_id)
+
+
+@pytest.mark.trio
+async def test_client_send_pong(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.pong_sent.subscribe_and_wait():
+            async with bob.events.pong_received.subscribe_and_wait():
+                await alice_client.send_pong(bob.endpoint, bob.node_id, request_id=1234)
+
+
+@pytest.mark.trio
+async def test_client_send_find_nodes(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.find_nodes_sent.subscribe_and_wait():
+            async with bob.events.find_nodes_received.subscribe_and_wait():
+                await alice_client.send_find_nodes(
+                    bob.endpoint, bob.node_id, distance=0
+                )
+
+
+@pytest.mark.parametrize(
+    "enrs",
+    (
+        ENRFactory.create_batch(1),
+        ENRFactory.create_batch(2),
+        ENRFactory.create_batch(10),
+        ENRFactory.create_batch(50),
+    ),
+)
+@pytest.mark.trio
+async def test_client_send_found_nodes(alice, bob, alice_client, bob_client, enrs):
+    with trio.fail_after(2):
+        async with alice.events.found_nodes_sent.subscribe_and_wait():
+            async with bob.events.found_nodes_received.subscribe() as subscription:
+                await alice_client.send_found_nodes(
+                    bob.endpoint, bob.node_id, enrs=enrs, request_id=1234,
+                )
+
+                with trio.fail_after(2):
+                    first_message = await subscription.receive()
+                    remaining_messages = []
+                    for _ in range(first_message.message.total - 1):
+                        remaining_messages.append(await subscription.receive())
+        all_received_enrs = tuple(first_message.message.enrs) + tuple(
+            itertools.chain(*(message.message.enrs for message in remaining_messages))
+        )
+        expected_enrs_by_node_id = {enr.node_id: enr for enr in enrs}
+        assert len(expected_enrs_by_node_id) == len(enrs)
+        actual_enrs_by_node_id = {enr.node_id: enr for enr in all_received_enrs}
+
+        assert expected_enrs_by_node_id == actual_enrs_by_node_id
+
+
+@pytest.mark.trio
+async def test_client_send_talk_request(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.talk_request_sent.subscribe_and_wait():
+            async with bob.events.talk_request_received.subscribe_and_wait():
+                await alice_client.send_talk_request(
+                    bob.endpoint,
+                    bob.node_id,
+                    protocol=b"test",
+                    request=b"test-request",
+                )
+
+
+@pytest.mark.trio
+async def test_client_send_talk_response(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.talk_response_sent.subscribe_and_wait():
+            async with bob.events.talk_response_received.subscribe_and_wait():
+                await alice_client.send_talk_response(
+                    bob.endpoint,
+                    bob.node_id,
+                    response=b"test-response",
+                    request_id=1234,
+                )
+
+
+@pytest.mark.trio
+async def test_client_send_register_topic(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.register_topic_sent.subscribe_and_wait():
+            async with bob.events.register_topic_received.subscribe_and_wait():
+                await alice_client.send_register_topic(
+                    bob.endpoint,
+                    bob.node_id,
+                    topic=b"unicornsrainbowsunicornsrainbows",
+                    enr=alice.enr,
+                    ticket=b"test-ticket",
+                    request_id=1234,
+                )
+
+
+@pytest.mark.trio
+async def test_client_send_ticket(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.ticket_sent.subscribe_and_wait():
+            async with bob.events.ticket_received.subscribe_and_wait():
+                await alice_client.send_ticket(
+                    bob.endpoint,
+                    bob.node_id,
+                    ticket=b"test-ticket",
+                    wait_time=600,
+                    request_id=1234,
+                )
+
+
+@pytest.mark.trio
+async def test_client_send_registration_confirmation(
+    alice, bob, alice_client, bob_client
+):
+    with trio.fail_after(2):
+        async with alice.events.registration_confirmation_sent.subscribe_and_wait():
+            async with bob.events.registration_confirmation_received.subscribe_and_wait():
+                await alice_client.send_registration_confirmation(
+                    bob.endpoint,
+                    bob.node_id,
+                    topic=b"unicornsrainbowsunicornsrainbows",
+                    request_id=1234,
+                )
+
+
+@pytest.mark.trio
+async def test_client_send_topic_query(alice, bob, alice_client, bob_client):
+    with trio.fail_after(2):
+        async with alice.events.topic_query_sent.subscribe_and_wait():
+            async with bob.events.topic_query_received.subscribe_and_wait():
+                await alice_client.send_topic_query(
+                    bob.endpoint,
+                    bob.node_id,
+                    topic=b"unicornsrainbowsunicornsrainbows",
+                    request_id=1234,
+                )


### PR DESCRIPTION
## What was wrong?

Need the ability to send each of the supported message types.

## How was it fixed?

Implemented `ClientAPI.send_XXXX` for each message type.

#### Cute Animal Picture

![confused monkey](https://user-images.githubusercontent.com/824194/90453685-847df500-e0ae-11ea-8c7a-98d18d42abfe.jpg)
