### PR TITLE
Handle zero sequence number on handshake

### DIFF
--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -384,7 +384,10 @@ class SessionInitiator(BaseSession):
             ephemeral_public_key=ephemeral_public_key,
             record=(
                 local_enr
-                if packet.auth_data.enr_sequence_number < local_enr.sequence_number
+                if (
+                    packet.auth_data.enr_sequence_number < local_enr.sequence_number
+                    or packet.auth_data.enr_sequence_number == 0
+                )
                 else None
             ),
         )


### PR DESCRIPTION
## What was wrong?

When the initiator of the handshake has a zero sequence number they should always send their ENR record in the final handshake packet since they cannot determine whether the recipient has their ENR record or not.

## How was it fixed?

Always send ENR record when the recipient signals that their latest seen sequence number is 0

#### Cute Animal Picture

![c6054e0c806db68b86838c43012fb366](https://user-images.githubusercontent.com/824194/91073541-72dda580-e5f8-11ea-97d2-69ff7e001cc9.jpg)
