### PR TITLE
Periodically ping routing table entries

### DIFF
--- a/ddht/kademlia.py
+++ b/ddht/kademlia.py
@@ -133,10 +133,9 @@ class KademliaRoutingTable(RoutingTableAPI):
             node_id
         )
         if include_replacement_cache:
-            nodes = bucket + replacement_cache
+            return node_id in bucket or node_id in replacement_cache
         else:
-            nodes = bucket
-        return node_id in nodes
+            return node_id in bucket
 
     def get_index_bucket_and_replacement_cache(
         self, node_id: NodeID

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -397,8 +397,13 @@ class NetworkAPI(ServiceAPI):
     #
     # High Level API
     #
+    async def bond(
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
+    ) -> bool:
+        ...
+
     async def ping(
-        self, node_id: NodeID, endpoint: Optional[Endpoint] = None
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
     ) -> PongMessage:
         ...
 

--- a/ddht/v5_1/constants.py
+++ b/ddht/v5_1/constants.py
@@ -5,6 +5,8 @@ from ddht.enr import ENR
 
 SESSION_IDLE_TIMEOUT = 60
 
+ROUTING_TABLE_KEEP_ALIVE = 300
+
 REQUEST_RESPONSE_TIMEOUT = 10
 
 # safe upper bound on the size of the ENR list in a nodes message


### PR DESCRIPTION
## What was wrong?

Part of the discv5 spec dictates that records from the routing table should be periodically verified to be lively.

## How was it fixed?

This is an imperfect but good enough implementation.

- Monitor `PongMessage` record the last time a pong was received.
- Periodically scan for the entry from the routing table that was least recently pinged and try to ping them.

This is considered *good enough* because the `PongMessages` may not actually be in response to a ping request which isn't exactly invalid, but a strict interpretation of the protocol would suggest we should ignore such messages.

#### Cute Animal Picture

![25 Examples of Confused Animals 24](https://user-images.githubusercontent.com/824194/91473556-44f59c80-e856-11ea-9a9c-91d8501b3f37.jpg)
