### PR TITLE
handle invalid ENR rlp

### DIFF
--- a/ddht/v5_1/packets.py
+++ b/ddht/v5_1/packets.py
@@ -133,7 +133,12 @@ class HandshakePacket:
         ephemeral_public_key = stream.read(auth_data_head.ephemeral_key_size)
         enr_bytes = stream.read()
         if len(enr_bytes) > 0:
-            enr = rlp.decode(enr_bytes, sedes=ENRSedes)
+            try:
+                enr = rlp.decode(enr_bytes, sedes=ENRSedes)
+            except rlp.DecodingError as err:
+                # re-raise using the local library DecodingError instead of the
+                # rlp one
+                raise DecodingError(str(err)) from err
         else:
             enr = None
 


### PR DESCRIPTION
## What was wrong?

An invalid ENR record in a WhoAreYou packet would crash the node.

## How was it fixed?

Catch and handle the exception.

#### Cute Animal Picture

![dog-desk-book](https://user-images.githubusercontent.com/824194/91916007-428dab00-ec79-11ea-9b49-a6f04595124e.jpg)

