### PR TITLE
Decompose ABC interfaces into more modular units

### DIFF
--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -188,23 +188,24 @@ class Client(Service, ClientAPI):
 
     async def send_ping(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         *,
+        enr_seq: Optional[int] = None,
         request_id: Optional[bytes] = None,
     ) -> bytes:
+        if enr_seq is None:
+            enr_seq = self.enr_manager.enr.sequence_number
         with self._get_request_id(node_id, request_id) as message_request_id:
             message = AnyOutboundMessage(
-                PingMessage(message_request_id, self.enr_manager.enr.sequence_number),
-                endpoint,
-                node_id,
+                PingMessage(message_request_id, enr_seq), endpoint, node_id,
             )
             await self.dispatcher.send_message(message)
 
         return message_request_id
 
     async def send_pong(
-        self, endpoint: Endpoint, node_id: NodeID, *, request_id: bytes,
+        self, node_id: NodeID, endpoint: Endpoint, *, request_id: bytes,
     ) -> None:
         message = AnyOutboundMessage(
             PongMessage(
@@ -220,8 +221,8 @@ class Client(Service, ClientAPI):
 
     async def send_find_nodes(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         *,
         distances: Collection[int],
         request_id: Optional[bytes] = None,
@@ -238,8 +239,8 @@ class Client(Service, ClientAPI):
 
     async def send_found_nodes(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         *,
         enrs: Sequence[ENRAPI],
         request_id: bytes,
@@ -258,8 +259,8 @@ class Client(Service, ClientAPI):
 
     async def send_talk_request(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         *,
         protocol: bytes,
         payload: bytes,
@@ -276,7 +277,7 @@ class Client(Service, ClientAPI):
         return message_request_id
 
     async def send_talk_response(
-        self, endpoint: Endpoint, node_id: NodeID, *, payload: bytes, request_id: bytes,
+        self, node_id: NodeID, endpoint: Endpoint, *, payload: bytes, request_id: bytes,
     ) -> None:
         message = AnyOutboundMessage(
             TalkResponseMessage(request_id, payload), endpoint, node_id,
@@ -285,8 +286,8 @@ class Client(Service, ClientAPI):
 
     async def send_register_topic(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         *,
         topic: bytes,
         enr: ENRAPI,
@@ -305,8 +306,8 @@ class Client(Service, ClientAPI):
 
     async def send_ticket(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         *,
         ticket: bytes,
         wait_time: int,
@@ -318,7 +319,7 @@ class Client(Service, ClientAPI):
         await self.dispatcher.send_message(message)
 
     async def send_registration_confirmation(
-        self, endpoint: Endpoint, node_id: NodeID, *, topic: bytes, request_id: bytes,
+        self, node_id: NodeID, endpoint: Endpoint, *, topic: bytes, request_id: bytes,
     ) -> None:
         message = AnyOutboundMessage(
             RegistrationConfirmationMessage(request_id, topic), endpoint, node_id,
@@ -327,8 +328,8 @@ class Client(Service, ClientAPI):
 
     async def send_topic_query(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         *,
         topic: bytes,
         request_id: Optional[bytes] = None,
@@ -344,7 +345,7 @@ class Client(Service, ClientAPI):
     # Request/Response API
     #
     async def ping(
-        self, endpoint: Endpoint, node_id: NodeID
+        self, node_id: NodeID, endpoint: Endpoint
     ) -> InboundMessage[PongMessage]:
         with self._get_request_id(node_id) as request_id:
             assert isinstance(request_id, bytes)
@@ -359,7 +360,7 @@ class Client(Service, ClientAPI):
                 return await subscription.receive()
 
     async def find_nodes(
-        self, endpoint: Endpoint, node_id: NodeID, distances: Collection[int],
+        self, node_id: NodeID, endpoint: Endpoint, distances: Collection[int],
     ) -> Tuple[InboundMessage[FoundNodesMessage], ...]:
         with self._get_request_id(node_id) as request_id:
             request = AnyOutboundMessage(
@@ -403,7 +404,7 @@ class Client(Service, ClientAPI):
                 return responses
 
     async def talk(
-        self, endpoint: Endpoint, node_id: NodeID, protocol: bytes, payload: bytes
+        self, node_id: NodeID, endpoint: Endpoint, protocol: bytes, payload: bytes
     ) -> InboundMessage[TalkResponseMessage]:
         with self._get_request_id(node_id) as request_id:
             request = AnyOutboundMessage(
@@ -416,8 +417,8 @@ class Client(Service, ClientAPI):
 
     async def register_topic(
         self,
-        endpoint: Endpoint,
         node_id: NodeID,
+        endpoint: Endpoint,
         topic: bytes,
         ticket: Optional[bytes] = None,
     ) -> Tuple[
@@ -427,6 +428,6 @@ class Client(Service, ClientAPI):
         raise NotImplementedError
 
     async def topic_query(
-        self, endpoint: Endpoint, node_id: NodeID, topic: bytes
+        self, node_id: NodeID, endpoint: Endpoint, topic: bytes
     ) -> InboundMessage[FoundNodesMessage]:
         raise NotImplementedError

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -119,7 +119,7 @@ class Network(Service, NetworkAPI):
     ) -> PongMessage:
         if endpoint is None:
             endpoint = self._endpoint_for_node_id(node_id)
-        response = await self.client.ping(endpoint, node_id)
+        response = await self.client.ping(node_id, endpoint)
         return response.message
 
     async def find_nodes(
@@ -130,7 +130,7 @@ class Network(Service, NetworkAPI):
 
         if endpoint is None:
             endpoint = self._endpoint_for_node_id(node_id)
-        responses = await self.client.find_nodes(endpoint, node_id, distances=distances)
+        responses = await self.client.find_nodes(node_id, endpoint, distances=distances)
         return tuple(enr for response in responses for enr in response.message.enrs)
 
     async def talk(
@@ -143,7 +143,7 @@ class Network(Service, NetworkAPI):
     ) -> bytes:
         if endpoint is None:
             endpoint = self._endpoint_for_node_id(node_id)
-        response = await self.client.talk(endpoint, node_id, protocol, payload)
+        response = await self.client.talk(node_id, endpoint, protocol, payload)
         return response.message.payload
 
     async def get_enr(
@@ -386,8 +386,8 @@ class Network(Service, NetworkAPI):
                         raise Exception("Should be unreachable")
 
                 await self.client.send_found_nodes(
-                    request.sender_endpoint,
                     request.sender_node_id,
+                    request.sender_endpoint,
                     enrs=response_enrs,
                     request_id=request.message.request_id,
                 )

--- a/tests/core/v5_1/test_dispatcher_session_management.py
+++ b/tests/core/v5_1/test_dispatcher_session_management.py
@@ -16,7 +16,7 @@ async def test_dispatcher_detects_handshake_timeout_as_initiator(
             async with alice.events.session_created.subscribe_and_wait():
                 async with bob.events.packet_sent.subscribe() as subscription:
                     await alice_client.send_ping(
-                        endpoint=bob.endpoint, node_id=bob.node_id
+                        node_id=bob.node_id, endpoint=bob.endpoint,
                     )
                     _, envelope = await subscription.receive()
                     assert envelope.packet.is_who_are_you
@@ -42,7 +42,7 @@ async def test_dispatcher_detects_handshake_timeout_as_recipient(
             async with bob.events.session_created.subscribe_and_wait():
                 async with alice.events.packet_received.subscribe() as subscription:
                     await alice_client.send_ping(
-                        endpoint=bob.endpoint, node_id=bob.node_id
+                        node_id=bob.node_id, endpoint=bob.endpoint,
                     )
                     async for _, envelope in subscription:
                         if envelope.packet.is_who_are_you:
@@ -71,7 +71,7 @@ async def test_dispatcher_initiates_new_session_when_packet_cannot_be_decoded(
             async with alice.events.session_created.subscribe_and_wait():
                 async with bob.events.session_handshake_complete.subscribe() as subscription:
                     await bob_client.send_ping(
-                        endpoint=alice.endpoint, node_id=alice.node_id
+                        node_id=alice.node_id, endpoint=alice.endpoint,
                     )
                     session = await subscription.receive()
                     bob_client.pool.remove_session(session.id)
@@ -81,7 +81,7 @@ async def test_dispatcher_initiates_new_session_when_packet_cannot_be_decoded(
                 async with alice.events.session_created.subscribe_and_wait():
                     async with bob.events.session_created.subscribe_and_wait():
                         await bob_client.send_ping(
-                            endpoint=alice.endpoint, node_id=alice.node_id
+                            node_id=alice.node_id, endpoint=alice.endpoint,
                         )
 
 
@@ -96,7 +96,7 @@ async def test_dispatcher_detects_duplicate_handshakes(alice, bob, autojump_cloc
             async with alice.events.session_created.subscribe_and_wait():
                 async with bob.events.session_handshake_complete.subscribe() as subscription:
                     await bob_client.send_ping(
-                        endpoint=alice.endpoint, node_id=alice.node_id
+                        node_id=alice.node_id, endpoint=alice.endpoint,
                     )
                     session = await subscription.receive()
                     bob_client.pool.remove_session(session.id)
@@ -105,7 +105,7 @@ async def test_dispatcher_detects_duplicate_handshakes(alice, bob, autojump_cloc
             async with bob.events.session_created.subscribe() as subscription:
                 async with alice.events.session_created.subscribe_and_wait():
                     await bob_client.send_ping(
-                        endpoint=alice.endpoint, node_id=alice.node_id
+                        node_id=alice.node_id, endpoint=alice.endpoint,
                     )
                     session = await subscription.receive()
                 bob_client.pool.remove_session(session.id)
@@ -127,7 +127,7 @@ async def test_dispatcher_detects_duplicate_handshakes(alice, bob, autojump_cloc
             # success, alice should remove the full handshake
             async with alice.events.session_handshake_complete.subscribe() as subscription:
                 await bob_client.send_ping(
-                    endpoint=alice.endpoint, node_id=alice.node_id
+                    node_id=alice.node_id, endpoint=alice.endpoint,
                 )
                 new_full_session = await subscription.receive()
 

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -16,7 +16,7 @@ async def test_network_responds_to_pings(alice, bob):
     async with alice.network() as alice_network:
         async with bob.network():
             with trio.fail_after(2):
-                response = await alice_network.client.ping(bob.endpoint, bob.node_id,)
+                response = await alice_network.client.ping(bob.node_id, bob.endpoint)
 
     assert response.message.enr_seq == bob.enr.sequence_number
     assert response.message.packet_ip == alice.endpoint.ip_address
@@ -41,7 +41,7 @@ async def test_network_responds_to_find_node_requests(alice, bob):
 
             with trio.fail_after(2):
                 responses = await alice_network.client.find_nodes(
-                    bob.endpoint, bob.node_id, distances=(0, 255, 256),
+                    bob.node_id, bob.endpoint, distances=(0, 255, 256),
                 )
 
     assert all(
@@ -215,8 +215,8 @@ async def test_network_talk_api(alice, bob):
         async with network.dispatcher.subscribe(TalkRequestMessage) as subscription:
             request = await subscription.receive()
             await network.client.send_talk_response(
-                request.sender_endpoint,
                 request.sender_node_id,
+                request.sender_endpoint,
                 payload=b"test-response-payload",
                 request_id=request.message.request_id,
             )


### PR DESCRIPTION
## What was wrong?

While working on #95 it became clear that implementing the overlay network is going to involve mirroring a lot of the functionality from the base implementation.  Specifically all of the logic surrounding management of the routing table (PING, PONG, FIND_NODES, NODES).

For example, #99 will split out some of this functionality into re-usable services.  It should be possible for these services to be used in both the main network as well as the overlay network to avoid some duplication.

## How was it fixed?

WIP

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
