### PR TITLE
Implement RequestTrackerAPI

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -4,6 +4,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncContextManager,
+    ContextManager,
     Deque,
     Generic,
     Iterator,
@@ -281,6 +282,22 @@ class SubscriptionManagerAPI(ABC, Generic[TMessage]):
         endpoint: Optional[Endpoint] = None,
         node_id: Optional[NodeID] = None,
     ) -> AsyncContextManager[trio.abc.ReceiveChannel[InboundMessage[TMessage]]]:
+        ...
+
+
+class RequestTrackerAPI(ABC):
+    @abstractmethod
+    def get_free_request_id(self, node_id: NodeID) -> bytes:
+        ...
+
+    @abstractmethod
+    def reserve_request_id(
+        self, node_id: NodeID, request_id: Optional[bytes] = None
+    ) -> ContextManager[bytes]:
+        ...
+
+    @abstractmethod
+    def is_request_id_active(self, node_id: NodeID, request_id: bytes) -> bool:
         ...
 
 

--- a/ddht/request_tracker.py
+++ b/ddht/request_tracker.py
@@ -1,0 +1,60 @@
+from contextlib import contextmanager
+import secrets
+from typing import Iterator, Optional, Set, Tuple
+
+from eth_typing import NodeID
+
+from ddht.abc import RequestTrackerAPI
+
+MAX_REQUEST_ID_ATTEMPTS = 3
+
+
+def _get_random_request_id() -> bytes:
+    return secrets.token_bytes(4)
+
+
+class RequestTracker(RequestTrackerAPI):
+    def __init__(self) -> None:
+        self._reserved_request_ids: Set[Tuple[NodeID, bytes]] = set()
+
+    def get_free_request_id(self, node_id: NodeID) -> bytes:
+        for _ in range(MAX_REQUEST_ID_ATTEMPTS):
+            request_id = _get_random_request_id()
+
+            if (node_id, request_id) in self._reserved_request_ids:
+                continue
+            else:
+                return request_id
+        else:
+            # The improbability of picking three already used request ids in a
+            # row is sufficiently improbable that we can generally assume it
+            # just will not ever happen (< 1/2**96)
+            raise ValueError(
+                f"Failed to get free request id ({len(self._reserved_request_ids)} "
+                f"handlers added right now)"
+            )
+
+    @contextmanager
+    def reserve_request_id(
+        self, node_id: NodeID, request_id: Optional[bytes] = None
+    ) -> Iterator[bytes]:
+        """
+        Reserve a `request_id` during the lifecycle of the context block.
+
+        If a `request_id` is not provided, one will be generated lazily.
+
+        .. note::
+
+            If an explicit `request_id` is provided, it is not guaranteed to be
+            collision free.
+        """
+        if request_id is None:
+            request_id = self.get_free_request_id(node_id)
+        try:
+            self._reserved_request_ids.add((node_id, request_id))
+            yield request_id
+        finally:
+            self._reserved_request_ids.remove((node_id, request_id))
+
+    def is_request_id_active(self, node_id: NodeID, request_id: bytes) -> bool:
+        return (node_id, request_id) in self._reserved_request_ids

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -1,15 +1,6 @@
 from abc import ABC, abstractmethod
 import logging
-from typing import (
-    Any,
-    AsyncContextManager,
-    Collection,
-    ContextManager,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-)
+from typing import Any, AsyncContextManager, Collection, Optional, Sequence, Tuple, Type
 import uuid
 
 from async_service import ServiceAPI
@@ -21,6 +12,7 @@ import trio
 from ddht.abc import (
     EventAPI,
     HandshakeSchemeAPI,
+    RequestTrackerAPI,
     RoutingTableAPI,
     SubscriptionManagerAPI,
 )
@@ -213,14 +205,6 @@ class DispatcherAPI(ServiceAPI):
         ...
 
     @abstractmethod
-    def get_free_request_id(self, node_id: NodeID) -> bytes:
-        ...
-
-    @abstractmethod
-    def reserve_request_id(self, node_id: NodeID) -> ContextManager[bytes]:
-        ...
-
-    @abstractmethod
     def subscribe(
         self,
         message_type: Type[TBaseMessage],
@@ -242,6 +226,7 @@ class ClientAPI(ServiceAPI):
     dispatcher: DispatcherAPI
     pool: PoolAPI
     enr_db: ENRDatabaseAPI
+    request_tracker: RequestTrackerAPI
 
     @property
     @abstractmethod

--- a/tests/core/test_request_tracker.py
+++ b/tests/core/test_request_tracker.py
@@ -1,0 +1,27 @@
+from ddht.request_tracker import RequestTracker
+from ddht.tools.factories.node_id import NodeIDFactory
+
+
+def test_request_tracker_reserve_request_id_generated():
+    tracker = RequestTracker()
+
+    node_id = NodeIDFactory()
+
+    with tracker.reserve_request_id(node_id) as request_id:
+        assert tracker.is_request_id_active(node_id, request_id)
+    assert not tracker.is_request_id_active(node_id, request_id)
+
+
+def test_request_tracker_reserve_request_id_provided():
+    tracker = RequestTracker()
+
+    node_id = NodeIDFactory()
+
+    request_id = b"\x01\x02\x03\04"
+
+    assert not tracker.is_request_id_active(node_id, request_id)
+
+    with tracker.reserve_request_id(node_id, request_id) as actual_request_id:
+        assert actual_request_id == request_id
+        assert tracker.is_request_id_active(node_id, request_id)
+    assert not tracker.is_request_id_active(node_id, request_id)


### PR DESCRIPTION
## What was wrong?

The logic for tracking which request ids are in use is valuable when writing sub-protocols.  It was not re-usable in the current form, embedded int he `DispatcherAPI`

## How was it fixed?

Extracted the logic into a standalone `RequestTrackerAPI`

#### Cute Animal Picture

![unlikely-animal-friendships-17](https://user-images.githubusercontent.com/824194/95520689-19052500-0985-11eb-9dd8-1995e0a7e98d.jpeg)
