### PR TITLE
CLI entry point for v5.1 protocol.

### DIFF
--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -1,16 +1,24 @@
 import logging
 import os
 
-from async_service import background_trio_service
+from async_service import ServiceAPI, background_trio_service
 
-from ddht.app import Application
 from ddht.boot_info import BootInfo
+from ddht.constants import ProtocolVersion
+from ddht.v5.app import Application as ApplicationV5
+from ddht.v5_1.app import Application as ApplicationV5_1
 
 logger = logging.getLogger("ddht")
 
 
 async def do_main(boot_info: BootInfo) -> None:
-    app = Application(boot_info)
+    app: ServiceAPI
+    if boot_info.protocol_version is ProtocolVersion.v5:
+        app = ApplicationV5(boot_info)
+    elif boot_info.protocol_version is ProtocolVersion.v5_1:
+        app = ApplicationV5_1(boot_info)
+    else:
+        raise Exception(f"Unsupported protocol version: {boot_info.protocol_version}")
 
     logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(app) as manager:

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from ddht import __version__
 from ddht.cli_commands import do_main
+from ddht.constants import ProtocolVersion
 from ddht.enr import ENR
 
 parser = argparse.ArgumentParser(description="Discovery V5 DHT")
@@ -29,6 +30,13 @@ network_parser = parser.add_argument_group("network")
 # Core
 #
 ddht_parser.add_argument("--private-key", help="Hex encoded 32 byte private key")
+ddht_parser.add_argument(
+    "--protocol-version",
+    default=ProtocolVersion.v5,
+    type=ProtocolVersion,
+    choices=ProtocolVersion,
+    help="Protocol version which should be used",
+)
 
 base_dir_parser = ddht_parser.add_mutually_exclusive_group()
 

--- a/ddht/constants.py
+++ b/ddht/constants.py
@@ -1,14 +1,5 @@
+import enum
 import ipaddress
-from typing import Tuple
-
-# Default bootnodes
-DEFAULT_BOOTNODES: Tuple[str, ...] = (
-    "enr:-LK4QHAlBrRpcx9d6JTRA5kVnTNSPwVs-v_QIwBE8wfZxIqPWqqMDGGKpZDXI2lhbbnO66cmGK3eEzot3D_P_MGbcUAhh2F0dG5ldHOIgRebSXZucWmEZXRoMpCA4XabAAAAAP__________gmlkgnY0gmlwhBLDX_-Jc2VjcDI1NmsxoQOnyC60XGPSxv86ncxxezh0khFdgu7E3Cqr4imui_h_6oN0Y3CCIyiDdWRwgiMo",  # noqa: E501
-    # https://github.com/goerli/medalla/blob/cd5c2042f6249de86bfad10d0cd141c988a42089/medalla/bootnodes.txt
-    "enr:-LK4QKWk9yZo258PQouLshTOEEGWVHH7GhKwpYmB5tmKE4eHeSfman0PZvM2Rpp54RWgoOagAsOfKoXgZSbiCYzERWABh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAAAAAAAAAAAAgmlkgnY0gmlwhDQlA5CJc2VjcDI1NmsxoQOYiWqrQtQksTEtS3qY6idxJE5wkm0t9wKqpzv2gCR21oN0Y3CCIyiDdWRwgiMo",  # noqa: E501
-    "enr:-LK4QEnIS-PIxxLCadJdnp83VXuJqgKvC9ZTIWaJpWqdKlUFCiup2sHxWihF9EYGlMrQLs0mq_2IyarhNq38eoaOHUoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAAAAAAAAAAAAgmlkgnY0gmlwhA37LMaJc2VjcDI1NmsxoQJ7k0mKtTd_kdEq251flOjD1HKpqgMmIETDoD-Msy_O-4N0Y3CCIyiDdWRwgiMo",  # noqa: E501
-    "enr:-KG4QIOJRu0BBlcXJcn3lI34Ub1aBLYipbnDaxBnr2uf2q6nE1TWnKY5OAajg3eG6mHheQSfRhXLuy-a8V5rqXKSoUEChGV0aDKQGK5MywAAAAH__________4JpZIJ2NIJpcIQKAAFhiXNlY3AyNTZrMaEDESplmV9c2k73v0DjxVXJ6__2bWyP-tK28_80lf7dUhqDdGNwgiMog3VkcIIjKA",  # noqa: E501
-)
 
 # Default port number
 DEFAULT_PORT: int = 30303
@@ -35,3 +26,8 @@ TCP_PORT_ENR_KEY = b"tcp"
 IP_V4_SIZE = 4  # size of an IPv4 address
 IP_V6_SIZE = 16  # size of an IPv6 address
 NUM_ROUTING_TABLE_BUCKETS = 256  # number of buckets in the routing table
+
+
+class ProtocolVersion(enum.Enum):
+    v5 = "v5"
+    v5_1 = "v5.1"

--- a/ddht/datagram.py
+++ b/ddht/datagram.py
@@ -42,7 +42,7 @@ async def DatagramReceiver(
                 DISCOVERY_DATAGRAM_BUFFER_SIZE
             )
             endpoint = Endpoint(inet_aton(ip_address), port)
-            logger.debug(f"Received {len(datagram)} bytes from {endpoint}")
+            logger.debug("Received %d bytes from %s", len(datagram), endpoint)
             inbound_datagram = InboundDatagram(datagram, endpoint)
             try:
                 await inbound_datagram_send_channel.send(inbound_datagram)
@@ -65,5 +65,5 @@ async def DatagramSender(
 
     async with outbound_datagram_receive_channel:
         async for datagram, endpoint in outbound_datagram_receive_channel:
-            logger.debug(f"Sending {len(datagram)} bytes to {endpoint}")
+            logger.debug("Sending %d bytes to %s", len(datagram), endpoint)
             await sock.sendto(datagram, (inet_ntoa(endpoint.ip_address), endpoint.port))

--- a/ddht/encryption.py
+++ b/ddht/encryption.py
@@ -58,7 +58,14 @@ def aesctr_encrypt(key: AES128Key, iv: bytes, plain_text: bytes) -> bytes:
 def aesctr_decrypt_stream(
     key: AES128Key, iv: bytes, cipher_text: bytes
 ) -> Iterator[int]:
-    cipher = Cipher(AES(key), CTR(iv), backend=default_backend())
+    aes_key = AES(key)
+    ctr = CTR(iv)
+
+    try:
+        cipher = Cipher(aes_key, ctr, backend=default_backend())
+    except ValueError as err:
+        raise DecryptionError(str(err)) from err
+
     decryptor = cipher.decryptor()
     num_blocks = int(math.ceil(len(cipher_text) / 16))
     for i in range(num_blocks):

--- a/ddht/enr.py
+++ b/ddht/enr.py
@@ -287,7 +287,8 @@ class UnsignedENR(BaseENR, ENRContentSedes):
         return other.__class__ is self.__class__ and dict(other) == dict(self)
 
     def __hash__(self) -> int:
-        return hash((self.sequence_number, tuple(self.items())))
+        sorted_key_value_pairs = tuple(sorted(self.items(), key=operator.itemgetter(0)))
+        return hash((self.sequence_number, sorted_key_value_pairs))
 
 
 class ENR(BaseENR, ENRSedes):
@@ -333,7 +334,8 @@ class ENR(BaseENR, ENRSedes):
         )
 
     def __hash__(self) -> int:
-        return hash((self.signature, self.sequence_number, tuple(self.items())))
+        sorted_key_value_pairs = tuple(sorted(self.items(), key=operator.itemgetter(0)))
+        return hash((self.signature, self.sequence_number, sorted_key_value_pairs))
 
     def __repr__(self) -> str:
         base64_rlp = base64.urlsafe_b64encode(rlp.encode(self))

--- a/ddht/exceptions.py
+++ b/ddht/exceptions.py
@@ -6,6 +6,14 @@ class BaseDDHTError(Exception):
     pass
 
 
+class DecodingError(BaseDDHTError):
+    """
+    Raised when a datagram could not be decoded.
+    """
+
+    pass
+
+
 class DecryptionError(BaseDDHTError):
     """
     Raised when a message could not be decrypted.

--- a/ddht/tools/factories/boot_info.py
+++ b/ddht/tools/factories/boot_info.py
@@ -1,21 +1,32 @@
+from typing import Dict, Tuple
+
 import factory
 
 from ddht.boot_info import BootInfo
-from ddht.constants import DEFAULT_BOOTNODES, DEFAULT_PORT
+from ddht.constants import DEFAULT_PORT, ProtocolVersion
 from ddht.enr import ENR
+from ddht.v5.constants import DEFAULT_BOOTNODES as DEFAULT_V5_BOOTNODES
+from ddht.v5_1.constants import DEFAULT_BOOTNODES as DEFAULT_V51_BOOTNODES
 from ddht.xdg import get_xdg_ddht_root
+
+BOOTNODES_V5 = tuple(ENR.from_repr(enr_repr) for enr_repr in DEFAULT_V5_BOOTNODES)
+BOOTNODES_V5_1 = tuple(ENR.from_repr(enr_repr) for enr_repr in DEFAULT_V51_BOOTNODES)
+
+BOOTNODES: Dict[ProtocolVersion, Tuple[ENR, ...]] = {
+    ProtocolVersion.v5: BOOTNODES_V5,
+    ProtocolVersion.v5_1: BOOTNODES_V5_1,
+}
 
 
 class BootInfoFactory(factory.Factory):  # type: ignore
     class Meta:
         model = BootInfo
 
+    protocol_version = ProtocolVersion.v5
     private_key = None
     base_dir = factory.LazyFunction(get_xdg_ddht_root)
     port = DEFAULT_PORT
     listen_on = None
-    bootnodes = factory.LazyFunction(
-        lambda: tuple(ENR.from_repr(enr_repr) for enr_repr in DEFAULT_BOOTNODES)
-    )
+    bootnodes = factory.LazyAttribute(lambda o: BOOTNODES[o.protocol_version])
     is_ephemeral = False
     is_upnp_enabled = True

--- a/ddht/v5/constants.py
+++ b/ddht/v5/constants.py
@@ -1,5 +1,17 @@
+from typing import Tuple
+
 from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
 from ddht.typing import Nonce
+
+# Default bootnodes
+DEFAULT_BOOTNODES: Tuple[str, ...] = (
+    "enr:-LK4QHAlBrRpcx9d6JTRA5kVnTNSPwVs-v_QIwBE8wfZxIqPWqqMDGGKpZDXI2lhbbnO66cmGK3eEzot3D_P_MGbcUAhh2F0dG5ldHOIgRebSXZucWmEZXRoMpCA4XabAAAAAP__________gmlkgnY0gmlwhBLDX_-Jc2VjcDI1NmsxoQOnyC60XGPSxv86ncxxezh0khFdgu7E3Cqr4imui_h_6oN0Y3CCIyiDdWRwgiMo",  # noqa: E501
+    # https://github.com/goerli/medalla/blob/cd5c2042f6249de86bfad10d0cd141c988a42089/medalla/bootnodes.txt
+    "enr:-LK4QKWk9yZo258PQouLshTOEEGWVHH7GhKwpYmB5tmKE4eHeSfman0PZvM2Rpp54RWgoOagAsOfKoXgZSbiCYzERWABh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAAAAAAAAAAAAgmlkgnY0gmlwhDQlA5CJc2VjcDI1NmsxoQOYiWqrQtQksTEtS3qY6idxJE5wkm0t9wKqpzv2gCR21oN0Y3CCIyiDdWRwgiMo",  # noqa: E501
+    "enr:-LK4QEnIS-PIxxLCadJdnp83VXuJqgKvC9ZTIWaJpWqdKlUFCiup2sHxWihF9EYGlMrQLs0mq_2IyarhNq38eoaOHUoBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpAAAAAAAAAAAAAAAAAAAAAAgmlkgnY0gmlwhA37LMaJc2VjcDI1NmsxoQJ7k0mKtTd_kdEq251flOjD1HKpqgMmIETDoD-Msy_O-4N0Y3CCIyiDdWRwgiMo",  # noqa: E501
+    "enr:-KG4QIOJRu0BBlcXJcn3lI34Ub1aBLYipbnDaxBnr2uf2q6nE1TWnKY5OAajg3eG6mHheQSfRhXLuy-a8V5rqXKSoUEChGV0aDKQGK5MywAAAAH__________4JpZIJ2NIJpcIQKAAFhiXNlY3AyNTZrMaEDESplmV9c2k73v0DjxVXJ6__2bWyP-tK28_80lf7dUhqDdGNwgiMog3VkcIIjKA",  # noqa: E501
+)
+
 
 NONCE_SIZE = 12  # size of an AESGCM nonce
 TAG_SIZE = 32  # size of the tag packet prefix

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -1,0 +1,115 @@
+import logging
+
+from async_service import Service, run_trio_service
+from eth.db.backends.level import LevelDB
+from eth_keys import keys
+from eth_utils import encode_hex
+import trio
+
+from ddht._utils import generate_node_key_file, read_node_key_file
+from ddht.boot_info import BootInfo
+from ddht.constants import DEFAULT_LISTEN, IP_V4_ADDRESS_ENR_KEY
+from ddht.endpoint import Endpoint
+from ddht.enr_manager import ENRManager
+from ddht.identity_schemes import default_identity_scheme_registry
+from ddht.node_db import NodeDB
+from ddht.typing import AnyIPAddress
+from ddht.upnp import UPnPService
+from ddht.v5_1.client import Client
+from ddht.v5_1.constants import DEFAULT_BOOTNODES
+from ddht.v5_1.events import Events
+from ddht.v5_1.messages import v51_registry
+from ddht.v5_1.network import Network
+
+logger = logging.getLogger("ddht.DDHT")
+
+
+ENR_DATABASE_DIR_NAME = "enr-db"
+
+
+def get_local_private_key(boot_info: BootInfo) -> keys.PrivateKey:
+    if boot_info.private_key is None:
+        # load from disk or generate
+        node_key_file_path = boot_info.base_dir / "nodekey"
+        if not node_key_file_path.exists():
+            generate_node_key_file(node_key_file_path)
+        return read_node_key_file(node_key_file_path)
+    else:
+        return boot_info.private_key
+
+
+class Application(Service):
+    logger = logger
+    _boot_info: BootInfo
+
+    def __init__(self, boot_info: BootInfo) -> None:
+        self._boot_info = boot_info
+
+    async def _update_enr_ip_from_upnp(
+        self, enr_manager: ENRManager, upnp_service: UPnPService
+    ) -> None:
+        await upnp_service.get_manager().wait_started()
+
+        with trio.move_on_after(10):
+            _, external_ip = await upnp_service.get_ip_addresses()
+            enr_manager.update((IP_V4_ADDRESS_ENR_KEY, external_ip.packed))
+
+        while self.manager.is_running:
+            _, external_ip = await upnp_service.wait_ip_changed()
+            enr_manager.update((IP_V4_ADDRESS_ENR_KEY, external_ip.packed))
+
+    async def run(self) -> None:
+        identity_scheme_registry = default_identity_scheme_registry
+
+        message_type_registry = v51_registry
+
+        enr_database_dir = self._boot_info.base_dir / ENR_DATABASE_DIR_NAME
+        enr_database_dir.mkdir(exist_ok=True)
+        node_db = NodeDB(identity_scheme_registry, LevelDB(enr_database_dir))
+
+        local_private_key = get_local_private_key(self._boot_info)
+
+        enr_manager = ENRManager(node_db=node_db, private_key=local_private_key,)
+
+        port = self._boot_info.port
+        events = Events()
+
+        if b"udp" not in enr_manager.enr:
+            enr_manager.update((b"udp", port))
+
+        listen_on_ip_address: AnyIPAddress
+        if self._boot_info.listen_on is None:
+            listen_on_ip_address = DEFAULT_LISTEN
+        else:
+            listen_on_ip_address = self._boot_info.listen_on
+            # Update the ENR if an explicit listening address was provided
+            enr_manager.update((IP_V4_ADDRESS_ENR_KEY, listen_on_ip_address.packed))
+
+        listen_on = Endpoint(listen_on_ip_address.packed, self._boot_info.port)
+
+        if self._boot_info.is_upnp_enabled:
+            upnp_service = UPnPService(port)
+            self.manager.run_daemon_child_service(upnp_service)
+            self.manager.run_daemon_task(
+                self._update_enr_ip_from_upnp, enr_manager, upnp_service
+            )
+
+        bootnodes = DEFAULT_BOOTNODES + self._boot_info.bootnodes
+
+        client = Client(
+            local_private_key=local_private_key,
+            listen_on=listen_on,
+            node_db=node_db,
+            events=events,
+            message_type_registry=message_type_registry,
+        )
+        network = Network(client=client, bootnodes=bootnodes,)
+
+        logger.info("Protocol-Version: %s", self._boot_info.protocol_version.value)
+        logger.info("DDHT base dir: %s", self._boot_info.base_dir)
+        logger.info("Starting discovery service...")
+        logger.info("Listening on %s:%d", listen_on, port)
+        logger.info("Local Node ID: %s", encode_hex(enr_manager.enr.node_id))
+        logger.info("Local ENR: %s", enr_manager.enr)
+
+        await run_trio_service(network)

--- a/ddht/v5_1/constants.py
+++ b/ddht/v5_1/constants.py
@@ -1,7 +1,6 @@
 from typing import Tuple
 
 from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
-from ddht.enr import ENR
 
 SESSION_IDLE_TIMEOUT = 60
 
@@ -13,4 +12,4 @@ REQUEST_RESPONSE_TIMEOUT = 10
 FOUND_NODES_MAX_PAYLOAD_SIZE = DISCOVERY_MAX_PACKET_SIZE - 200
 
 
-DEFAULT_BOOTNODES: Tuple[ENR, ...] = ()
+DEFAULT_BOOTNODES: Tuple[str, ...] = ()

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -28,7 +28,7 @@ from ddht.kademlia import (
 )
 from ddht.typing import NodeID
 from ddht.v5_1.abc import ClientAPI, DispatcherAPI, EventsAPI, NetworkAPI, PoolAPI
-from ddht.v5_1.constants import DEFAULT_BOOTNODES, ROUTING_TABLE_KEEP_ALIVE
+from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE
 from ddht.v5_1.messages import FindNodeMessage, PingMessage, PongMessage
 
 
@@ -37,9 +37,7 @@ class Network(Service, NetworkAPI):
 
     _bootnodes: Tuple[ENR, ...]
 
-    def __init__(
-        self, client: ClientAPI, bootnodes: Collection[ENR] = DEFAULT_BOOTNODES
-    ) -> None:
+    def __init__(self, client: ClientAPI, bootnodes: Collection[ENR],) -> None:
         self.client = client
 
         self._bootnodes = tuple(bootnodes)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 addopts= -v --showlocals --durations 10
-python_paths= .
 xfail_strict=true
 
 [pytest-watch]

--- a/tests/core/test_cli_parsing_to_boot_info.py
+++ b/tests/core/test_cli_parsing_to_boot_info.py
@@ -5,7 +5,8 @@ from eth_keys import keys
 import pytest
 
 from ddht.boot_info import BootInfo
-from ddht.tools.factories.boot_info import BootInfoFactory
+from ddht.constants import ProtocolVersion
+from ddht.tools.factories.boot_info import BOOTNODES_V5_1, BootInfoFactory
 from ddht.tools.factories.discovery import ENRFactory
 
 KEY_RAW = b"unicornsrainbowsunicornsrainbows"
@@ -42,6 +43,12 @@ ENR_B = ENRFactory()
             (dict(bootnodes=(ENR_A, ENR_B))),
         ),
         (("--disable-upnp",), (dict(is_upnp_enabled=False)),),
+        # protocol version
+        (("--protocol-version", "v5"), {}),
+        (
+            ("--protocol-version", "v5.1"),
+            dict(protocol_version=ProtocolVersion.v5_1, bootnodes=BOOTNODES_V5_1),
+        ),
     ),
 )
 def test_cli_args_to_boot_info(args, factory_kwargs):

--- a/tests/core/v5/test_v5_bootnodes.py
+++ b/tests/core/v5/test_v5_bootnodes.py
@@ -1,0 +1,13 @@
+import pytest
+
+from ddht.enr import ENR
+from ddht.v5.constants import DEFAULT_BOOTNODES
+
+
+@pytest.mark.parametrize(
+    "enr_repr", DEFAULT_BOOTNODES,
+)
+def test_default_bootnodes_valid(enr_repr):
+    enr = ENR.from_repr(enr_repr)
+    assert b"ip" in enr or b"ip6" in enr
+    assert b"udp" in enr

--- a/tests/core/v5_1/test_dispatcher.py
+++ b/tests/core/v5_1/test_dispatcher.py
@@ -6,7 +6,6 @@ from ddht.v5_1.messages import PingMessage, PongMessage
 
 
 @pytest.mark.trio
-@pytest.mark.this_one
 async def test_dispatcher_handles_incoming_envelopes(tester, driver, alice, bob):
     await driver.handshake()
 

--- a/tests/core/v5_1/test_v51_bootnodes.py
+++ b/tests/core/v5_1/test_v51_bootnodes.py
@@ -1,7 +1,7 @@
 import pytest
 
-from ddht.constants import DEFAULT_BOOTNODES
 from ddht.enr import ENR
+from ddht.v5_1.constants import DEFAULT_BOOTNODES
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What was wrong?

Need to be able to enter the v5.1 protocol via the CLI.

## How was it fixed?

Added new `--protocol-version` flag that defaults to `v5`.

Copy/Pasta of application logic from the original v5 entry point.


#### Cute Animal Picture

![confused-dog-bunny-its-head](https://user-images.githubusercontent.com/824194/91584017-459e3980-e90f-11ea-9450-c4d5132a472d.jpg)

