### PR TITLE
Use a RotatingFileHandler for logs, default to XDG_DATA_HOME

### DIFF
--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -50,10 +50,9 @@ base_dir_parser.add_argument(
 #
 logging_parser.add_argument(
     "--log-file",
-    type=str,
-    default="ddht.debuglog",
+    type=pathlib.Path,
     dest="log_file",
-    help=("Configure the logging destination"),
+    help=("Manually override the logging destination."),
 )
 logging_parser.add_argument(
     "--log-level-file",

--- a/ddht/main.py
+++ b/ddht/main.py
@@ -39,7 +39,7 @@ async def main() -> None:
         logdir = log_file = get_xdg_ddht_root() / "logs"
         logdir.mkdir(parents=True, exist_ok=True)
 
-        log_file = logdir / "ddht.logfile"
+        log_file = logdir / "ddht.log"
     else:
         log_file = args.log_file
 

--- a/ddht/main.py
+++ b/ddht/main.py
@@ -4,7 +4,7 @@ import shutil
 from ddht.boot_info import BootInfo
 from ddht.cli_parser import parser
 from ddht.logging import setup_logging
-from ddht.xdg import get_xdg_data_home
+from ddht.xdg import get_xdg_data_home, get_xdg_ddht_root
 
 DDHT_HEADER = "\n".join(
     (
@@ -24,10 +24,6 @@ logger = logging.getLogger("ddht")
 async def main() -> None:
     args = parser.parse_args()
 
-    setup_logging(args.log_file, args.log_level_file, args.log_level_stderr)
-
-    logger.info(DDHT_HEADER)
-
     boot_info = BootInfo.from_namespace(args)
 
     if not boot_info.base_dir.exists():
@@ -38,6 +34,18 @@ async def main() -> None:
                 "Not creating DDHT root directory as it is not present and is "
                 f"not under the $XDG_DATA_HOME: {boot_info.base_dir}"
             )
+
+    if args.log_file is None:
+        logdir = log_file = get_xdg_ddht_root() / "logs"
+        logdir.mkdir(parents=True, exist_ok=True)
+
+        log_file = logdir / "ddht.logfile"
+    else:
+        log_file = args.log_file
+
+    setup_logging(log_file, args.log_level_file, args.log_level_stderr)
+
+    logger.info(DDHT_HEADER)
 
     try:
         await args.func(boot_info)


### PR DESCRIPTION
Small fixes, missed in #73 

- Switch to using a rotating file handler.
- Default to throwing logs into `.local/share/ddht/logs`

#### Cute Animal Picture

![smol-chipmunk](https://user-images.githubusercontent.com/466333/91625160-ddc11080-e959-11ea-9c83-484887220d5a.jpeg)
