### PR TITLE
Fix incorrectly configured bucket size

### DIFF
--- a/ddht/constants.py
+++ b/ddht/constants.py
@@ -26,6 +26,7 @@ TCP_PORT_ENR_KEY = b"tcp"
 IP_V4_SIZE = 4  # size of an IPv4 address
 IP_V6_SIZE = 16  # size of an IPv6 address
 NUM_ROUTING_TABLE_BUCKETS = 256  # number of buckets in the routing table
+ROUTING_TABLE_BUCKET_SIZE = 16
 
 
 class ProtocolVersion(enum.Enum):

--- a/ddht/v5/app.py
+++ b/ddht/v5/app.py
@@ -12,7 +12,7 @@ from ddht.boot_info import BootInfo
 from ddht.constants import (
     DEFAULT_LISTEN,
     IP_V4_ADDRESS_ENR_KEY,
-    NUM_ROUTING_TABLE_BUCKETS,
+    ROUTING_TABLE_BUCKET_SIZE,
 )
 from ddht.datagram import (
     DatagramReceiver,
@@ -93,7 +93,7 @@ class Application(Service):
             self.manager.run_daemon_child_service(upnp_service)
 
         routing_table = KademliaRoutingTable(
-            enr_manager.enr.node_id, NUM_ROUTING_TABLE_BUCKETS
+            enr_manager.enr.node_id, ROUTING_TABLE_BUCKET_SIZE
         )
 
         for enr in self._boot_info.bootnodes:

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -14,7 +14,7 @@ from ddht._utils import every, humanize_node_id
 from ddht.abc import ENRManagerAPI, NodeDBAPI
 from ddht.constants import (
     IP_V4_ADDRESS_ENR_KEY,
-    NUM_ROUTING_TABLE_BUCKETS,
+    ROUTING_TABLE_BUCKET_SIZE,
     UDP_PORT_ENR_KEY,
 )
 from ddht.endpoint import Endpoint
@@ -42,7 +42,7 @@ class Network(Service, NetworkAPI):
 
         self._bootnodes = tuple(bootnodes)
         self.routing_table = KademliaRoutingTable(
-            self.client.enr_manager.enr.node_id, NUM_ROUTING_TABLE_BUCKETS,
+            self.client.enr_manager.enr.node_id, ROUTING_TABLE_BUCKET_SIZE,
         )
         self._routing_table_ready = trio.Event()
 


### PR DESCRIPTION
## What was wrong?

We were not using the correct bucket size in our routing table

## How was it fixed?

Updated to use a bucket size of 16


#### Cute Animal Picture

![07b942f2a72ec34b0b2612c79a6ddc5d](https://user-images.githubusercontent.com/824194/91600255-e814e780-e924-11ea-9996-cf34ae426932.jpg)

