### PR TITLE
Add nodes from inbound pings to routing table

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -459,7 +459,7 @@ class NetworkAPI(ServiceAPI):
 
     @abstractmethod
     async def get_enr(
-        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
+        self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
     ) -> ENRAPI:
         ...
 

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -7,7 +7,6 @@ import pytest
 import trio
 
 from ddht.kademlia import compute_log_distance
-from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE
 from ddht.v5_1.messages import FoundNodesMessage, TalkRequestMessage
 
 
@@ -140,73 +139,6 @@ async def test_network_recursive_find_nodes(tester, alice, bob):
 
         # Ensure that one of the three closest node ids was in the returned node ids
         assert best_node_ids_by_distance.intersection(found_node_ids)
-
-
-@pytest.mark.trio
-async def test_network_pings_oldest_routing_table(tester, alice, bob, autojump_clock):
-    async with AsyncExitStack() as stack:
-        carol = tester.node()
-        dylan = tester.node()
-
-        # startup a few peers to put in the routing table
-        bob_network = await stack.enter_async_context(bob.network())
-        carol_network = await stack.enter_async_context(carol.network())
-
-        # populate the routing table and ENR database
-        alice.enr_db.set_enr(bob.enr)
-        alice.enr_db.set_enr(carol.enr)
-        alice.enr_db.set_enr(dylan.enr)
-
-        async with AsyncExitStack() as handshakes_done:
-            await handshakes_done.enter_async_context(
-                bob.events.session_handshake_complete.subscribe_and_wait()
-            )
-            await handshakes_done.enter_async_context(
-                carol.events.session_handshake_complete.subscribe_and_wait()
-            )
-
-            alice_network = await stack.enter_async_context(
-                alice.network(bootnodes=[bob.enr, carol.enr, dylan.enr]),
-            )
-        alice_network.routing_table.update(dylan.node_id)
-        alice_network.routing_table.update(bob.node_id)
-        alice_network.routing_table.update(carol.node_id)
-
-        assert alice_network.routing_table._contains(bob.node_id, False)
-        assert alice_network.routing_table._contains(carol.node_id, False)
-        assert alice_network.routing_table._contains(dylan.node_id, False)
-
-        # run through a few checkpoints which should remove dylan from the routing table
-        await trio.sleep(ROUTING_TABLE_KEEP_ALIVE)
-        await trio.sleep(ROUTING_TABLE_KEEP_ALIVE)
-
-        assert alice_network.routing_table._contains(bob.node_id, False)
-        assert alice_network.routing_table._contains(carol.node_id, False)
-        assert not alice_network.routing_table._contains(dylan.node_id, False)
-
-        # now take carol offline and let her be removed
-        carol_network.get_manager().cancel()
-        alice_network._last_pong_at[carol.node_id] = (
-            trio.current_time() - ROUTING_TABLE_KEEP_ALIVE - 1
-        )
-        await trio.sleep(ROUTING_TABLE_KEEP_ALIVE)
-        await trio.sleep(ROUTING_TABLE_KEEP_ALIVE)
-
-        assert alice_network.routing_table._contains(bob.node_id, False)
-        assert not alice_network.routing_table._contains(carol.node_id, False)
-        assert not alice_network.routing_table._contains(dylan.node_id, False)
-
-        # now take bob offline and let her be removed
-        bob_network.get_manager().cancel()
-        alice_network._last_pong_at[bob.node_id] = (
-            trio.current_time() - ROUTING_TABLE_KEEP_ALIVE - 1
-        )
-        await trio.sleep(ROUTING_TABLE_KEEP_ALIVE)
-        await trio.sleep(ROUTING_TABLE_KEEP_ALIVE)
-
-        assert not alice_network.routing_table._contains(bob.node_id, False)
-        assert not alice_network.routing_table._contains(carol.node_id, False)
-        assert not alice_network.routing_table._contains(dylan.node_id, False)
 
 
 @pytest.mark.trio


### PR DESCRIPTION
fixes #104 

## What was wrong?

When we receive and inbound ping we should be adding the node to the routing table.

## How was it fixed?

Now when an inbound ping is retrieved the client will ensure we have their ENR record and then will add them to the routing table.

#### Cute Animal Picture

![15-unlikely-animal-friends](https://user-images.githubusercontent.com/824194/95368410-54bfc200-0893-11eb-8083-a27acccd2fb7.jpg)

