### PR TITLE
Fix crash due to trying to message 'self'

### DIFF
--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -195,7 +195,7 @@ class Network(Service, NetworkAPI):
             closest_k_unqueried_candidates = (
                 candidate
                 for candidate in closest_k_candidates
-                if candidate not in queried_node_ids
+                if candidate not in queried_node_ids and candidate != self.local_node_id
             )
             nodes_to_query = tuple(take(3, closest_k_unqueried_candidates))
 


### PR DESCRIPTION
## What was wrong?

Crash due to attempt to message *self*

```
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/_boot.py", line 27, in run
Oct 06 23:02:18 localhost launch.sh[32136]:     await _main()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/_boot.py", line 13, in _main
Oct 06 23:02:18 localhost launch.sh[32136]:     await main()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/main.py", line 51, in main
Oct 06 23:02:18 localhost launch.sh[32136]:     await args.func(boot_info)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/cli_commands.py", line 25, in do_main
Oct 06 23:02:18 localhost launch.sh[32136]:     await manager.wait_finished()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_generator/_util.py", line 42, in __aexit__
Oct 06 23:02:18 localhost launch.sh[32136]:     await self._agen.asend(None)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_service/trio.py", line 411, in background_trio_service
Oct 06 23:02:18 localhost launch.sh[32136]:     await manager.stop()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/trio/_core/_run.py", line 741, in __aexit__
Oct 06 23:02:18 localhost launch.sh[32136]:     raise combined_error_from_nursery
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_service/trio.py", line 205, in run
Oct 06 23:02:18 localhost launch.sh[32136]:     raise trio.MultiError(
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_service/base.py", line 324, in _run_and_manage_task
Oct 06 23:02:18 localhost launch.sh[32136]:     await task.run()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_service/base.py", line 169, in run
Oct 06 23:02:18 localhost launch.sh[32136]:     await self.child_manager.run()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_service/trio.py", line 205, in run
Oct 06 23:02:18 localhost launch.sh[32136]:     raise trio.MultiError(
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_service/base.py", line 324, in _run_and_manage_task
Oct 06 23:02:18 localhost launch.sh[32136]:     await task.run()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_service/trio.py", line 76, in run
Oct 06 23:02:18 localhost launch.sh[32136]:     await self._async_fn(*self._async_fn_args)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/network.py", line 325, in _manage_routing_table
Oct 06 23:02:18 localhost launch.sh[32136]:     found_enrs = await self.recursive_find_nodes(target_node_id)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/network.py", line 210, in recursive_find_nodes
Oct 06 23:02:18 localhost launch.sh[32136]:     nursery.start_soon(do_lookup, peer)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/trio/_core/_run.py", line 741, in __aexit__
Oct 06 23:02:18 localhost launch.sh[32136]:     raise combined_error_from_nursery
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/network.py", line 171, in do_lookup
Oct 06 23:02:18 localhost launch.sh[32136]:     enrs = await self.find_nodes(node_id, distance)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/network.py", line 133, in find_nodes
Oct 06 23:02:18 localhost launch.sh[32136]:     responses = await self.client.find_nodes(endpoint, node_id, distances=distances)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/client.py", line 403, in find_nodes
Oct 06 23:02:18 localhost launch.sh[32136]:     return responses
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/async_generator/_util.py", line 53, in __aexit__
Oct 06 23:02:18 localhost launch.sh[32136]:     await self._agen.athrow(type, value, traceback)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/dispatcher.py", line 487, in subscribe_request
Oct 06 23:02:18 localhost launch.sh[32136]:     nursery.cancel_scope.cancel()
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/trio/_core/_run.py", line 741, in __aexit__
Oct 06 23:02:18 localhost launch.sh[32136]:     raise combined_error_from_nursery
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/dispatcher.py", line 508, in _manage_request_response
Oct 06 23:02:18 localhost launch.sh[32136]:     await self.send_message(request)
Oct 06 23:02:18 localhost launch.sh[32136]:   File "/root/env/lib/python3.8/site-packages/ddht/v5_1/dispatcher.py", line 433, in send_message
Oct 06 23:02:18 localhost launch.sh[32136]:     raise Exception("Cannot send message to self")
Oct 06 23:02:18 localhost launch.sh[32136]: Exception: Cannot send message to self
```

## How was it fixed?

Filter out any node_ids that are our own.

#### Cute Animal Picture

![liemer](https://user-images.githubusercontent.com/824194/95269337-70c15600-07f6-11eb-80ec-f6df1a31afe3.jpg)

