### PR TITLE
Reduce logging levels for v5 implementation

### DIFF
--- a/ddht/v5/app.py
+++ b/ddht/v5/app.py
@@ -68,6 +68,7 @@ class Application(Service):
         enr_database_dir = self._boot_info.base_dir / ENR_DATABASE_DIR_NAME
         enr_database_dir.mkdir(exist_ok=True)
         enr_db = ENRDB(LevelDB(enr_database_dir), identity_scheme_registry)
+        self.enr_db = enr_db
 
         local_private_key = get_local_private_key(self._boot_info)
 
@@ -93,6 +94,7 @@ class Application(Service):
         routing_table = KademliaRoutingTable(
             enr_manager.enr.node_id, ROUTING_TABLE_BUCKET_SIZE
         )
+        self.routing_table = routing_table
 
         for enr in self._boot_info.bootnodes:
             try:

--- a/ddht/v5/channel_services.py
+++ b/ddht/v5/channel_services.py
@@ -49,7 +49,7 @@ async def PacketDecoder(
                     f"Successfully decoded {packet.__class__.__name__} from {endpoint}"
                 )
             except ValidationError:
-                logger.warning(
+                logger.debug(
                     f"Failed to decode a packet from {endpoint}", exc_info=True
                 )
             else:

--- a/ddht/v5/message_dispatcher.py
+++ b/ddht/v5/message_dispatcher.py
@@ -129,7 +129,7 @@ class MessageDispatcher(Service, MessageDispatcherAPI):
         ) in self.response_handler_send_channels
 
         if is_request and is_response:
-            self.logger.warning(
+            self.logger.debug(
                 "%s from %s is both a response to an earlier request (id %d) and a request a "
                 "handler is present for (message type %d). Message will be handled twice.",
                 inbound_message,
@@ -138,7 +138,7 @@ class MessageDispatcher(Service, MessageDispatcherAPI):
                 message_type,
             )
         if not is_request and not is_response:
-            self.logger.warning(
+            self.logger.debug(
                 "Dropping %s from %s (request id %d, message type %d) as neither a request nor a "
                 "response handler is present",
                 inbound_message,


### PR DESCRIPTION
## What was wrong?

When embedding this app in trinity the logging levels used by the v5 implementation were far too noisy.  Also needed the routing table and enr database exposed.

## How was it fixed?

Reduced logging levels and placed the routing table and ENR database as properties on the application.

#### Cute Animal Picture

![animals-stuck-08](https://user-images.githubusercontent.com/824194/92813894-663ea880-f37f-11ea-8a55-8f7262174757.jpg)

