### PR TITLE
Dispatcher session management

### DIFF
--- a/ddht/v5_1/events.py
+++ b/ddht/v5_1/events.py
@@ -5,7 +5,7 @@ from ddht.base_message import InboundMessage, OutboundMessage
 from ddht.endpoint import Endpoint
 from ddht.event import Event
 from ddht.v5_1.abc import EventsAPI, SessionAPI
-from ddht.v5_1.envelope import InboundEnvelope
+from ddht.v5_1.envelope import InboundEnvelope, OutboundEnvelope
 from ddht.v5_1.messages import (
     FindNodeMessage,
     FoundNodesMessage,
@@ -28,6 +28,12 @@ class Events(EventsAPI):
         )
         self.session_timeout: EventAPI[SessionAPI] = Event("session.timeout")
 
+        self.packet_sent: EventAPI[Tuple[SessionAPI, OutboundEnvelope]] = Event(
+            "session.packet.sent"
+        )
+        self.packet_received: EventAPI[Tuple[SessionAPI, InboundEnvelope]] = Event(
+            "session.packet.received"
+        )
         self.packet_discarded: EventAPI[Tuple[SessionAPI, InboundEnvelope]] = Event(
             "session.packet.discarded"
         )

--- a/ddht/v5_1/pool.py
+++ b/ddht/v5_1/pool.py
@@ -12,7 +12,6 @@ from ddht.endpoint import Endpoint
 from ddht.message_registry import MessageTypeRegistry
 from ddht.typing import NodeID
 from ddht.v5_1.abc import EventsAPI, PoolAPI, SessionAPI
-from ddht.v5_1.constants import SESSION_IDLE_TIMEOUT
 from ddht.v5_1.envelope import OutboundEnvelope
 from ddht.v5_1.events import Events
 from ddht.v5_1.exceptions import SessionNotFound
@@ -60,20 +59,6 @@ class Pool(PoolAPI):
 
         self._sessions_by_endpoint[session.remote_endpoint].remove(session)
         return session
-
-    def get_idle_sesssions(self) -> Tuple[SessionAPI, ...]:
-        idle_at = trio.current_time() - SESSION_IDLE_TIMEOUT
-        return tuple(
-            session
-            for session in self._sessions.values()
-            if (
-                (
-                    session.is_after_handshake
-                    and session.last_message_received_at <= idle_at
-                )
-                or (session.created_at <= idle_at)
-            )
-        )
 
     def get_sessions_for_endpoint(
         self, remote_endpoint: Endpoint

--- a/tests/core/v5_1/test_dispatcher_session_management.py
+++ b/tests/core/v5_1/test_dispatcher_session_management.py
@@ -1,0 +1,146 @@
+import pytest
+import trio
+
+from ddht.v5_1.constants import SESSION_IDLE_TIMEOUT
+
+
+@pytest.fixture(autouse=True)
+def _share_enr_records(alice, bob):
+    alice.node_db.set_enr(bob.enr)
+    bob.node_db.set_enr(alice.enr)
+
+
+@pytest.mark.trio
+async def test_dispatcher_detects_handshake_timeout_as_initiator(
+    alice, bob, autojump_clock
+):
+    alice.node_db.set_enr(bob.enr)
+
+    async with alice.client() as alice_client:
+        async with bob.client() as bob_client:
+            async with alice.events.session_created.subscribe_and_wait():
+                async with bob.events.packet_sent.subscribe() as subscription:
+                    await alice_client.send_ping(
+                        endpoint=bob.endpoint, node_id=bob.node_id
+                    )
+                    _, envelope = await subscription.receive()
+                    assert envelope.packet.is_who_are_you
+                    bob_client.get_manager().cancel()
+        # Here we know that the session with bob was created and that bob has terminated
+        #
+        # Now we wait for the timeout to be triggered
+        with trio.fail_after(SESSION_IDLE_TIMEOUT + 1):
+            async with alice.events.session_timeout.subscribe() as subscription:
+                session = await subscription.receive()
+                assert session.remote_node_id == bob.node_id
+
+
+@pytest.mark.trio
+async def test_dispatcher_detects_handshake_timeout_as_recipient(
+    alice, bob, autojump_clock
+):
+    alice.node_db.set_enr(bob.enr)
+
+    async with bob.client():
+        async with alice.client() as alice_client:
+            async with bob.events.session_created.subscribe_and_wait():
+                async with alice.events.packet_received.subscribe() as subscription:
+                    await alice_client.send_ping(
+                        endpoint=bob.endpoint, node_id=bob.node_id
+                    )
+                    async for _, envelope in subscription:
+                        if envelope.packet.is_who_are_you:
+                            alice_client.get_manager().cancel()
+                            break
+        # Here we know that the session with bob was created and that alice has
+        # terminated, failing to send the final HandshakePacket
+        #
+        # Now we wait for the timeout to be triggered
+        with trio.fail_after(SESSION_IDLE_TIMEOUT + 1):
+            async with bob.events.session_timeout.subscribe() as subscription:
+                session = await subscription.receive()
+                assert session.remote_node_id == alice.node_id
+
+
+@pytest.mark.trio
+async def test_dispatcher_initiates_new_session_when_packet_cannot_be_decoded(
+    alice, bob, autojump_clock
+):
+    bob.node_db.set_enr(alice.enr)
+
+    async with alice.client():
+        async with bob.client() as bob_client:
+            # initiate a fully completed session and then remove it from bob's side.
+            async with alice.events.session_created.subscribe_and_wait():
+                async with bob.events.session_handshake_complete.subscribe() as subscription:
+                    await bob_client.send_ping(
+                        endpoint=alice.endpoint, node_id=alice.node_id
+                    )
+                    session = await subscription.receive()
+                    bob_client.pool.remove_session(session.id)
+
+            # initiate another session but abort the handshake partway through
+            with trio.fail_after(2):
+                async with alice.events.session_created.subscribe_and_wait():
+                    async with bob.events.session_created.subscribe_and_wait():
+                        await bob_client.send_ping(
+                            endpoint=alice.endpoint, node_id=alice.node_id
+                        )
+
+
+@pytest.mark.trio
+async def test_dispatcher_detects_duplicate_handshakes(alice, bob, autojump_clock):
+    bob.node_db.set_enr(alice.enr)
+
+    async with alice.client() as alice_client:
+        async with bob.client() as bob_client:
+            # initiate a fully completed session and then remove it from bob's side.
+            async with alice.events.session_created.subscribe_and_wait():
+                async with bob.events.session_handshake_complete.subscribe() as subscription:
+                    await bob_client.send_ping(
+                        endpoint=alice.endpoint, node_id=alice.node_id
+                    )
+                    session = await subscription.receive()
+                    bob_client.pool.remove_session(session.id)
+
+            # initiate another session but abort the handshake partway through
+            async with bob.events.session_created.subscribe() as subscription:
+                async with alice.events.session_created.subscribe_and_wait():
+                    await bob_client.send_ping(
+                        endpoint=alice.endpoint, node_id=alice.node_id
+                    )
+                    session = await subscription.receive()
+                bob_client.pool.remove_session(session.id)
+
+            # now we can verify alice has one fully handshaked session and one partial session
+            alice_sessions_with_bob = alice_client.pool.get_sessions_for_endpoint(
+                bob.endpoint
+            )
+            assert len(alice_sessions_with_bob) == 2
+            session_a, session_b = alice_sessions_with_bob
+            if session_a.is_after_handshake:
+                assert not session_b.is_after_handshake
+                full_session, partial_session = session_a, session_b
+            else:
+                assert session_b.is_after_handshake
+                full_session, partial_session = session_b, session_a
+
+            # now bob initiates yet another handshake with alice, which upon
+            # success, alice should remove the full handshake
+            async with alice.events.session_handshake_complete.subscribe() as subscription:
+                await bob_client.send_ping(
+                    endpoint=alice.endpoint, node_id=alice.node_id
+                )
+                new_full_session = await subscription.receive()
+
+            for _ in range(10):
+                await trio.hazmat.checkpoint()
+
+            alice_sessions_with_bob = alice_client.pool.get_sessions_for_endpoint(
+                bob.endpoint
+            )
+            assert len(alice_sessions_with_bob) == 2
+
+            assert full_session not in alice_sessions_with_bob
+            assert partial_session in alice_sessions_with_bob
+            assert new_full_session in alice_sessions_with_bob


### PR DESCRIPTION
## What was wrong?

- Need to initiate new sessions when a new `MessagePacket` arrives that can't be decoded by any of the existing sessions.
- Some exception cases that need to be handled.
- Timeout sessions that haven't seen any activity in a while
- Only retain one fully handshaked session for any given endpoint/node-id pair.
- Do not dispatch outgoing messages to `SessionRecipient` when before handshake.
- Handle `HandshakePacket` with bad signature.

## How was it fixed?

Implemented the functionality.

#### Cute Animal Picture

![20-confused-animals](https://user-images.githubusercontent.com/824194/91191708-59992f80-e6b2-11ea-9875-775ef1f597e7.jpg)
