### PR TITLE
Update ENR partitioning to ensure batch size within limit

### DIFF
--- a/tests/core/test_enr_partitioning.py
+++ b/tests/core/test_enr_partitioning.py
@@ -1,0 +1,36 @@
+import itertools
+
+from eth_utils.toolz import sliding_window
+from hypothesis import given, settings
+from hypothesis import strategies as st
+import rlp
+
+from ddht.constants import DISCOVERY_MAX_PACKET_SIZE, MAX_ENR_SIZE
+from ddht.enr import ENRSedes, partition_enrs
+from ddht.tools.factories.enr import ENRFactory
+
+
+@settings(max_examples=50, deadline=1000)
+@given(
+    num_enr_records=st.integers(min_value=1, max_value=100),
+    max_payload_size=st.integers(
+        min_value=MAX_ENR_SIZE, max_value=DISCOVERY_MAX_PACKET_SIZE
+    ),
+)
+def test_enr_partitioning(num_enr_records, max_payload_size):
+    enrs = ENRFactory.create_batch(num_enr_records)
+    batches = partition_enrs(enrs, max_payload_size)
+
+    assert sum(len(batch) for batch in batches) == len(enrs)
+    assert set(itertools.chain(*batches)) == set(enrs)
+
+    for batch in batches:
+        encoded_batch = rlp.encode(batch, sedes=rlp.sedes.CountableList(ENRSedes))
+        assert len(encoded_batch) <= max_payload_size
+
+    for batch, next_batch in sliding_window(2, batches):
+        overfull_batch = tuple(batch) + (next_batch[0],)
+        encoded_batch = rlp.encode(
+            overfull_batch, sedes=rlp.sedes.CountableList(ENRSedes)
+        )
+        assert len(encoded_batch) > max_payload_size


### PR DESCRIPTION
## What was wrong?

The previous logic which partitioned ENR records did not take into account the additional overhead of RLP encoding record sequence.

## How was it fixed?

Updated logic to do the partitioning inclusive of the rlp overhead.

#### Cute Animal Picture

![confused-look](https://user-images.githubusercontent.com/824194/91069976-54c17680-e5f3-11ea-8d0d-39329fa02502.jpg)

