### PR TITLE
Add file logging, more control over what is logged

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ Read more in the [documentation on ReadTheDocs](https://ddht.readthedocs.io/). [
 pip install ddht
 ```
 
+To run it:
+
+```sh
+ddht
+```
+
+`--help` will tell you about the arguments `ddht` accepts. The LOGLEVEL environment
+variable can be used to control which log messages are emitted. For example, to suppress
+unimportant messages from the Packer you can run:
+
+```sh
+LOGLEVEL=WARNING:ddht.v5.packer.Packer ddht
+```
+
 ## Developer Setup
 
 If you would like to hack on ddht, please check out the [Snake Charmers

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -41,11 +41,23 @@ base_dir_parser.add_argument(
 # Logging
 #
 logging_parser.add_argument(
-    "-l",
-    "--log-level",
+    "--log-file",
+    type=str,
+    default="ddht.debuglog",
+    dest="log_file",
+    help=("Configure the logging destination"),
+)
+logging_parser.add_argument(
+    "--log-level-file",
     type=int,
-    dest="log_level",
-    help=("Configure the logging level. "),
+    dest="log_level_file",
+    help=("Configure the file logging level"),
+)
+logging_parser.add_argument(
+    "--log-level-stderr",
+    type=int,
+    dest="log_level_stderr",
+    help=("Configure the stderr logging level"),
 )
 
 

--- a/ddht/logging.py
+++ b/ddht/logging.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import sys
+from typing import Dict, Optional, Tuple
 
 
 class DDHTFormatter(logging.Formatter):
@@ -16,37 +17,37 @@ LOG_FORMATTER = DDHTFormatter(
 
 
 LOG_LEVEL_CHOICES = {
-    'DEBUG': logging.DEBUG,
-    'INFO': logging.INFO,
-    'WARN': logging.WARNING,
-    'WARNING': logging.WARNING,
-    'ERROR': logging.ERROR,
-    'CRITICAL': logging.CRITICAL,
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARN": logging.WARNING,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
 }
 
 
-def parse_raw_log_level(raw_level: str):
+def parse_raw_log_level(raw_level: str) -> int:
     if raw_level.upper() in LOG_LEVEL_CHOICES:
         return LOG_LEVEL_CHOICES[raw_level.upper()]
 
-    raise Exception(f'Invalid log level: {raw_level}')
+    raise Exception(f"Invalid log level: {raw_level}")
 
 
-def parse_log_level_spec(log_level_spec):
-    raw_level, _, path = log_level_spec.partition(':')
+def parse_log_level_spec(log_level_spec: str) -> Tuple[Optional[str], int]:
+    raw_level, _, raw_path = log_level_spec.partition(":")
     level = parse_raw_log_level(raw_level)
 
     # if there is no colon then this is a spec for the root logger and path will be ''
-    path = path if path != '' else None
+    path = raw_path if raw_path != "" else None
     return path, level
 
 
-def environment_to_log_levels(raw_levels):
+def environment_to_log_levels(raw_levels: Optional[str]) -> Dict[Optional[str], int]:
     if raw_levels is None:
         return dict()
 
     levels = dict()
-    for raw_level in raw_levels.split(','):
+    for raw_level in raw_levels.split(","):
         path, level = parse_log_level_spec(raw_level)
         levels[path] = level
 
@@ -57,8 +58,8 @@ def setup_logging(logfile: str, file_log_level: int, stderr_level: int = None) -
     stderr_level = stderr_level or logging.INFO
     file_log_level = file_log_level or logging.DEBUG
 
-    environ_log_levels = os.environ.get('LOGLEVEL', None)
-    environ_log_levels = environment_to_log_levels(environ_log_levels)
+    raw_environ_log_levels = os.environ.get("LOGLEVEL", None)
+    environ_log_levels = environment_to_log_levels(raw_environ_log_levels)
 
     for path, level in environ_log_levels.items():
         logging.getLogger(path).setLevel(level)
@@ -70,7 +71,7 @@ def setup_logging(logfile: str, file_log_level: int, stderr_level: int = None) -
     setup_file_logging(logfile, file_log_level)
 
 
-def setup_stderr_logging(level: int = None) -> logging.StreamHandler:
+def setup_stderr_logging(level: int) -> logging.StreamHandler:
     handler_stream = logging.StreamHandler(sys.stderr)
     handler_stream.setLevel(level)
     handler_stream.setFormatter(LOG_FORMATTER)
@@ -81,7 +82,7 @@ def setup_stderr_logging(level: int = None) -> logging.StreamHandler:
     return handler_stream
 
 
-def setup_file_logging(logfile: str, level: int = None) -> logging.FileHandler:
+def setup_file_logging(logfile: str, level: int) -> logging.FileHandler:
     handler_file = logging.FileHandler(logfile)
     handler_file.setLevel(level)
     handler_file.setFormatter(LOG_FORMATTER)

--- a/ddht/logging.py
+++ b/ddht/logging.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 
 
@@ -10,28 +11,82 @@ class DDHTFormatter(logging.Formatter):
 
 
 LOG_FORMATTER = DDHTFormatter(
-    fmt="%(levelname)8s  %(asctime)s  %(shortname)20s  %(message)s"
+    fmt="%(levelname)8s  %(asctime)s  %(name)20s  %(message)s"
 )
 
 
-def setup_logging(level: int = None) -> None:
-    setup_stderr_logging(level)
+LOG_LEVEL_CHOICES = {
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'WARN': logging.WARNING,
+    'WARNING': logging.WARNING,
+    'ERROR': logging.ERROR,
+    'CRITICAL': logging.CRITICAL,
+}
+
+
+def parse_raw_log_level(raw_level: str):
+    if raw_level.upper() in LOG_LEVEL_CHOICES:
+        return LOG_LEVEL_CHOICES[raw_level.upper()]
+
+    raise Exception(f'Invalid log level: {raw_level}')
+
+
+def parse_log_level_spec(log_level_spec):
+    raw_level, _, path = log_level_spec.partition(':')
+    level = parse_raw_log_level(raw_level)
+
+    # if there is no colon then this is a spec for the root logger and path will be ''
+    path = path if path != '' else None
+    return path, level
+
+
+def environment_to_log_levels(raw_levels):
+    if raw_levels is None:
+        return dict()
+
+    levels = dict()
+    for raw_level in raw_levels.split(','):
+        path, level = parse_log_level_spec(raw_level)
+        levels[path] = level
+
+    return levels
+
+
+def setup_logging(logfile: str, file_log_level: int, stderr_level: int = None) -> None:
+    stderr_level = stderr_level or logging.INFO
+    file_log_level = file_log_level or logging.DEBUG
+
+    environ_log_levels = os.environ.get('LOGLEVEL', None)
+    environ_log_levels = environment_to_log_levels(environ_log_levels)
+
+    for path, level in environ_log_levels.items():
+        logging.getLogger(path).setLevel(level)
+
+    logger = logging.getLogger()
+    logger.setLevel(min(stderr_level, file_log_level))
+
+    setup_stderr_logging(stderr_level)
+    setup_file_logging(logfile, file_log_level)
 
 
 def setup_stderr_logging(level: int = None) -> logging.StreamHandler:
-    if level is None:
-        level = logging.INFO
-    logger = logging.getLogger()
-    logger.setLevel(level)
-
     handler_stream = logging.StreamHandler(sys.stderr)
-
-    if level is not None:
-        handler_stream.setLevel(level)
+    handler_stream.setLevel(level)
     handler_stream.setFormatter(LOG_FORMATTER)
 
+    logger = logging.getLogger()
     logger.addHandler(handler_stream)
 
-    logger.debug("Logging initialized for stderr")
-
     return handler_stream
+
+
+def setup_file_logging(logfile: str, level: int = None) -> logging.FileHandler:
+    handler_file = logging.FileHandler(logfile)
+    handler_file.setLevel(level)
+    handler_file.setFormatter(LOG_FORMATTER)
+
+    logger = logging.getLogger()
+    logger.addHandler(handler_file)
+
+    return handler_file

--- a/ddht/main.py
+++ b/ddht/main.py
@@ -24,7 +24,7 @@ logger = logging.getLogger("ddht")
 async def main() -> None:
     args = parser.parse_args()
 
-    setup_logging(args.log_level)
+    setup_logging(args.log_file, args.log_level_file, args.log_level_stderr)
 
     logger.info(DDHT_HEADER)
 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,6 +1,6 @@
-import pexpect
 import logging
 
+import pexpect
 import pytest
 
 from ddht import __version__
@@ -24,9 +24,9 @@ def test_ddht_help():
     "env,expected",
     (
         (None, dict()),
-        ('debug', {None: logging.DEBUG}),
-        ('DEBUG,INFO:root', {None: logging.DEBUG, 'root': logging.INFO}),
-    )
+        ("debug", {None: logging.DEBUG}),
+        ("DEBUG,INFO:root", {None: logging.DEBUG, "root": logging.INFO}),
+    ),
 )
 def test_loglevel_parsing(env, expected):
     parsed = ddht_logging.environment_to_log_levels(env)
@@ -35,4 +35,4 @@ def test_loglevel_parsing(env, expected):
 
 def test_bad_log_level():
     with pytest.raises(Exception):
-        ddht_logging.environment_to_log_levels('debu')
+        ddht_logging.environment_to_log_levels("debu")

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,6 +1,10 @@
 import pexpect
+import logging
+
+import pytest
 
 from ddht import __version__
+from ddht import logging as ddht_logging
 
 
 def test_ddht_version():
@@ -14,3 +18,21 @@ def test_ddht_help():
     child.expect("core:")
     child.expect("logging:")
     child.expect("network:")
+
+
+@pytest.mark.parametrize(
+    "env,expected",
+    (
+        (None, dict()),
+        ('debug', {None: logging.DEBUG}),
+        ('DEBUG,INFO:root', {None: logging.DEBUG, 'root': logging.INFO}),
+    )
+)
+def test_loglevel_parsing(env, expected):
+    parsed = ddht_logging.environment_to_log_levels(env)
+    assert parsed == expected
+
+
+def test_bad_log_level():
+    with pytest.raises(Exception):
+        ddht_logging.environment_to_log_levels('debu')


### PR DESCRIPTION
Fixes #14.

I took some liberties here, let me know if you want to back any of them out:

- `-l` and `--level` are gone, and have been replaced with the more specific `--log-level-file` and `--log-level-stderr`. Those default to DEBUG and INFO, respectively.
- I changed `shortname` to `name`, to make it easier to figure out exactly which logger is spamming you, so it can be silenced with `LOGLEVEL`.
- I added a `LOGLEVEL` variable, which is inspired by [`PYTHONWARNINGS`](https://docs.python.org/3/library/warnings.html#describing-warning-filters), and gives precise control over which loggers are used. I begun by trying to implement it with `--level` and argparse, as Trinity does, but realized that the env variable would require a lot less code, and makes it easier to manage, using either an `.env` file or an `export`.

Here's a command which gets rid of all the upnp spam:

> LOGLEVEL=INFO:ddht.upnp,INFO:urllib3.connectionpool,INFO:Service,INFO:Action,INFO:ssdp,INFO:Device ddht --log-level-stderr 10

It's unwieldy to write this out every time. But after an `export` we can get all the benefit of not being spammed by upnp, while still running just

> ddht --log-level-stderr 10

In the future it might make sense to read configuration from `pyproject.toml`, but for now this seems nice and convenient.

#### Cute Animal Picture

![beaver](https://user-images.githubusercontent.com/466333/91599000-6ae47500-e91a-11ea-9aeb-de460708c3e7.jpg)
