### PR TITLE
Use eth-typing NodeID type

### DIFF
--- a/ddht/_utils.py
+++ b/ddht/_utils.py
@@ -16,10 +16,9 @@ from typing import (
 )
 
 from eth_keys import keys
+from eth_typing import NodeID
 from eth_utils import humanize_hash
 import trio
-
-from ddht.typing import NodeID
 
 
 def humanize_node_id(node_id: NodeID) -> str:

--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -15,12 +15,13 @@ from typing import (
     TypeVar,
 )
 
+from eth_typing import NodeID
 import trio
 
 from ddht.base_message import BaseMessage
 from ddht.enr import ENR
 from ddht.identity_schemes import IdentitySchemeRegistry
-from ddht.typing import ENR_KV, NodeID
+from ddht.typing import ENR_KV
 
 TAddress = TypeVar("TAddress", bound="AddressAPI")
 

--- a/ddht/base_message.py
+++ b/ddht/base_message.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
+from eth_typing import NodeID
 from eth_utils import int_to_big_endian
 import rlp
 
 from ddht.endpoint import Endpoint
-from ddht.typing import NodeID
 
 
 class BaseMessage(rlp.Serializable):  # type: ignore

--- a/ddht/enr.py
+++ b/ddht/enr.py
@@ -14,6 +14,7 @@ from typing import (
     ValuesView,
 )
 
+from eth_typing import NodeID
 from eth_utils import ValidationError, to_dict
 from eth_utils.toolz import cons, interleave
 import rlp
@@ -25,7 +26,6 @@ from ddht.identity_schemes import (
     default_identity_scheme_registry as default_id_scheme_registry,
 )
 from ddht.identity_schemes import IdentityScheme, IdentitySchemeRegistry
-from ddht.typing import NodeID
 
 
 class ENRContentSedes:

--- a/ddht/enr_manager.py
+++ b/ddht/enr_manager.py
@@ -2,6 +2,7 @@ import logging
 from typing import Mapping, Optional
 
 from eth_keys import keys
+from eth_typing import NodeID
 from eth_utils.toolz import merge
 import trio
 
@@ -11,7 +12,7 @@ from ddht.identity_schemes import (
     IdentitySchemeRegistry,
     default_identity_scheme_registry,
 )
-from ddht.typing import ENR_KV, NodeID
+from ddht.typing import ENR_KV
 
 
 class ENRManager(ENRManagerAPI):

--- a/ddht/identity_schemes.py
+++ b/ddht/identity_schemes.py
@@ -11,10 +11,11 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from eth_keys.datatypes import NonRecoverableSignature, PrivateKey, PublicKey
 from eth_keys.exceptions import BadSignature
 from eth_keys.exceptions import ValidationError as EthKeysValidationError
+from eth_typing import NodeID
 from eth_utils import ValidationError, encode_hex, keccak
 
 from ddht.constants import AES128_KEY_SIZE, HKDF_INFO, ID_NONCE_SIGNATURE_PREFIX
-from ddht.typing import AES128Key, IDNonce, NodeID, SessionKeys
+from ddht.typing import AES128Key, IDNonce, SessionKeys
 
 if TYPE_CHECKING:
     from ddht.enr import ENR, BaseENR  # noqa: F401

--- a/ddht/kademlia.py
+++ b/ddht/kademlia.py
@@ -19,11 +19,11 @@ from typing import (
     cast,
 )
 
+from eth_typing import NodeID
 from eth_utils import big_endian_to_int, encode_hex
 
 from ddht.abc import AddressAPI, RoutingTableAPI, TAddress
 from ddht.constants import NUM_ROUTING_TABLE_BUCKETS
-from ddht.typing import NodeID
 
 
 def check_relayed_addr(sender: AddressAPI, addr: AddressAPI) -> bool:

--- a/ddht/node_db.py
+++ b/ddht/node_db.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from eth.abc import DatabaseAPI
+from eth_typing import NodeID
 from eth_utils.encoding import big_endian_to_int, int_to_big_endian
 import rlp
 
@@ -9,7 +10,6 @@ from ddht.abc import NodeDBAPI
 from ddht.enr import ENR
 from ddht.exceptions import OldSequenceNumber, UnknownIdentityScheme
 from ddht.identity_schemes import IdentitySchemeRegistry
-from ddht.typing import NodeID
 
 
 class NodeDB(NodeDBAPI):

--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -2,13 +2,13 @@ from abc import ABC, abstractmethod
 from typing import AsyncContextManager, Collection, NamedTuple, Optional, Tuple
 
 from eth_keys import keys
+from eth_typing import NodeID
 
 from ddht.abc import NodeDBAPI
 from ddht.base_message import AnyInboundMessage, BaseMessage
 from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.tools.factories.v5_1 import SessionChannels
-from ddht.typing import NodeID
 from ddht.v5_1.abc import (
     ClientAPI,
     DispatcherAPI,

--- a/ddht/tools/driver/node.py
+++ b/ddht/tools/driver/node.py
@@ -3,6 +3,7 @@ from typing import AsyncIterator, Collection, Optional
 from async_generator import asynccontextmanager
 from async_service import background_trio_service
 from eth_keys import keys
+from eth_typing import NodeID
 from eth_utils import humanize_hash
 
 from ddht.abc import NodeDBAPI
@@ -11,7 +12,6 @@ from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.tools.driver.abc import NodeAPI
 from ddht.tools.factories.enr import ENRFactory
-from ddht.typing import NodeID
 from ddht.v5_1.abc import ClientAPI, EventsAPI, NetworkAPI
 from ddht.v5_1.client import Client
 from ddht.v5_1.events import Events

--- a/ddht/tools/driver/tester.py
+++ b/ddht/tools/driver/tester.py
@@ -5,6 +5,7 @@ from typing import AsyncIterator, Dict, NamedTuple, Optional, Set, Tuple
 from async_generator import asynccontextmanager
 from async_service import background_trio_service
 from eth_keys import keys
+from eth_typing import NodeID
 import trio
 
 from ddht._utils import humanize_node_id
@@ -17,7 +18,6 @@ from ddht.tools.factories.endpoint import EndpointFactory
 from ddht.tools.factories.keys import PrivateKeyFactory
 from ddht.tools.factories.node_db import NodeDBFactory
 from ddht.tools.factories.v5_1 import SessionChannels
-from ddht.typing import NodeID
 from ddht.v5_1.abc import DispatcherAPI, EventsAPI, PoolAPI, SessionAPI
 from ddht.v5_1.dispatcher import Dispatcher
 from ddht.v5_1.envelope import InboundEnvelope, OutboundEnvelope

--- a/ddht/tools/factories/node_id.py
+++ b/ddht/tools/factories/node_id.py
@@ -1,12 +1,12 @@
 import random
 from typing import Tuple
 
+from eth_typing import NodeID
 from eth_utils import big_endian_to_int, int_to_big_endian
 from eth_utils.toolz import reduce
 import factory
 
 from ddht.kademlia import compute_log_distance
-from ddht.typing import NodeID
 
 
 def bytes_to_bits(input_bytes: bytes) -> Tuple[bool, ...]:

--- a/ddht/tools/factories/v5_1.py
+++ b/ddht/tools/factories/v5_1.py
@@ -1,11 +1,12 @@
 import secrets
 from typing import NamedTuple, Optional
 
+from eth_typing import NodeID
 import factory
 import trio
 
 from ddht.base_message import AnyInboundMessage, BaseMessage
-from ddht.typing import AES128Key, NodeID, Nonce
+from ddht.typing import AES128Key, Nonce
 from ddht.v5_1.envelope import OutboundEnvelope
 from ddht.v5_1.packets import (
     PROTOCOL_ID,

--- a/ddht/v5/abc.py
+++ b/ddht/v5/abc.py
@@ -9,11 +9,12 @@ from typing import (
     TypeVar,
 )
 
+from eth_typing import NodeID
+
 from ddht.base_message import AnyInboundMessage, BaseMessage, InboundMessage, TMessage
 from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.identity_schemes import IdentityScheme
-from ddht.typing import NodeID
 from ddht.v5.packets import Packet
 from ddht.v5.typing import HandshakeResult, Tag
 

--- a/ddht/v5/endpoint_tracker.py
+++ b/ddht/v5/endpoint_tracker.py
@@ -2,6 +2,7 @@ import logging
 from typing import NamedTuple
 
 from async_service import Service
+from eth_typing import NodeID
 from eth_utils import encode_hex
 from eth_utils.toolz import merge
 from trio.abc import ReceiveChannel
@@ -11,7 +12,6 @@ from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
 from ddht.endpoint import Endpoint
 from ddht.enr import UnsignedENR
 from ddht.identity_schemes import IdentitySchemeRegistry
-from ddht.typing import NodeID
 
 
 class EndpointVote(NamedTuple):

--- a/ddht/v5/handshake.py
+++ b/ddht/v5/handshake.py
@@ -2,12 +2,13 @@ import secrets
 from typing import Optional, Type
 
 from eth_keys.datatypes import PublicKey
+from eth_typing import NodeID
 from eth_utils import ValidationError, encode_hex
 
 from ddht.enr import ENR
 from ddht.exceptions import DecryptionError, HandshakeFailure
 from ddht.identity_schemes import IdentityScheme
-from ddht.typing import AES128Key, IDNonce, NodeID, Nonce
+from ddht.typing import AES128Key, IDNonce, Nonce
 from ddht.v5.abc import HandshakeParticipantAPI
 from ddht.v5.messages import BaseMessage
 from ddht.v5.packets import (

--- a/ddht/v5/message_dispatcher.py
+++ b/ddht/v5/message_dispatcher.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 from async_service import Service
+from eth_typing import NodeID
 from eth_utils import encode_hex
 import trio
 from trio.abc import ReceiveChannel, SendChannel
@@ -29,7 +30,6 @@ from ddht.base_message import (
 from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
 from ddht.endpoint import Endpoint
 from ddht.exceptions import UnexpectedMessage
-from ddht.typing import NodeID
 from ddht.v5.abc import ChannelHandlerSubscriptionAPI, MessageDispatcherAPI
 from ddht.v5.constants import (
     MAX_NODES_MESSAGE_TOTAL,

--- a/ddht/v5/packer.py
+++ b/ddht/v5/packer.py
@@ -2,6 +2,7 @@ import logging
 from typing import Dict, List, NamedTuple, Optional
 
 from async_service import LifecycleError, Service, TrioManager
+from eth_typing import NodeID
 from eth_utils import ValidationError, encode_hex
 import trio
 from trio.abc import ReceiveChannel, SendChannel
@@ -11,7 +12,7 @@ from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
 from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.exceptions import DecryptionError, HandshakeFailure
-from ddht.typing import NodeID, Nonce, SessionKeys
+from ddht.typing import Nonce, SessionKeys
 from ddht.v5.abc import HandshakeParticipantAPI
 from ddht.v5.channel_services import InboundPacket, OutboundPacket
 from ddht.v5.constants import HANDSHAKE_TIMEOUT

--- a/ddht/v5/packets.py
+++ b/ddht/v5/packets.py
@@ -2,7 +2,7 @@ import hashlib
 import secrets
 from typing import Callable, NamedTuple, Optional, Tuple, Union, cast
 
-from eth_typing import Hash32
+from eth_typing import Hash32, NodeID
 from eth_utils import (
     ValidationError,
     big_endian_to_int,
@@ -20,7 +20,7 @@ from ddht.base_message import BaseMessage
 from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
 from ddht.encryption import aesgcm_decrypt, aesgcm_encrypt, validate_nonce
 from ddht.enr import ENR
-from ddht.typing import AES128Key, IDNonce, NodeID, Nonce
+from ddht.typing import AES128Key, IDNonce, Nonce
 from ddht.v5.constants import (
     AUTH_RESPONSE_VERSION,
     AUTH_SCHEME_NAME,

--- a/ddht/v5/routing_table.py
+++ b/ddht/v5/routing_table.py
@@ -3,9 +3,8 @@ import logging
 import secrets
 from typing import Any, Collection, Deque, Iterator
 
+from eth_typing import NodeID
 from eth_utils import encode_hex
-
-from ddht.typing import NodeID
 
 
 class FlatRoutingTable(Collection[NodeID]):

--- a/ddht/v5/routing_table_manager.py
+++ b/ddht/v5/routing_table_manager.py
@@ -5,6 +5,7 @@ import time
 from typing import List, Optional, Tuple
 
 from async_service import Service
+from eth_typing import NodeID
 from eth_utils import encode_hex
 from eth_utils.toolz import take
 from mypy_extensions import TypedDict
@@ -23,7 +24,6 @@ from ddht.endpoint import Endpoint
 from ddht.enr import ENR, partition_enrs
 from ddht.exceptions import OldSequenceNumber, UnexpectedMessage
 from ddht.kademlia import KademliaRoutingTable, compute_log_distance, iter_closest_nodes
-from ddht.typing import NodeID
 from ddht.v5.abc import MessageDispatcherAPI
 from ddht.v5.constants import (
     FIND_NODE_RESPONSE_TIMEOUT,

--- a/ddht/v5/tags.py
+++ b/ddht/v5/tags.py
@@ -1,7 +1,8 @@
 import hashlib
 
+from eth_typing import NodeID
+
 from ddht._utils import sxor
-from ddht.typing import NodeID
 from ddht.v5.typing import Tag
 
 

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -13,6 +13,7 @@ import uuid
 
 from async_service import ServiceAPI
 from eth_keys import keys
+from eth_typing import NodeID
 import trio
 
 from ddht.abc import ENRManagerAPI, EventAPI, NodeDBAPI, RoutingTableAPI
@@ -24,7 +25,7 @@ from ddht.base_message import (
 )
 from ddht.endpoint import Endpoint
 from ddht.enr import ENR
-from ddht.typing import NodeID, SessionKeys
+from ddht.typing import SessionKeys
 from ddht.v5_1.envelope import InboundEnvelope, OutboundEnvelope
 from ddht.v5_1.messages import (
     FindNodeMessage,

--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -5,6 +5,7 @@ from typing import Collection, ContextManager, Iterator, List, Optional, Sequenc
 
 from async_service import Service
 from eth_keys import keys
+from eth_typing import NodeID
 from eth_utils import ValidationError
 import trio
 
@@ -21,7 +22,6 @@ from ddht.enr import ENR, partition_enrs
 from ddht.enr_manager import ENRManager
 from ddht.kademlia import compute_log_distance
 from ddht.message_registry import MessageTypeRegistry
-from ddht.typing import NodeID
 from ddht.v5_1.abc import ClientAPI, EventsAPI
 from ddht.v5_1.constants import FOUND_NODES_MAX_PAYLOAD_SIZE, REQUEST_RESPONSE_TIMEOUT
 from ddht.v5_1.dispatcher import Dispatcher

--- a/ddht/v5_1/dispatcher.py
+++ b/ddht/v5_1/dispatcher.py
@@ -16,6 +16,7 @@ from typing import (
 
 from async_generator import asynccontextmanager
 from async_service import Service
+from eth_typing import NodeID
 import trio
 
 from ddht._utils import humanize_node_id
@@ -29,7 +30,6 @@ from ddht.base_message import (
 )
 from ddht.endpoint import Endpoint
 from ddht.message_registry import MessageTypeRegistry
-from ddht.typing import NodeID
 from ddht.v5_1.abc import DispatcherAPI, EventsAPI, PoolAPI, SessionAPI
 from ddht.v5_1.constants import REQUEST_RESPONSE_TIMEOUT
 from ddht.v5_1.envelope import InboundEnvelope

--- a/ddht/v5_1/envelope.py
+++ b/ddht/v5_1/envelope.py
@@ -2,6 +2,7 @@ import logging
 from typing import NamedTuple
 
 from async_service import Service
+from eth_typing import NodeID
 from eth_utils import ValidationError
 import trio
 from trio.abc import ReceiveChannel, SendChannel
@@ -9,7 +10,6 @@ from trio.abc import ReceiveChannel, SendChannel
 from ddht.datagram import InboundDatagram, OutboundDatagram
 from ddht.endpoint import Endpoint
 from ddht.exceptions import DecodingError, DecryptionError
-from ddht.typing import NodeID
 from ddht.v5_1.packets import AnyPacket, decode_packet
 
 

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -6,6 +6,7 @@ import time
 from typing import Collection, Iterable, List, Optional, Set, Tuple
 
 from async_service import Service
+from eth_typing import NodeID
 from eth_utils import to_tuple
 from eth_utils.toolz import cons, excepts, first, groupby, take
 import trio
@@ -26,7 +27,6 @@ from ddht.kademlia import (
     compute_log_distance,
     iter_closest_nodes,
 )
-from ddht.typing import NodeID
 from ddht.v5_1.abc import ClientAPI, DispatcherAPI, EventsAPI, NetworkAPI, PoolAPI
 from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE
 from ddht.v5_1.messages import FindNodeMessage, PingMessage, PongMessage

--- a/ddht/v5_1/packets.py
+++ b/ddht/v5_1/packets.py
@@ -4,6 +4,7 @@ import secrets
 import struct
 from typing import Generic, NamedTuple, Optional, TypeVar, Union, cast
 
+from eth_typing import NodeID
 from eth_utils.toolz import take
 import rlp
 
@@ -11,7 +12,7 @@ from ddht.base_message import BaseMessage
 from ddht.encryption import aesctr_decrypt_stream, aesctr_encrypt, aesgcm_encrypt
 from ddht.enr import ENR, ENRSedes
 from ddht.exceptions import DecodingError
-from ddht.typing import AES128Key, IDNonce, NodeID, Nonce
+from ddht.typing import AES128Key, IDNonce, Nonce
 
 PROTOCOL_ID = b"discv5  "
 

--- a/ddht/v5_1/pool.py
+++ b/ddht/v5_1/pool.py
@@ -4,13 +4,13 @@ from typing import DefaultDict, Dict, Set, Tuple
 import uuid
 
 from eth_keys import keys
+from eth_typing import NodeID
 import trio
 
 from ddht.abc import NodeDBAPI
 from ddht.base_message import AnyInboundMessage
 from ddht.endpoint import Endpoint
 from ddht.message_registry import MessageTypeRegistry
-from ddht.typing import NodeID
 from ddht.v5_1.abc import EventsAPI, PoolAPI, SessionAPI
 from ddht.v5_1.envelope import OutboundEnvelope
 from ddht.v5_1.events import Events

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple, cast
 import uuid
 
 from eth_keys import keys
+from eth_typing import NodeID
 from eth_utils import ValidationError
 import rlp
 import trio
@@ -19,7 +20,7 @@ from ddht.endpoint import Endpoint
 from ddht.enr import ENR
 from ddht.exceptions import DecryptionError, HandshakeFailure
 from ddht.message_registry import MessageTypeRegistry
-from ddht.typing import AES128Key, IDNonce, NodeID, Nonce, SessionKeys
+from ddht.typing import AES128Key, IDNonce, Nonce, SessionKeys
 from ddht.v5_1.abc import EventsAPI, SessionAPI
 from ddht.v5_1.constants import SESSION_IDLE_TIMEOUT
 from ddht.v5_1.envelope import InboundEnvelope, OutboundEnvelope

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "async-service==0.1.0a8",
         "eth-hash[pycryptodome]>=0.1.4,<1",
         "eth-keys>=0.3.3,<0.4.0",
+        "eth-typing>=2.2.2,<3",
         "eth-utils>=1.8.4,<2",
         "plyvel==1.2.0",
         "py-evm==0.3.0a18",


### PR DESCRIPTION
## What was wrong?

New `eth-typing` has a shared `NodeID` type.

## How was it fixed?

Removed local `NodeID` concept and use the `eth-typing` one.

#### Cute Animal Picture

![Screen-Shot-2018-07-16-at-10 34 32-AM](https://user-images.githubusercontent.com/824194/92059039-64f0f880-ed4d-11ea-8355-c1a86de36f5d.png)

