### PR TITLE
Routing table management

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import AsyncContextManager, NamedTuple, Optional, Tuple
+from typing import AsyncContextManager, Collection, NamedTuple, Optional, Tuple
 
 from eth_keys import keys
 
@@ -43,7 +43,9 @@ class NodeAPI(ABC):
         ...
 
     @abstractmethod
-    def network(self) -> AsyncContextManager[NetworkAPI]:
+    def network(
+        self, bootnodes: Collection[ENR] = ()
+    ) -> AsyncContextManager[NetworkAPI]:
         ...
 
 

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -224,6 +224,11 @@ class ClientAPI(ServiceAPI):
     pool: PoolAPI
     node_db: NodeDBAPI
 
+    @property
+    @abstractmethod
+    def local_node_id(self) -> NodeID:
+        ...
+
     @abstractmethod
     async def wait_listening(self) -> None:
         ...
@@ -325,7 +330,7 @@ class ClientAPI(ServiceAPI):
         ...
 
     async def find_nodes(
-        self, endpoint: Endpoint, node_id: NodeID, distance: Collection[int]
+        self, endpoint: Endpoint, node_id: NodeID, distances: Collection[int]
     ) -> Tuple[InboundMessage[FoundNodesMessage], ...]:
         ...
 
@@ -361,6 +366,11 @@ class NetworkAPI(ServiceAPI):
     #
     @property
     @abstractmethod
+    def local_node_id(self) -> NodeID:
+        ...
+
+    @property
+    @abstractmethod
     def events(self) -> EventsAPI:
         ...
 
@@ -382,4 +392,25 @@ class NetworkAPI(ServiceAPI):
     @property
     @abstractmethod
     def node_db(self) -> NodeDBAPI:
+        ...
+
+    #
+    # High Level API
+    #
+    async def ping(
+        self, node_id: NodeID, endpoint: Optional[Endpoint] = None
+    ) -> PongMessage:
+        ...
+
+    async def find_nodes(
+        self, node_id: NodeID, *distances: int, endpoint: Optional[Endpoint] = None,
+    ) -> Tuple[ENR, ...]:
+        ...
+
+    async def get_enr(
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
+    ) -> ENR:
+        ...
+
+    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENR, ...]:
         ...

--- a/ddht/v5_1/constants.py
+++ b/ddht/v5_1/constants.py
@@ -1,4 +1,7 @@
+from typing import Tuple
+
 from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
+from ddht.enr import ENR
 
 SESSION_IDLE_TIMEOUT = 60
 
@@ -6,3 +9,6 @@ REQUEST_RESPONSE_TIMEOUT = 10
 
 # safe upper bound on the size of the ENR list in a nodes message
 FOUND_NODES_MAX_PAYLOAD_SIZE = DISCOVERY_MAX_PACKET_SIZE - 200
+
+
+DEFAULT_BOOTNODES: Tuple[ENR, ...] = ()

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -1,29 +1,60 @@
+import functools
+import itertools
 import logging
-from typing import List
+import operator
+import secrets
+from typing import Collection, Iterable, List, Optional, Set, Tuple
 
 from async_service import Service
+from eth_utils import to_tuple
+from eth_utils.toolz import groupby, take
+import trio
 
-from ddht._utils import humanize_node_id
+from ddht._utils import every, humanize_node_id
 from ddht.abc import ENRManagerAPI, NodeDBAPI
-from ddht.constants import NUM_ROUTING_TABLE_BUCKETS
+from ddht.constants import (
+    IP_V4_ADDRESS_ENR_KEY,
+    NUM_ROUTING_TABLE_BUCKETS,
+    UDP_PORT_ENR_KEY,
+)
+from ddht.endpoint import Endpoint
 from ddht.enr import ENR
-from ddht.kademlia import KademliaRoutingTable
+from ddht.exceptions import OldSequenceNumber
+from ddht.kademlia import (
+    KademliaRoutingTable,
+    compute_distance,
+    compute_log_distance,
+    iter_closest_nodes,
+)
+from ddht.typing import NodeID
 from ddht.v5_1.abc import ClientAPI, DispatcherAPI, EventsAPI, NetworkAPI, PoolAPI
+from ddht.v5_1.constants import DEFAULT_BOOTNODES
 from ddht.v5_1.messages import FindNodeMessage, PingMessage, PongMessage
 
 
 class Network(Service, NetworkAPI):
     logger = logging.getLogger("ddht.Network")
 
-    def __init__(self, client: ClientAPI) -> None:
+    _bootnodes: Tuple[ENR, ...]
+
+    def __init__(
+        self, client: ClientAPI, bootnodes: Collection[ENR] = DEFAULT_BOOTNODES
+    ) -> None:
         self.client = client
+
+        self._bootnodes = tuple(bootnodes)
         self.routing_table = KademliaRoutingTable(
             self.client.enr_manager.enr.node_id, NUM_ROUTING_TABLE_BUCKETS,
         )
+        self._routing_table_ready = trio.Event()
 
     #
     # Proxied ClientAPI properties
     #
+    @property
+    def local_node_id(self) -> NodeID:
+        return self.client.local_node_id
+
     @property
     def events(self) -> EventsAPI:
         return self.client.events
@@ -44,14 +75,155 @@ class Network(Service, NetworkAPI):
     def node_db(self) -> NodeDBAPI:
         return self.client.node_db
 
+    #
+    # High Level API
+    #
+    async def ping(
+        self, node_id: NodeID, endpoint: Optional[Endpoint] = None
+    ) -> PongMessage:
+        if endpoint is None:
+            endpoint = self._endpoint_for_node_id(node_id)
+        response = await self.client.ping(endpoint, node_id)
+        return response.message
+
+    async def find_nodes(
+        self, node_id: NodeID, *distances: int, endpoint: Optional[Endpoint] = None,
+    ) -> Tuple[ENR, ...]:
+        if not distances:
+            raise TypeError("Must provide at least one distance")
+
+        if endpoint is None:
+            endpoint = self._endpoint_for_node_id(node_id)
+        responses = await self.client.find_nodes(endpoint, node_id, distances=distances)
+        return tuple(enr for response in responses for enr in response.message.enrs)
+
+    async def get_enr(
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
+    ) -> ENR:
+        enrs = await self.find_nodes(node_id, 0, endpoint=endpoint)
+        if not enrs:
+            raise Exception("Invalid response")
+        # This reduce accounts for
+        return _reduce_enrs(enrs)[0]
+
+    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENR, ...]:
+        self.logger.debug("Recursive find nodes: %s", humanize_node_id(target))
+
+        queried_node_ids = set()
+        unresponsive_node_ids = set()
+        received_enrs: List[ENR] = []
+        received_node_ids: Set[NodeID] = set()
+
+        async def do_lookup(node_id: NodeID) -> None:
+            queried_node_ids.add(node_id)
+
+            distance = compute_log_distance(node_id, target)
+            try:
+                enrs = await self.find_nodes(node_id, distance)
+            except trio.TooSlowError:
+                unresponsive_node_ids.add(node_id)
+
+            for enr in enrs:
+                received_node_ids.add(enr.node_id)
+                try:
+                    self.node_db.set_enr(enr)
+                except OldSequenceNumber:
+                    received_enrs.append(self.node_db.get_enr(enr.node_id))
+                else:
+                    received_enrs.append(enr)
+
+        for lookup_round_counter in itertools.count():
+            candidates = iter_closest_nodes(
+                target, self.routing_table, received_node_ids
+            )
+            responsive_candidates = itertools.dropwhile(
+                lambda node: node in unresponsive_node_ids, candidates
+            )
+            closest_k_candidates = take(
+                self.routing_table.bucket_size, responsive_candidates
+            )
+            closest_k_unqueried_candidates = (
+                candidate
+                for candidate in closest_k_candidates
+                if candidate not in queried_node_ids
+            )
+            nodes_to_query = tuple(take(3, closest_k_unqueried_candidates))
+
+            if nodes_to_query:
+                self.logger.debug(
+                    "Starting lookup round %d for %s",
+                    lookup_round_counter + 1,
+                    humanize_node_id(target),
+                )
+                async with trio.open_nursery() as nursery:
+                    for peer in nodes_to_query:
+                        nursery.start_soon(do_lookup, peer)
+            else:
+                self.logger.debug(
+                    "Lookup for %s finished in %d rounds",
+                    humanize_node_id(target),
+                    lookup_round_counter,
+                )
+                break
+
+        # now sort and return the ENR records in order of closesness to the target.
+        return tuple(
+            sorted(
+                _reduce_enrs(received_enrs),
+                key=lambda enr: compute_distance(enr.node_id, target),
+            )
+        )
+
+    #
+    # Long Running Processes
+    #
     async def run(self) -> None:
         self.manager.run_daemon_child_service(self.client)
         await self.client.wait_listening()
 
+        self.manager.run_daemon_task(self._manage_routing_table)
         self.manager.run_daemon_task(self._pong_when_pinged)
         self.manager.run_daemon_task(self._serve_find_nodes)
 
         await self.manager.wait_finished()
+
+    async def _manage_routing_table(self) -> None:
+        # First load all the bootnode ENRs into our database
+        for enr in self._bootnodes:
+            try:
+                self.node_db.set_enr(enr)
+            except OldSequenceNumber:
+                pass
+
+        # Now repeatedly try to bond with each bootnode until one succeeds.
+        async with trio.open_nursery() as nursery:
+            while self.manager.is_running:
+                for enr in self._bootnodes:
+                    if enr.node_id == self.local_node_id:
+                        continue
+                    endpoint = self._endpoint_for_enr(enr)
+                    nursery.start_soon(
+                        functools.partial(self._bond, endpoint=endpoint), enr.node_id,
+                    )
+
+                with trio.move_on_after(10):
+                    await self._routing_table_ready.wait()
+                    break
+
+        # TODO: Need better logic here for more quickly populating the
+        # routing table.  Should start off aggressively filling in the
+        # table, only backing off once the table contains some minimum
+        # number of records **or** searching for new records fails to find
+        # new nodes.  Maybe use a TokenBucket
+        async for _ in every(30):
+            async with trio.open_nursery() as nursery:
+                target_node_id = NodeID(secrets.token_bytes(32))
+                found_enrs = await self.recursive_find_nodes(target_node_id)
+                for enr in found_enrs:
+                    endpoint = self._endpoint_for_enr(enr)
+                    nursery.start_soon(
+                        functools.partial(self._bond, endpoint=endpoint), enr.node_id,
+                    )
 
     async def _pong_when_pinged(self) -> None:
         async with self.dispatcher.subscribe(PingMessage) as subscription:
@@ -78,32 +250,36 @@ class Network(Service, NetworkAPI):
                         humanize_node_id(request.sender_node_id),
                         request.sender_endpoint,
                     )
-                    return
+                    continue
                 elif not distances:
                     self.logger.debug(
                         "Ignoring invalid FindNodeMessage from %s@%s: empty distances",
                         humanize_node_id(request.sender_node_id),
                         request.sender_endpoint,
                     )
-                    return
+                    continue
+                elif any(
+                    distance > self.routing_table.num_buckets for distance in distances
+                ):
+                    self.logger.debug(
+                        "Ignoring invalid FindNodeMessage from %s@%s: distances: %s",
+                        humanize_node_id(request.sender_node_id),
+                        request.sender_endpoint,
+                        distances,
+                    )
+                    continue
 
                 for distance in distances:
                     if distance == 0:
                         response_enrs.append(self.enr_manager.enr)
-                    elif distance < self.routing_table.num_buckets:
+                    elif distance <= self.routing_table.num_buckets:
                         node_ids_at_distance = self.routing_table.get_nodes_at_log_distance(
                             distance,
                         )
                         for node_id in node_ids_at_distance:
                             response_enrs.append(self.node_db.get_enr(node_id))
                     else:
-                        self.logger.debug(
-                            "Ignoring invalid FindNodeMessage from %s@%s: invalid distance: %d",
-                            humanize_node_id(request.sender_node_id),
-                            request.sender_endpoint,
-                            distance,
-                        )
-                        return
+                        raise Exception("Should be unreachable")
 
                 await self.client.send_found_nodes(
                     request.sender_endpoint,
@@ -111,3 +287,67 @@ class Network(Service, NetworkAPI):
                     enrs=response_enrs,
                     request_id=request.message.request_id,
                 )
+
+    #
+    # Utility
+    #
+    async def _bond(
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
+    ) -> None:
+        try:
+            pong = await self.ping(node_id, endpoint=endpoint)
+        except trio.TooSlowError:
+            self.logger.debug(
+                "Bonding with %s timed out during ping", humanize_node_id(node_id)
+            )
+            return
+
+        try:
+            enr = self.node_db.get_enr(node_id)
+        except KeyError:
+            try:
+                enr = await self.get_enr(node_id, endpoint=endpoint)
+            except trio.TooSlowError:
+                self.logger.debug(
+                    "Bonding with %s timed out during ENR retrieval",
+                    humanize_node_id(node_id),
+                )
+                return
+        else:
+            if pong.enr_seq > enr.sequence_number:
+                try:
+                    enr = await self.get_enr(node_id, endpoint=endpoint)
+                except trio.TooSlowError:
+                    self.logger.debug(
+                        "Bonding with %s timed out during ENR retrieval",
+                        humanize_node_id(node_id),
+                    )
+                else:
+                    self.node_db.set_enr(enr)
+
+        self.routing_table.update(enr.node_id)
+
+        self._routing_table_ready.set()
+
+    def _endpoint_for_enr(self, enr: ENR) -> Endpoint:
+        try:
+            ip_address = enr[IP_V4_ADDRESS_ENR_KEY]
+            port = enr[UDP_PORT_ENR_KEY]
+        except KeyError:
+            raise Exception("Missing endpoint address information: ")
+
+        return Endpoint(ip_address, port)
+
+    def _endpoint_for_node_id(self, node_id: NodeID) -> Endpoint:
+        enr = self.node_db.get_enr(node_id)
+        return self._endpoint_for_enr(enr)
+
+
+@to_tuple
+def _reduce_enrs(enrs: Collection[ENR]) -> Iterable[ENR]:
+    enrs_by_node_id = groupby(operator.attrgetter("node_id"), enrs)
+    for _, enr_group in enrs_by_node_id.items():
+        if len(enr_group) == 1:
+            yield enr_group[0]
+        else:
+            yield max(enr_group, key=operator.attrgetter("sequence_number"))

--- a/tests/core/v5_1/test_client.py
+++ b/tests/core/v5_1/test_client.py
@@ -198,14 +198,13 @@ async def test_client_request_response_find_nodes_found_nodes(
 
     checked_bucket_indexes = []
 
-    for distance in range(255, 0, -1):
+    for distance in range(256, 1, -1):
         async with trio.open_nursery() as nursery:
             async with bob.events.find_nodes_received.subscribe() as subscription:
-                bucket = table.buckets[distance]
+                bucket = table.buckets[distance - 1]
                 if not len(bucket):
                     break
 
-                bucket = table.buckets[distance]
                 expected_enrs = tuple(
                     bob.node_db.get_enr(node_id) for node_id in bucket
                 )

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -1,3 +1,7 @@
+import collections
+from contextlib import AsyncExitStack
+import secrets
+
 import pytest
 import trio
 
@@ -20,18 +24,23 @@ async def test_network_responds_to_pings(alice, bob):
 
 @pytest.mark.trio
 async def test_network_responds_to_find_node_requests(alice, bob):
-    distances = (0, 255, 254)
+    distances = {0}
 
     async with alice.network() as alice_network:
         async with bob.network() as bob_network:
-            for _ in range(20):
+            for _ in range(200):
                 enr = ENRFactory()
                 bob.node_db.set_enr(enr)
                 bob_network.routing_table.update(enr.node_id)
+                distances.add(compute_log_distance(enr.node_id, bob.node_id))
+                if distances.issuperset({0, 256, 255}):
+                    break
+            else:
+                raise Exception("failed")
 
             with trio.fail_after(2):
                 responses = await alice_network.client.find_nodes(
-                    bob.endpoint, bob.node_id, distances=distances,
+                    bob.endpoint, bob.node_id, distances=(0, 255, 256),
                 )
 
     assert all(
@@ -46,4 +55,87 @@ async def test_network_responds_to_find_node_requests(alice, bob):
         else 0
         for enr in response_enrs
     }
-    assert response_distances == set(distances)
+    assert response_distances.issuperset({0, 255, 256})
+
+
+@pytest.mark.trio
+async def test_network_ping_api(alice, bob):
+    async with alice.network() as alice_network:
+        async with bob.network():
+            with trio.fail_after(2):
+                pong = await alice_network.ping(bob.node_id)
+
+    assert pong.enr_seq == bob.enr.sequence_number
+    assert pong.packet_ip == alice.endpoint.ip_address
+    assert pong.packet_port == alice.endpoint.port
+
+
+@pytest.mark.trio
+async def test_network_find_nodes_api(alice, bob):
+    distances = {0}
+
+    async with alice.network() as alice_network:
+        async with bob.network() as bob_network:
+            for _ in range(200):
+                enr = ENRFactory()
+                bob.node_db.set_enr(enr)
+                bob_network.routing_table.update(enr.node_id)
+                distances.add(compute_log_distance(enr.node_id, bob.node_id))
+                if distances.issuperset({0, 256, 255}):
+                    break
+            else:
+                raise Exception("failed")
+
+            with trio.fail_after(2):
+                enrs = await alice_network.find_nodes(bob.node_id, 0, 255, 256)
+
+    assert any(enr.node_id == bob.node_id for enr in enrs)
+    response_distances = {
+        compute_log_distance(enr.node_id, bob.node_id)
+        for enr in enrs
+        if enr.node_id != bob.node_id
+    }
+    assert response_distances == {256, 255}
+
+
+@pytest.mark.trio
+async def test_network_recursive_find_nodes(tester, alice, bob):
+    async with AsyncExitStack() as stack:
+        await stack.enter_async_context(bob.network())
+        bootnodes = collections.deque((bob.enr,), maxlen=4)
+        nodes = [bob, alice]
+        for _ in range(20):
+            node = tester.node()
+            nodes.append(node)
+            await stack.enter_async_context(node.network(bootnodes=bootnodes))
+            bootnodes.append(node.enr)
+
+        # give the the network some time to interconnect.
+        with trio.fail_after(5):
+            for _ in range(1000):
+                await trio.hazmat.checkpoint()
+
+        alice_network = await stack.enter_async_context(
+            alice.network(bootnodes=bootnodes)
+        )
+
+        # give alice a little time to connect to the network as well
+        with trio.fail_after(5):
+            for _ in range(1000):
+                await trio.hazmat.checkpoint()
+
+        target_node_id = secrets.token_bytes(32)
+        node_ids_by_distance = tuple(
+            sorted(
+                tuple(node.enr.node_id for node in nodes),
+                key=lambda node_id: compute_log_distance(target_node_id, node_id),
+            )
+        )
+        best_node_ids_by_distance = set(node_ids_by_distance[:3])
+
+        with trio.fail_after(10):
+            found_enrs = await alice_network.recursive_find_nodes(target_node_id)
+        found_node_ids = tuple(enr.node_id for enr in found_enrs)
+
+        # Ensure that one of the three closest node ids was in the returned node ids
+        assert best_node_ids_by_distance.intersection(found_node_ids)


### PR DESCRIPTION
## What was wrong?

The network API holds the routing table but currently does nothing to manage it.

## How was it fixed?

The network API now manages the routing table.

- upon booting it establishes connections with the provided bootnodes and bootsraps the routing table.
- a long running process periodically searches the network for a random node-id, bonding with the discovered nodes and adding them to the routing table.
- supporting functionality is implemented for both singular `find_nodes` requests and `ping` requests as well as recursive lookups.

#### Cute Animal Picture

![preview16](https://user-images.githubusercontent.com/824194/91457888-1ec60180-e842-11ea-86ef-741b86bd9dd1.jpg)

