### PR TITLE
Ensure generated port numbers can be bound to

### DIFF
--- a/ddht/_utils.py
+++ b/ddht/_utils.py
@@ -114,9 +114,11 @@ def read_node_key_file(path: pathlib.Path) -> keys.PrivateKey:
 
 
 def get_open_port() -> int:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("", 0))
-    s.listen(1)
-    port = s.getsockname()[1]
-    s.close()
-    return port  # type: ignore
+    port: int = 0
+    while port < 1024:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("", 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+        s.close()
+    return port

--- a/ddht/tools/factories/endpoint.py
+++ b/ddht/tools/factories/endpoint.py
@@ -15,7 +15,7 @@ class EndpointFactory(factory.Factory):  # type: ignore
     ip_address = factory.LazyFunction(
         lambda: socket.inet_aton(factory.Faker("ipv4").generate({}))
     )
-    port = factory.Faker("pyint", min_value=0, max_value=65535)
+    port = factory.Faker("pyint", min_value=1024, max_value=65535)
 
     @classmethod
     def localhost(cls, *args: Any, **kwargs: Any) -> Endpoint:


### PR DESCRIPTION
## What was wrong?

My system would get angry when a randomly generated port number fell into the "small" number range.

## How was it fixed?

Updated port number generation to only happen between 1024 - MAX_PORT


#### Cute Animal Picture

![3_CATERS_CLUELESS_MONKEY_04-1024x683](https://user-images.githubusercontent.com/824194/91070247-bc77c180-e5f3-11ea-8d37-cc0df0648756.jpg)

