### PR TITLE
Implement SubscriptionManagerAPI

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -20,8 +20,9 @@ from eth_enr.abc import IdentitySchemeAPI
 from eth_typing import NodeID
 import trio
 
-from ddht.base_message import BaseMessage
+from ddht.base_message import AnyInboundMessage, BaseMessage, InboundMessage, TMessage
 from ddht.boot_info import BootInfo
+from ddht.endpoint import Endpoint
 from ddht.typing import JSON, SessionKeys
 
 TAddress = TypeVar("TAddress", bound="AddressAPI")
@@ -265,6 +266,21 @@ class RPCResponse(TypedDict, total=False):
 class RPCHandlerAPI(ABC):
     @abstractmethod
     async def __call__(self, request: RPCRequest) -> RPCResponse:
+        ...
+
+
+class SubscriptionManagerAPI(ABC, Generic[TMessage]):
+    @abstractmethod
+    def feed_subscriptions(self, message: AnyInboundMessage) -> None:
+        ...
+
+    @abstractmethod
+    def subscribe(
+        self,
+        message_type: Type[TMessage],
+        endpoint: Optional[Endpoint] = None,
+        node_id: Optional[NodeID] = None,
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[InboundMessage[TMessage]]]:
         ...
 
 

--- a/ddht/base_message.py
+++ b/ddht/base_message.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from eth_typing import NodeID
 from eth_utils import int_to_big_endian
@@ -15,7 +15,8 @@ class BaseMessage(rlp.Serializable):  # type: ignore
         return b"".join((int_to_big_endian(self.message_type), rlp.encode(self)))
 
 
-TMessage = TypeVar("TMessage", bound=BaseMessage)
+TMessage = TypeVar("TMessage")
+TBaseMessage = TypeVar("TBaseMessage", bound=BaseMessage)
 TResponseMessage = TypeVar("TResponseMessage", bound=BaseMessage)
 
 
@@ -48,5 +49,5 @@ class InboundMessage(Generic[TMessage]):
         )
 
 
-AnyInboundMessage = InboundMessage[BaseMessage]
-AnyOutboundMessage = OutboundMessage[BaseMessage]
+AnyInboundMessage = InboundMessage[Any]
+AnyOutboundMessage = OutboundMessage[Any]

--- a/ddht/subscription_manager.py
+++ b/ddht/subscription_manager.py
@@ -1,0 +1,73 @@
+import collections
+import logging
+from typing import Any, AsyncIterator, DefaultDict, NamedTuple, Optional, Set, Type
+
+from async_generator import asynccontextmanager
+from eth_typing import NodeID
+import trio
+
+from ddht.abc import SubscriptionManagerAPI
+from ddht.base_message import AnyInboundMessage, InboundMessage, TMessage
+from ddht.endpoint import Endpoint
+
+
+class _Subcription(NamedTuple):
+    send_channel: trio.abc.SendChannel[AnyInboundMessage]
+    filter_by_endpoint: Optional[Endpoint]
+    filter_by_node_id: Optional[NodeID]
+
+
+class SubscriptionManager(SubscriptionManagerAPI[TMessage]):
+    logger = logging.getLogger("ddht.SubscriptionManager")
+
+    _subscriptions: DefaultDict[Type[Any], Set[_Subcription]]
+
+    def __init__(self) -> None:
+        self._subscriptions = collections.defaultdict(set)
+
+    def feed_subscriptions(self, message: AnyInboundMessage) -> None:
+        message_type = type(message.message)
+
+        subscriptions = tuple(self._subscriptions[message_type])
+        self.logger.debug(
+            "Handling %d subscriptions for message: %s", len(subscriptions), message,
+        )
+        for subscription in subscriptions:
+            if subscription.filter_by_endpoint is not None:
+                if message.sender_endpoint != subscription.filter_by_endpoint:
+                    continue
+            if subscription.filter_by_node_id is not None:
+                if message.sender_node_id != subscription.filter_by_node_id:
+                    continue
+
+            try:
+                subscription.send_channel.send_nowait(message)  # type: ignore
+            except trio.WouldBlock:
+                self.logger.debug(
+                    "Discarding message for subscription %s due to full channel: %s",
+                    subscription,
+                    message,
+                )
+            except trio.BrokenResourceError:
+                pass
+
+    @asynccontextmanager
+    async def subscribe(
+        self,
+        message_type: Type[TMessage],
+        endpoint: Optional[Endpoint] = None,
+        node_id: Optional[NodeID] = None,
+    ) -> AsyncIterator[trio.abc.ReceiveChannel[InboundMessage[TMessage]]]:
+        send_channel, receive_channel = trio.open_memory_channel[
+            InboundMessage[TMessage]
+        ](256)
+        subscription = _Subcription(send_channel, endpoint, node_id)
+        self._subscriptions[message_type].add(subscription)
+
+        self.logger.debug("Subscription setup for: %s", message_type)
+
+        try:
+            async with receive_channel:
+                yield receive_channel
+        finally:
+            self._subscriptions[message_type].remove(subscription)

--- a/ddht/v5/abc.py
+++ b/ddht/v5/abc.py
@@ -14,7 +14,12 @@ from eth_enr import ENRAPI, IdentitySchemeAPI
 from eth_typing import NodeID
 
 from ddht.abc import HandshakeSchemeAPI
-from ddht.base_message import AnyInboundMessage, BaseMessage, InboundMessage, TMessage
+from ddht.base_message import (
+    AnyInboundMessage,
+    BaseMessage,
+    InboundMessage,
+    TBaseMessage,
+)
 from ddht.endpoint import Endpoint
 from ddht.v5.packets import Packet
 from ddht.v5.typing import HandshakeResult, Tag
@@ -165,8 +170,8 @@ class MessageDispatcherAPI(ABC):
 
     @abstractmethod
     def add_request_handler(
-        self, message_class: Type[TMessage]
-    ) -> ChannelHandlerSubscriptionAPI[InboundMessage[TMessage]]:
+        self, message_class: Type[TBaseMessage]
+    ) -> ChannelHandlerSubscriptionAPI[InboundMessage[TBaseMessage]]:
         """
         Add a request handler for messages of a given type.
 

--- a/ddht/v5/message_dispatcher.py
+++ b/ddht/v5/message_dispatcher.py
@@ -24,7 +24,7 @@ from ddht.base_message import (
     AnyInboundMessage,
     AnyOutboundMessage,
     InboundMessage,
-    TMessage,
+    TBaseMessage,
 )
 from ddht.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
 from ddht.endpoint import Endpoint
@@ -87,7 +87,7 @@ class ChannelHandlerSubscription(ChannelHandlerSubscriptionAPI[ChannelContentTyp
             raise StopAsyncIteration
 
 
-InboundMessageSubscription = ChannelHandlerSubscription[InboundMessage[TMessage]]
+InboundMessageSubscription = ChannelHandlerSubscription[InboundMessage[TBaseMessage]]
 AnyInboundMessageSubscription = ChannelHandlerSubscription[AnyInboundMessage]
 
 
@@ -183,15 +183,15 @@ class MessageDispatcher(Service, MessageDispatcherAPI):
             )
 
     def add_request_handler(
-        self, message_class: Type[TMessage]
-    ) -> InboundMessageSubscription[TMessage]:
+        self, message_class: Type[TBaseMessage]
+    ) -> InboundMessageSubscription[TBaseMessage]:
         message_type = message_class.message_type
         if message_type in self.request_handler_send_channels:
             raise ValueError(
                 f"Request handler for {message_class.__name__} is already added"
             )
 
-        request_channels = trio.open_memory_channel[InboundMessage[TMessage]](0)
+        request_channels = trio.open_memory_channel[InboundMessage[TBaseMessage]](0)
         self.request_handler_send_channels[message_type] = request_channels[0]
 
         self.logger.debug("Adding request handler for %s", message_class.__name__)

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -18,12 +18,18 @@ from eth_keys import keys
 from eth_typing import NodeID
 import trio
 
-from ddht.abc import EventAPI, HandshakeSchemeAPI, RoutingTableAPI
+from ddht.abc import (
+    EventAPI,
+    HandshakeSchemeAPI,
+    RoutingTableAPI,
+    SubscriptionManagerAPI,
+)
 from ddht.base_message import (
     AnyOutboundMessage,
+    BaseMessage,
     InboundMessage,
     OutboundMessage,
-    TMessage,
+    TBaseMessage,
 )
 from ddht.endpoint import Endpoint
 from ddht.typing import SessionKeys
@@ -200,6 +206,8 @@ class PoolAPI(ABC):
 
 
 class DispatcherAPI(ServiceAPI):
+    subscription_manager: SubscriptionManagerAPI[BaseMessage]
+
     @abstractmethod
     async def send_message(self, message: AnyOutboundMessage) -> None:
         ...
@@ -215,18 +223,16 @@ class DispatcherAPI(ServiceAPI):
     @abstractmethod
     def subscribe(
         self,
-        payload_type: Type[TMessage],
+        message_type: Type[TBaseMessage],
         endpoint: Optional[Endpoint] = None,
         node_id: Optional[NodeID] = None,
-    ) -> AsyncContextManager[trio.abc.ReceiveChannel[InboundMessage[TMessage]]]:
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[InboundMessage[TBaseMessage]]]:
         ...
 
     @abstractmethod
     def subscribe_request(
-        self, request: AnyOutboundMessage, response_payload_type: Type[TMessage],
-    ) -> AsyncContextManager[
-        trio.abc.ReceiveChannel[InboundMessage[TMessage]]
-    ]:  # noqa: E501
+        self, request: AnyOutboundMessage, response_message_type: Type[TBaseMessage],
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[InboundMessage[TBaseMessage]]]:
         ...
 
 

--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -116,7 +116,6 @@ class Client(Service, ClientAPI):
             self._inbound_message_receive_channel,
             self.pool,
             self.enr_db,
-            self._registry,
             self.events,
         )
         self.envelope_decoder = EnvelopeEncoder(

--- a/tests/core/test_subscription_manager.py
+++ b/tests/core/test_subscription_manager.py
@@ -1,0 +1,158 @@
+from contextlib import AsyncExitStack
+
+import pytest
+import trio
+
+from ddht.base_message import InboundMessage
+from ddht.subscription_manager import SubscriptionManager
+from ddht.tools.factories.endpoint import EndpointFactory
+from ddht.tools.factories.node_id import NodeIDFactory
+
+
+class MessageForTesting:
+    request_id = b"\x01"
+
+    def __init__(self, id):
+        self.id = id
+
+
+class OtherMessageForTesting:
+    request_id = b"\x01"
+
+    def __init__(self, id):
+        self.id = id
+
+
+@pytest.mark.trio
+async def test_subscribe_delivers_messages():
+    node_id = NodeIDFactory()
+    endpoint = EndpointFactory()
+    manager = SubscriptionManager()
+
+    async with manager.subscribe(MessageForTesting) as subscription:
+        with pytest.raises(trio.WouldBlock):
+            subscription.receive_nowait()
+
+        manager.feed_subscriptions(
+            InboundMessage(
+                message=OtherMessageForTesting(1234),
+                sender_node_id=node_id,
+                sender_endpoint=endpoint,
+            )
+        )
+        manager.feed_subscriptions(
+            InboundMessage(
+                message=MessageForTesting(1234),
+                sender_node_id=node_id,
+                sender_endpoint=endpoint,
+            )
+        )
+
+        with trio.fail_after(1):
+            message = await subscription.receive()
+
+        assert isinstance(message.message, MessageForTesting)
+        assert message.message.id == 1234
+
+        with pytest.raises(trio.WouldBlock):
+            subscription.receive_nowait()
+
+    manager.feed_subscriptions(
+        InboundMessage(
+            message=MessageForTesting(1234),
+            sender_node_id=node_id,
+            sender_endpoint=endpoint,
+        )
+    )
+    with pytest.raises(trio.ClosedResourceError):
+        subscription.receive_nowait()
+
+
+@pytest.mark.trio
+async def test_subscribe_filters_by_node_id_and_endpoint():
+    node_id = NodeIDFactory()
+    endpoint = EndpointFactory()
+    manager = SubscriptionManager()
+
+    async with AsyncExitStack() as stack:
+
+        subscription_a = await stack.enter_async_context(
+            manager.subscribe(MessageForTesting)
+        )
+        subscription_b = await stack.enter_async_context(
+            manager.subscribe(MessageForTesting, node_id=node_id)
+        )
+        subscription_c = await stack.enter_async_context(
+            manager.subscribe(MessageForTesting, node_id=node_id, endpoint=endpoint)
+        )
+
+        with pytest.raises(trio.WouldBlock):
+            subscription_a.receive_nowait()
+        with pytest.raises(trio.WouldBlock):
+            subscription_b.receive_nowait()
+        with pytest.raises(trio.WouldBlock):
+            subscription_c.receive_nowait()
+
+        # One Message that doesn't match the message type
+        manager.feed_subscriptions(
+            InboundMessage(
+                message=OtherMessageForTesting(1234),
+                sender_node_id=node_id,
+                sender_endpoint=endpoint,
+            )
+        )
+
+        # One Message that only matches the message type
+        manager.feed_subscriptions(
+            InboundMessage(
+                message=MessageForTesting(1),
+                sender_node_id=NodeIDFactory(),
+                sender_endpoint=EndpointFactory(),
+            )
+        )
+
+        # One Message that matches the message type AND node_id
+        manager.feed_subscriptions(
+            InboundMessage(
+                message=MessageForTesting(2),
+                sender_node_id=node_id,
+                sender_endpoint=EndpointFactory(),
+            )
+        )
+
+        # One Message that matches the message type AND node_id AND endpoint
+        manager.feed_subscriptions(
+            InboundMessage(
+                message=MessageForTesting(3),
+                sender_node_id=node_id,
+                sender_endpoint=endpoint,
+            )
+        )
+
+        # now grab all the messages
+        with trio.fail_after(1):
+            message_a_0 = await subscription_a.receive()
+            message_a_1 = await subscription_a.receive()
+            message_a_2 = await subscription_a.receive()
+
+            message_b_0 = await subscription_b.receive()
+            message_b_1 = await subscription_b.receive()
+
+            message_c_0 = await subscription_c.receive()
+
+        # all of the subscriptions should now be empty
+        with pytest.raises(trio.WouldBlock):
+            subscription_a.receive_nowait()
+        with pytest.raises(trio.WouldBlock):
+            subscription_b.receive_nowait()
+        with pytest.raises(trio.WouldBlock):
+            subscription_c.receive_nowait()
+
+        assert message_a_0.message.id == 1
+        assert message_a_1.message.id == 2
+        assert message_a_2.message.id == 3
+
+        assert message_b_0.message.id == 2
+        assert message_b_1.message.id == 3
+
+        assert message_c_0.message.id == 3


### PR DESCRIPTION
## What was wrong?

The `DispatcherAPI` implements the subscription logic.  This logic is useful when designing sub-protocols, but isn't re-usable in the current form.

## How was it fixed?

Extracted the functionality to a standalone and generic implementation that isn't bound to the core protocol message types and can be extended for use in TALK subprotocols.

#### Cute Animal Picture

![20-unlikely-animal-friends](https://user-images.githubusercontent.com/824194/95520590-dc392e00-0984-11eb-8fe0-1e8597e1da6d.jpg)

