### PR TITLE
Update EventsAPI with all message types

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -17,7 +17,18 @@ from ddht.base_message import (
 from ddht.endpoint import Endpoint
 from ddht.typing import NodeID, SessionKeys
 from ddht.v5_1.envelope import InboundEnvelope
-from ddht.v5_1.messages import PingMessage, PongMessage
+from ddht.v5_1.messages import (
+    FindNodeMessage,
+    FoundNodesMessage,
+    PingMessage,
+    PongMessage,
+    RegisterTopicMessage,
+    RegistrationConfirmationMessage,
+    TalkRequestMessage,
+    TalkResponseMessage,
+    TicketMessage,
+    TopicQueryMessage,
+)
 
 
 class SessionAPI(ABC):
@@ -85,6 +96,34 @@ class EventsAPI(ABC):
 
     pong_sent: EventAPI[OutboundMessage[PongMessage]]
     pong_received: EventAPI[InboundMessage[PongMessage]]
+
+    find_nodes_sent: EventAPI[OutboundMessage[FindNodeMessage]]
+    find_nodes_received: EventAPI[InboundMessage[FindNodeMessage]]
+
+    found_nodes_sent: EventAPI[OutboundMessage[FoundNodesMessage]]
+    found_nodes_received: EventAPI[InboundMessage[FoundNodesMessage]]
+
+    talk_request_sent: EventAPI[OutboundMessage[TalkRequestMessage]]
+    talk_request_received: EventAPI[InboundMessage[TalkRequestMessage]]
+
+    talk_response_sent: EventAPI[OutboundMessage[TalkResponseMessage]]
+    talk_response_received: EventAPI[InboundMessage[TalkResponseMessage]]
+
+    register_topic_sent: EventAPI[OutboundMessage[RegisterTopicMessage]]
+    register_topic_received: EventAPI[InboundMessage[RegisterTopicMessage]]
+
+    ticket_sent: EventAPI[OutboundMessage[TicketMessage]]
+    ticket_received: EventAPI[InboundMessage[TicketMessage]]
+
+    registration_confirmation_sent: EventAPI[
+        OutboundMessage[RegistrationConfirmationMessage]
+    ]
+    registration_confirmation_received: EventAPI[
+        InboundMessage[RegistrationConfirmationMessage]
+    ]
+
+    topic_query_sent: EventAPI[OutboundMessage[TopicQueryMessage]]
+    topic_query_received: EventAPI[InboundMessage[TopicQueryMessage]]
 
 
 class PoolAPI(ABC):

--- a/ddht/v5_1/events.py
+++ b/ddht/v5_1/events.py
@@ -6,7 +6,18 @@ from ddht.endpoint import Endpoint
 from ddht.event import Event
 from ddht.v5_1.abc import EventsAPI, SessionAPI
 from ddht.v5_1.envelope import InboundEnvelope
-from ddht.v5_1.messages import PingMessage, PongMessage
+from ddht.v5_1.messages import (
+    FindNodeMessage,
+    FoundNodesMessage,
+    PingMessage,
+    PongMessage,
+    RegisterTopicMessage,
+    RegistrationConfirmationMessage,
+    TalkRequestMessage,
+    TalkResponseMessage,
+    TicketMessage,
+    TopicQueryMessage,
+)
 
 
 class Events(EventsAPI):
@@ -39,4 +50,60 @@ class Events(EventsAPI):
         )
         self.pong_received: EventAPI[InboundMessage[PongMessage]] = Event(
             "messages.pong.received"
+        )
+
+        self.find_nodes_sent: EventAPI[OutboundMessage[FindNodeMessage]] = Event(
+            "messages.find_nodes.sent"
+        )
+        self.find_nodes_received: EventAPI[InboundMessage[FindNodeMessage]] = Event(
+            "messages.find_nodes.received"
+        )
+
+        self.found_nodes_sent: EventAPI[OutboundMessage[FoundNodesMessage]] = Event(
+            "messages.found_nodes.sent"
+        )
+        self.found_nodes_received: EventAPI[InboundMessage[FoundNodesMessage]] = Event(
+            "messages.found_nodes.received"
+        )
+
+        self.talk_request_sent: EventAPI[OutboundMessage[TalkRequestMessage]] = Event(
+            "messages.talk_request.sent"
+        )
+        self.talk_request_received: EventAPI[
+            InboundMessage[TalkRequestMessage]
+        ] = Event("messages.talk_request.received")
+
+        self.talk_response_sent: EventAPI[OutboundMessage[TalkResponseMessage]] = Event(
+            "messages.talk_response.sent"
+        )
+        self.talk_response_received: EventAPI[
+            InboundMessage[TalkResponseMessage]
+        ] = Event("messages.talk_response.received")
+
+        self.register_topic_sent: EventAPI[
+            OutboundMessage[RegisterTopicMessage]
+        ] = Event("messages.register_topic.sent")
+        self.register_topic_received: EventAPI[
+            InboundMessage[RegisterTopicMessage]
+        ] = Event("messages.register_topic.received")
+
+        self.ticket_sent: EventAPI[OutboundMessage[TicketMessage]] = Event(
+            "messages.ticket.sent"
+        )
+        self.ticket_received: EventAPI[InboundMessage[TicketMessage]] = Event(
+            "messages.ticket.received"
+        )
+
+        self.registration_confirmation_sent: EventAPI[
+            OutboundMessage[RegistrationConfirmationMessage]
+        ] = Event("messages.registration_confirmation.sent")
+        self.registration_confirmation_received: EventAPI[
+            InboundMessage[RegistrationConfirmationMessage]
+        ] = Event("messages.registration_confirmation.received")
+
+        self.topic_query_sent: EventAPI[OutboundMessage[TopicQueryMessage]] = Event(
+            "messages.topic_query.sent"
+        )
+        self.topic_query_received: EventAPI[InboundMessage[TopicQueryMessage]] = Event(
+            "messages.topic_query.received"
         )

--- a/ddht/v5_1/messages.py
+++ b/ddht/v5_1/messages.py
@@ -42,7 +42,7 @@ class FindNodeMessage(BaseMessage):
 
 
 @v51_registry.register
-class NodesMessage(BaseMessage):
+class FoundNodesMessage(BaseMessage):
     message_type = 4
 
     fields = (
@@ -53,21 +53,21 @@ class NodesMessage(BaseMessage):
 
 
 @v51_registry.register
-class TalkReqMessage(BaseMessage):
+class TalkRequestMessage(BaseMessage):
     message_type = 5
 
     fields = (("request_id", big_endian_int), ("protocol", binary), ("request", binary))
 
 
 @v51_registry.register
-class TalkRespMessage(BaseMessage):
+class TalkResponseMessage(BaseMessage):
     message_type = 6
 
     fields = (("request_id", big_endian_int), ("response", binary))
 
 
 @v51_registry.register
-class RegTopicMessage(BaseMessage):
+class RegisterTopicMessage(BaseMessage):
     message_type = 7
 
     fields = (
@@ -90,7 +90,7 @@ class TicketMessage(BaseMessage):
 
 
 @v51_registry.register
-class RegConfirmationMessage(BaseMessage):
+class RegistrationConfirmationMessage(BaseMessage):
     message_type = 9
 
     fields = (("request_id", big_endian_int), ("topic", binary))


### PR DESCRIPTION
## What was wrong?

Needed events for the sending and receiving of each message type.

## How was it fixed?

Added them to the `EventsAPI` as well as code in the dispatcher that triggers them upon sending/receiving such an event.

#### Cute Animal Picture

![o-103202489-facebook](https://user-images.githubusercontent.com/824194/91072287-7f60fe80-e5f6-11ea-9fd1-2636a0b345a4.jpg)

