### PR TITLE
Make request_id retrievable from the InboundMessage

### DIFF
--- a/ddht/base_message.py
+++ b/ddht/base_message.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 from eth_typing import NodeID
 from eth_utils import int_to_big_endian
@@ -35,6 +35,30 @@ class InboundMessage(Generic[TMessage]):
     message: TMessage
     sender_endpoint: Endpoint
     sender_node_id: NodeID
+    explicit_request_id: Optional[bytes] = None
+
+    @property
+    def request_id(self) -> bytes:
+        """
+        Return the ``request_id`` for this message.
+
+        This API exists to allow this class to be used with both base-protocol
+        messages which contain the ``request_id`` as well as with
+        TALKREQ/TALKRESP based sub-protocol messages.  In the TALKREQ/TALKRESP
+        case the ``request_id`` is only present on the base protocol message
+        and needs to be duplicated into the sub-protocol message.  This is
+        integral to being able to use the ``SubscriptionManagerAPI`` with both
+        the base protocol and sub-protocols.
+        """
+        if self.explicit_request_id is not None:
+            return self.explicit_request_id
+        elif hasattr(self.message, "request_id"):
+            return self.message.request_id  # type: ignore
+        else:
+            raise AttributeError(
+                f"No explicit request_id and message does not have a "
+                f"`request_id` property: {self.message}"
+            )
 
     def __str__(self) -> str:
         return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -252,6 +252,9 @@ class ClientAPI(ServiceAPI):
     async def wait_listening(self) -> None:
         ...
 
+    #
+    # Message Sending API
+    #
     @abstractmethod
     async def send_ping(
         self,
@@ -262,9 +265,6 @@ class ClientAPI(ServiceAPI):
     ) -> bytes:
         ...
 
-    #
-    # Message Sending API
-    #
     @abstractmethod
     async def send_pong(
         self, endpoint: Endpoint, node_id: NodeID, *, request_id: bytes,
@@ -358,19 +358,19 @@ class ClientAPI(ServiceAPI):
     #
     @abstractmethod
     async def ping(
-        self, endpoint: Endpoint, node_id: NodeID
+        self, endpoint: Endpoint, node_id: NodeID,
     ) -> InboundMessage[PongMessage]:
         ...
 
     @abstractmethod
     async def find_nodes(
-        self, endpoint: Endpoint, node_id: NodeID, distances: Collection[int]
+        self, endpoint: Endpoint, node_id: NodeID, distances: Collection[int],
     ) -> Tuple[InboundMessage[FoundNodesMessage], ...]:
         ...
 
     @abstractmethod
     async def talk(
-        self, endpoint: Endpoint, node_id: NodeID, protocol: bytes, payload: bytes
+        self, endpoint: Endpoint, node_id: NodeID, protocol: bytes, payload: bytes,
     ) -> InboundMessage[TalkResponseMessage]:
         ...
 
@@ -389,7 +389,7 @@ class ClientAPI(ServiceAPI):
 
     @abstractmethod
     async def topic_query(
-        self, endpoint: Endpoint, node_id: NodeID, topic: bytes
+        self, endpoint: Endpoint, node_id: NodeID, topic: bytes,
     ) -> InboundMessage[FoundNodesMessage]:
         ...
 
@@ -442,7 +442,7 @@ class NetworkAPI(ServiceAPI):
 
     @abstractmethod
     async def ping(
-        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
     ) -> PongMessage:
         ...
 

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -336,7 +336,7 @@ class Network(Service, NetworkAPI):
                 await self.dispatcher.send_message(
                     request.to_response(
                         PongMessage(
-                            request.message.request_id,
+                            request.request_id,
                             self.enr_manager.enr.sequence_number,
                             request.sender_endpoint.ip_address,
                             request.sender_endpoint.port,
@@ -397,7 +397,7 @@ class Network(Service, NetworkAPI):
                     request.sender_endpoint,
                     request.sender_node_id,
                     enrs=response_enrs,
-                    request_id=request.message.request_id,
+                    request_id=request.request_id,
                 )
 
     #


### PR DESCRIPTION
## What was wrong?

The `InboundMessage` API is useful in Alexandria as well, however some of the mechanics of doing sub-protocol messages require that we can still access the `request_id` from the base protocol request/response.

## How was it fixed?

Allow explicitly specifying the `request_id` when instantiating `InboundMessage`.  This allows the base protocol `request_id` to  be preserved for sub-protocol messages.

#### Cute Animal Picture

![unlikely-animal-friendships-13](https://user-images.githubusercontent.com/824194/95520365-52896080-0984-11eb-9814-fe23f126fc33.jpeg)

