### PR TITLE
Piper/implement json rpc ping endpoint

### DIFF
--- a/ddht/endpoint.py
+++ b/ddht/endpoint.py
@@ -1,6 +1,9 @@
 from socket import inet_ntoa
 from typing import NamedTuple
 
+from eth_enr import ENRAPI
+from eth_enr.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
+
 
 class Endpoint(NamedTuple):
     ip_address: bytes
@@ -8,3 +11,13 @@ class Endpoint(NamedTuple):
 
     def __str__(self) -> str:
         return f"{inet_ntoa(self.ip_address)}:{self.port}"
+
+    @classmethod
+    def from_enr(self, enr: ENRAPI) -> "Endpoint":
+        try:
+            ip_address = enr[IP_V4_ADDRESS_ENR_KEY]
+            port = enr[UDP_PORT_ENR_KEY]
+        except KeyError:
+            raise Exception("Missing endpoint address information: ")
+
+        return Endpoint(ip_address, port)

--- a/ddht/rpc.py
+++ b/ddht/rpc.py
@@ -198,8 +198,8 @@ class RPCServer(Service):
             self.logger.error("Error handling request: %s  error: %s", request, err)
             self.logger.debug("Error handling request: %s", request, exc_info=True)
             response = generate_error_response(request, f"Unexpected Error: {err}")
-        finally:
-            return json.dumps(response)
+
+        return json.dumps(response)
 
     async def serve(self, ipc_path: pathlib.Path) -> None:
         self.logger.info("Starting RPC server over IPC socket: %s", ipc_path)

--- a/ddht/tools/web3.py
+++ b/ddht/tools/web3.py
@@ -99,6 +99,8 @@ def ping_munger(
     module: Any, identifier: Union[ENRAPI, str, bytes, NodeID, HexStr]
 ) -> List[str]:
     """
+    See: https://github.com/ethereum/web3.py/blob/002151020cecd826a694ded2fdc10cc70e73e636/web3/method.py#L77  # noqa: E501
+
     Normalizes the any of the following inputs into the appropriate payload for
     the ``discv5_ping` JSON-RPC API endpoint.
 

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -2,6 +2,7 @@ from eth.db.backends.level import LevelDB
 from eth_enr import ENRDB, ENRManager, default_identity_scheme_registry
 from eth_keys import keys
 from eth_utils import encode_hex
+from eth_utils.toolz import merge
 import trio
 
 from ddht._utils import generate_node_key_file, read_node_key_file
@@ -17,6 +18,7 @@ from ddht.v5_1.client import Client
 from ddht.v5_1.events import Events
 from ddht.v5_1.messages import v51_registry
 from ddht.v5_1.network import Network
+from ddht.v5_1.rpc_handlers import get_v51_rpc_handlers
 
 ENR_DATABASE_DIR_NAME = "enr-db"
 
@@ -94,7 +96,10 @@ class Application(BaseApplication):
         network = Network(client=client, bootnodes=bootnodes,)
 
         if self._boot_info.is_rpc_enabled:
-            handlers = get_core_rpc_handlers(network.routing_table)
+            handlers = merge(
+                get_core_rpc_handlers(network.routing_table),
+                get_v51_rpc_handlers(network),
+            )
             rpc_server = RPCServer(self._boot_info.ipc_path, handlers)
             self.manager.run_daemon_child_service(rpc_server)
 

--- a/ddht/v5_1/rpc_handlers.py
+++ b/ddht/v5_1/rpc_handlers.py
@@ -1,0 +1,111 @@
+import ipaddress
+from socket import inet_ntoa
+from typing import Any, Iterable, Optional, Tuple, TypedDict
+
+from eth_enr import ENR
+from eth_typing import HexStr, NodeID
+from eth_utils import decode_hex, is_hex, remove_0x_prefix, to_dict
+
+from ddht.abc import RPCHandlerAPI
+from ddht.endpoint import Endpoint
+from ddht.rpc import RPCError, RPCHandler, RPCRequest
+from ddht.v5_1.abc import NetworkAPI
+
+
+class PongResponse(TypedDict):
+    enr_seq: int
+    packet_ip: str
+    packet_port: int
+
+
+def is_hex_node_id(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and is_hex(value)
+        and len(remove_0x_prefix(HexStr(value))) == 64
+    )
+
+
+def validate_hex_node_id(value: Any) -> None:
+    if not is_hex_node_id(value):
+        raise RPCError(f"Invalid NodeID: {value}")
+
+
+def is_endpoint(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    ip_address, _, port = value.rpartition(":")
+    try:
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        return False
+
+    if not port.isdigit():
+        return False
+
+    return True
+
+
+def validate_endpoint(value: Any) -> None:
+    if not is_endpoint(value):
+        raise RPCError(f"Invalid Endpoint: {value}")
+
+
+class PingHandler(RPCHandler[Tuple[NodeID, Optional[Endpoint]], PongResponse]):
+    def __init__(self, network: NetworkAPI) -> None:
+        self._network = network
+
+    def extract_params(self, request: RPCRequest) -> Tuple[NodeID, Optional[Endpoint]]:
+        try:
+            raw_params = request["params"]
+        except KeyError as err:
+            raise RPCError(f"Missiing call params: {err}")
+
+        if len(raw_params) != 1:
+            raise RPCError(
+                f"`ddht_ping` endpoint expects a single parameter: "
+                f"Got {len(raw_params)} params: {raw_params}"
+            )
+
+        value = raw_params[0]
+
+        node_id: NodeID
+        endpoint: Optional[Endpoint]
+
+        if is_hex_node_id(value):
+            node_id = NodeID(decode_hex(value))
+            endpoint = None
+        elif value.startswith("enode://"):
+            raw_node_id, _, raw_endpoint = value[8:].partition("@")
+
+            validate_hex_node_id(raw_node_id)
+            validate_endpoint(raw_endpoint)
+
+            node_id = NodeID(decode_hex(raw_node_id))
+
+            raw_ip_address, _, raw_port = raw_endpoint.partition(":")
+            ip_address = ipaddress.ip_address(raw_ip_address)
+            port = int(raw_port)
+            endpoint = Endpoint(ip_address.packed, port)
+        elif value.startswith("enr:"):
+            enr = ENR.from_repr(value)
+            node_id = enr.node_id
+            endpoint = Endpoint.from_enr(enr)
+        else:
+            raise RPCError(f"Unrecognized node identifier: {value}")
+
+        return node_id, endpoint
+
+    async def do_call(self, params: Tuple[NodeID, Optional[Endpoint]]) -> PongResponse:
+        node_id, endpoint = params
+        pong = await self._network.ping(node_id, endpoint=endpoint)
+        return PongResponse(
+            enr_seq=pong.enr_seq,
+            packet_ip=inet_ntoa(pong.packet_ip),
+            packet_port=pong.packet_port,
+        )
+
+
+@to_dict
+def get_v51_rpc_handlers(network: NetworkAPI) -> Iterable[Tuple[str, RPCHandlerAPI]]:
+    yield ("discv5_ping", PingHandler(network))

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,57 @@
+import io
+import itertools
+import json
+
+from eth_utils.toolz import take
+import pytest
+import trio
+
+from ddht.rpc import RPCRequest, read_json
+
+
+@pytest.fixture(name="make_raw_request")
+async def _make_raw_request(ipc_path, rpc_server):
+    socket = await trio.open_unix_socket(str(ipc_path))
+    async with socket:
+        buffer = io.StringIO()
+
+        async def make_raw_request(raw_request: str):
+            with trio.fail_after(2):
+                data = raw_request.encode("utf8")
+                data_iter = iter(data)
+                while True:
+                    chunk = bytes(take(1024, data_iter))
+                    if chunk:
+                        try:
+                            await socket.send_all(chunk)
+                        except trio.BrokenResourceError:
+                            break
+                    else:
+                        break
+                return await read_json(socket.socket, buffer)
+
+        yield make_raw_request
+
+
+@pytest.fixture(name="make_request")
+async def _make_request(make_raw_request):
+    id_counter = itertools.count()
+
+    async def make_request(method, params=None):
+        if params is None:
+            params = []
+        request = RPCRequest(
+            jsonrpc="2.0", method=method, params=params, id=next(id_counter),
+        )
+        raw_request = json.dumps(request)
+
+        raw_response = await make_raw_request(raw_request)
+
+        if "error" in raw_response:
+            raise Exception(raw_response)
+        elif "result" in raw_response:
+            return raw_response["result"]
+        else:
+            raise Exception("Invariant")
+
+    yield make_request

--- a/tests/core/test_core_rpc_handlers.py
+++ b/tests/core/test_core_rpc_handlers.py
@@ -1,18 +1,15 @@
-import io
-import itertools
 import json
 
 from async_service import background_trio_service
 from eth_enr.tools.factories import ENRFactory
 from eth_utils import decode_hex
-from eth_utils.toolz import take
 import pytest
 import trio
 from web3 import IPCProvider, Web3
 
 from ddht.constants import ROUTING_TABLE_BUCKET_SIZE
 from ddht.kademlia import KademliaRoutingTable
-from ddht.rpc import MAXIMUM_RPC_PAYLOAD_SIZE, RPCRequest, RPCServer, read_json
+from ddht.rpc import MAXIMUM_RPC_PAYLOAD_SIZE, RPCServer
 from ddht.rpc_handlers import get_core_rpc_handlers
 from ddht.tools.factories.node_id import NodeIDFactory
 from ddht.tools.web3 import DiscoveryV5Module
@@ -39,54 +36,6 @@ async def rpc_server(ipc_path, routing_table, enr):
 @pytest.fixture
 def w3(rpc_server, ipc_path):
     return Web3(IPCProvider(ipc_path), modules={"discv5": (DiscoveryV5Module,)})
-
-
-@pytest.fixture(name="make_raw_request")
-async def _make_raw_request(ipc_path, rpc_server):
-    socket = await trio.open_unix_socket(str(ipc_path))
-    async with socket:
-        buffer = io.StringIO()
-
-        async def make_raw_request(raw_request: str):
-            with trio.fail_after(2):
-                data = raw_request.encode("utf8")
-                data_iter = iter(data)
-                while True:
-                    chunk = bytes(take(1024, data_iter))
-                    if chunk:
-                        try:
-                            await socket.send_all(chunk)
-                        except trio.BrokenResourceError:
-                            break
-                    else:
-                        break
-                return await read_json(socket.socket, buffer)
-
-        yield make_raw_request
-
-
-@pytest.fixture(name="make_request")
-async def _make_request(make_raw_request):
-    id_counter = itertools.count()
-
-    async def make_request(method, params=None):
-        if params is None:
-            params = []
-        request = RPCRequest(
-            jsonrpc="2.0", method=method, params=params, id=next(id_counter),
-        )
-        raw_request = json.dumps(request)
-
-        raw_response = await make_raw_request(raw_request)
-
-        if "error" in raw_response:
-            raise Exception(raw_response)
-        elif "result" in raw_response:
-            return raw_response["result"]
-        else:
-            raise Exception("Invariant")
-
-    yield make_request
 
 
 @pytest.mark.trio

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -1,0 +1,80 @@
+import ipaddress
+from socket import inet_ntoa
+
+from async_service import background_trio_service
+from eth_utils import encode_hex
+import pytest
+import trio
+from web3 import IPCProvider, Web3
+
+from ddht.rpc import RPCServer
+from ddht.tools.web3 import DiscoveryV5Module
+from ddht.v5_1.rpc_handlers import get_v51_rpc_handlers
+
+
+@pytest.fixture
+async def rpc_server(ipc_path, alice):
+    async with alice.network() as network:
+        server = RPCServer(ipc_path, get_v51_rpc_handlers(network))
+        async with background_trio_service(server):
+            await server.wait_serving()
+            yield server
+
+
+@pytest.fixture
+def w3(rpc_server, ipc_path):
+    return Web3(IPCProvider(ipc_path), modules={"discv5": (DiscoveryV5Module,)})
+
+
+@pytest.fixture
+async def bob_network(bob):
+    async with bob.network() as network:
+        yield network
+
+
+@pytest.fixture(params=("nodeid", "enode", "enr"))
+def ping_params(request, alice, bob, bob_network):
+    alice.enr_db.set_enr(bob.enr)
+
+    if request.param == "nodeid":
+        return [bob.node_id.hex()]
+    elif request.param == "enode":
+        return [f"enode://{bob.node_id.hex()}@{bob.endpoint}"]
+    elif request.param == "enr":
+        return [repr(bob.enr)]
+    else:
+        raise Exception(f"Unhandled param: {request.param}")
+
+
+@pytest.mark.trio
+async def test_rpc_ping(make_request, ping_params, alice, bob):
+    pong = await make_request("discv5_ping", ping_params)
+    assert pong["enr_seq"] == bob.enr.sequence_number
+    assert pong["packet_ip"] == inet_ntoa(alice.endpoint.ip_address)
+    assert pong["packet_port"] == alice.endpoint.port
+
+
+@pytest.fixture(params=("nodeid", "nodeid-hex", "enode", "enr", "enr-repr"))
+def ping_param_w3(request, alice, bob, bob_network):
+    alice.enr_db.set_enr(bob.enr)
+
+    if request.param == "nodeid":
+        return bob.node_id
+    elif request.param == "nodeid-hex":
+        return encode_hex(bob.node_id)
+    elif request.param == "enode":
+        return f"enode://{bob.node_id.hex()}@{bob.endpoint}"
+    elif request.param == "enr":
+        return bob.enr
+    elif request.param == "enr-repr":
+        return repr(bob.enr)
+    else:
+        raise Exception(f"Unhandled param: {request.param}")
+
+
+@pytest.mark.trio
+async def test_rpc_ping_web3(make_request, ping_param_w3, alice, bob, w3):
+    pong = await trio.to_thread.run_sync(w3.discv5.ping, ping_param_w3)
+    assert pong.enr_seq == bob.enr.sequence_number
+    assert pong.packet_ip == ipaddress.ip_address(alice.endpoint.ip_address)
+    assert pong.packet_port == alice.endpoint.port


### PR DESCRIPTION
## What was wrong?

Need more JSON-RPC endpoints to allow interaction with the network via JSON-RPC

## How was it fixed?

Added a `discv5_ping` endpoint for sending a ping.



#### Cute Animal Picture

![lionbear](https://user-images.githubusercontent.com/824194/94204208-0e736780-fe7e-11ea-958d-3306a1b6232c.jpg)

