### PR TITLE
Add a `crawl` command which attempts to traverse the network and log found ENRs

### DIFF
--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from async_service import ServiceAPI, background_trio_service, as_service, Service
+from async_service import Service, ServiceAPI, as_service, background_trio_service
 import trio
 
 from ddht.boot_info import BootInfo
@@ -9,7 +9,6 @@ from ddht.constants import ProtocolVersion
 from ddht.v5.app import Application as ApplicationV5
 from ddht.v5.crawl import Crawler
 from ddht.v5_1.app import Application as ApplicationV5_1
-
 
 logger = logging.getLogger("ddht")
 
@@ -26,6 +25,7 @@ async def do_main(boot_info: BootInfo) -> None:
     logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(app) as manager:
         await manager.wait_finished()
+
 
 async def do_crawl(boot_info: BootInfo) -> None:
 

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -9,11 +9,16 @@ from ddht.constants import ProtocolVersion
 from ddht.v5.app import Application as ApplicationV5
 from ddht.v5_1.app import Application as ApplicationV5_1
 
+from ddht.v5.app import get_local_private_key
+from eth_enr import ENRDB, default_identity_scheme_registry, ENRManager, ENR
+from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
 from ddht.constants import DEFAULT_LISTEN
-from ddht.datagram import send_datagram, InboundDatagram, DatagramReceiver
-from ddht.v5.channel_services import InboundPacket, PacketDecoder
+from ddht.datagram import send_datagram, InboundDatagram, DatagramReceiver, OutboundDatagram, DatagramSender
+from ddht.v5.channel_services import InboundPacket, PacketDecoder, OutboundPacket, PacketEncoder
 from ddht.v5.constants import DEFAULT_BOOTNODES
-from ddht.v5.messages import PingMessage
+from ddht.v5.messages import PingMessage, v5_registry
+from ddht.v5.message_dispatcher import MessageDispatcher
+from ddht.v5.packer import Packer
 
 logger = logging.getLogger("ddht")
 
@@ -51,20 +56,28 @@ async def do_listen(boot_info: BootInfo) -> None:
     )
 
     listen_on = boot_info.listen_on or DEFAULT_LISTEN
+
+    enr_db = ENRDB(dict(), default_identity_scheme_registry)
+    local_private_key = get_local_private_key(boot_info)
+    enr_manager = ENRManager(private_key=local_private_key, enr_db=enr_db)
+    enr_manager.update((b"udp", boot_info.port))
+    enr_manager.update((b"ip", listen_on.packed))
+
     logger.info(f"About to listen. bind={listen_on}:{boot_info.port}")
+    logger.info(f"current enr. enr={enr_manager.enr}")
     await sock.bind((str(listen_on), boot_info.port))
 
     async def log_received_packets():
         async for packet in inbound_packet_channels[1]:
             logger.info(f"Received packet from {packet.sender_endpoint}: {packet}")
 
+    # TOOD: is there a way to do this which involves less ceremony?
+    #       I think the core benefit async_service provides is that it's trio & asyncio?
+
     class ListenService(Service):
         async def run(self) -> None:
             logger.info("starting listen service")
-            services = [
-                datagram_receiver, packet_decoder, # as_service(log_received_packets)
-            ]
-            for service in services:
+            for service in (datagram_receiver, packet_decoder):
                 self.manager.run_daemon_child_service(service)
             self.manager.run_daemon_task(log_received_packets)
             await self.manager.wait_finished()
@@ -90,14 +103,13 @@ async def do_crawl(boot_info: BootInfo) -> None:
     sock = trio.socket.socket(
         family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM
     )
-    await sock.bind(("0.0.0.0", 30306))
 
     # Bind to a socket and try to bond with a single bootnode
 
     test_bootnode = DEFAULT_BOOTNODES[0]
+    test_bootnode = "enr:-IS4QHoI1sHKaPmcfDU3m0KXBeoWK8uidDvvnUOy01oigUs3a0HQjx2U701KvBG0Dg5OAsU3A5f6W2CvdZEIGFXcxhgDgmlkgnY0gmlwhAAAAACJc2VjcDI1NmsxoQLgn7ZgocyVfD0cUxGpfI_flyR-Oe8GNqw1V9MeWwxKC4N1ZHCCdl8"
     logger.info(f"Attempting to bond with: {test_bootnode}")
-
-    ping = PingMessage(request_id=0, enr_seq=0)
+    bootnode_enr = ENR.from_repr(test_bootnode, default_identity_scheme_registry)
 
     # datagram = packet.to_wire_bytes()
     # send_datagram(sock, datagram, endpoint)
@@ -108,9 +120,82 @@ async def do_crawl(boot_info: BootInfo) -> None:
         # have to handshake all over again?
     # also a message type registry?
 
-    try:
-        with trio.fail_after(10):
-            pass
-            # inbound_message = await self.message_dispatcher.request(node_id, ping)
-    except trio.TooSlowError:
-        logger.error("No response from bootnode")
+    enr_db = ENRDB(dict(), default_identity_scheme_registry)
+    enr_db.set_enr(bootnode_enr)
+
+    outbound_datagram_channels = trio.open_memory_channel[OutboundDatagram](0)
+    inbound_datagram_channels = trio.open_memory_channel[InboundDatagram](0)
+    outbound_packet_channels = trio.open_memory_channel[OutboundPacket](0)
+    inbound_packet_channels = trio.open_memory_channel[InboundPacket](0)
+    outbound_message_channels = trio.open_memory_channel[AnyOutboundMessage](0)
+    inbound_message_channels = trio.open_memory_channel[AnyInboundMessage](0)
+
+    datagram_sender = DatagramSender(  # type: ignore
+        outbound_datagram_channels[1], sock
+    )
+    datagram_receiver = DatagramReceiver(  # type: ignore
+        sock, inbound_datagram_channels[0]
+    )
+
+    packet_encoder = PacketEncoder(  # type: ignore
+        outbound_packet_channels[1], outbound_datagram_channels[0]
+    )
+    packet_decoder = PacketDecoder(  # type: ignore
+        inbound_datagram_channels[1], inbound_packet_channels[0]
+    )
+
+    local_private_key = get_local_private_key(boot_info)
+    enr_manager = ENRManager(private_key=local_private_key, enr_db=enr_db)
+    enr_manager.update((b"udp", boot_info.port))
+    packer = Packer(
+        local_private_key=local_private_key.to_bytes(),
+        local_node_id=enr_manager.enr.node_id,
+        enr_db=enr_db,
+        message_type_registry=v5_registry,
+        inbound_packet_receive_channel=inbound_packet_channels[1],
+        inbound_message_send_channel=inbound_message_channels[0],
+        outbound_message_receive_channel=outbound_message_channels[1],
+        outbound_packet_send_channel=outbound_packet_channels[0],
+    )
+
+    message_dispatcher = MessageDispatcher(
+        enr_db=enr_db,
+        inbound_message_receive_channel=inbound_message_channels[1],
+        outbound_message_send_channel=outbound_message_channels[0],
+    )
+
+    services = (
+        packet_encoder, datagram_sender,
+        datagram_receiver, packet_decoder,
+        packer,
+        message_dispatcher,
+    )
+
+    async def ping_bootnode():
+        ping = PingMessage(request_id=0, enr_seq=0)
+
+        try:
+            logger.info(f"Sending ping to remote node.")
+            with trio.fail_after(10):
+                resp = await message_dispatcher.request(
+                    bootnode_enr.node_id,
+                    ping
+                )
+                logger.info(f"Received response. resp={resp}")
+        except trio.TooSlowError:
+            logger.error("No response from bootnode")
+
+    class CrawlService(Service):
+        async def run(self) -> None:
+            for service in services:
+                self.manager.run_daemon_child_service(service)
+            self.manager.run_daemon_task(ping_bootnode)
+            await self.manager.wait_finished()
+
+    listen_on = boot_info.listen_on or DEFAULT_LISTEN
+    logger.info(f"About to listen. bind={listen_on}:{boot_info.port}")
+    await sock.bind(("0.0.0.0", boot_info.port))
+
+    with sock:
+        async with background_trio_service(CrawlService()) as manager:
+            await manager.wait_finished()

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -31,7 +31,7 @@ async def do_crawl(boot_info: BootInfo) -> None:
     if boot_info.protocol_version is not ProtocolVersion.v5:
         raise Exception("Currently crawling is only supported on the v5 network.")
 
-    crawler = Crawler(concurrency=4, boot_info=boot_info)
+    crawler = Crawler(concurrency=32, boot_info=boot_info)
 
     logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(crawler) as manager:

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -23,3 +23,7 @@ async def do_main(boot_info: BootInfo) -> None:
     logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(app) as manager:
         await manager.wait_finished()
+
+
+async def do_crawl(boot_info: BootInfo) -> None:
+    logger.info("Crawling!")

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -29,7 +29,7 @@ async def do_main(boot_info: BootInfo) -> None:
 async def do_crawl(boot_info: BootInfo) -> None:
 
     if boot_info.protocol_version is not ProtocolVersion.v5:
-        raise Exception("Currently crawling is only supported on the v5 network.")
+        raise ValueError("Currently crawling is only supported on the v5 network.")
 
     crawler = Crawler(concurrency=32, boot_info=boot_info)
 

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -7,18 +7,9 @@ import trio
 from ddht.boot_info import BootInfo
 from ddht.constants import ProtocolVersion
 from ddht.v5.app import Application as ApplicationV5
+from ddht.v5.crawl import Crawler
 from ddht.v5_1.app import Application as ApplicationV5_1
 
-from ddht.v5.app import get_local_private_key
-from eth_enr import ENRDB, default_identity_scheme_registry, ENRManager, ENR
-from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
-from ddht.constants import DEFAULT_LISTEN
-from ddht.datagram import send_datagram, InboundDatagram, DatagramReceiver, OutboundDatagram, DatagramSender
-from ddht.v5.channel_services import InboundPacket, PacketDecoder, OutboundPacket, PacketEncoder
-from ddht.v5.constants import DEFAULT_BOOTNODES
-from ddht.v5.messages import PingMessage, v5_registry
-from ddht.v5.message_dispatcher import MessageDispatcher
-from ddht.v5.packer import Packer
 
 logger = logging.getLogger("ddht")
 
@@ -36,166 +27,13 @@ async def do_main(boot_info: BootInfo) -> None:
     async with background_trio_service(app) as manager:
         await manager.wait_finished()
 
-
-async def do_listen(boot_info: BootInfo) -> None:
-    # TODO: respect boot_info.protocol_version
-
-    sock = trio.socket.socket(
-        family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM
-    )
-
-    inbound_datagram_channels = trio.open_memory_channel[InboundDatagram](0)
-    inbound_packet_channels = trio.open_memory_channel[InboundPacket](0)
-
-    datagram_receiver = DatagramReceiver(  # type: ignore
-        sock, inbound_datagram_channels[0]
-    )
-
-    packet_decoder = PacketDecoder(  # type: ignore
-        inbound_datagram_channels[1], inbound_packet_channels[0]
-    )
-
-    listen_on = boot_info.listen_on or DEFAULT_LISTEN
-
-    enr_db = ENRDB(dict(), default_identity_scheme_registry)
-    local_private_key = get_local_private_key(boot_info)
-    enr_manager = ENRManager(private_key=local_private_key, enr_db=enr_db)
-    enr_manager.update((b"udp", boot_info.port))
-    enr_manager.update((b"ip", listen_on.packed))
-
-    logger.info(f"About to listen. bind={listen_on}:{boot_info.port}")
-    logger.info(f"current enr. enr={enr_manager.enr}")
-    await sock.bind((str(listen_on), boot_info.port))
-
-    async def log_received_packets():
-        async for packet in inbound_packet_channels[1]:
-            logger.info(f"Received packet from {packet.sender_endpoint}: {packet}")
-
-    # TOOD: is there a way to do this which involves less ceremony?
-    #       I think the core benefit async_service provides is that it's trio & asyncio?
-
-    class ListenService(Service):
-        async def run(self) -> None:
-            logger.info("starting listen service")
-            for service in (datagram_receiver, packet_decoder):
-                self.manager.run_daemon_child_service(service)
-            self.manager.run_daemon_task(log_received_packets)
-            await self.manager.wait_finished()
-
-    with sock:
-        async with background_trio_service(ListenService()) as manager:
-            await manager.wait_finished()
-
-
-# TODO: This should probably delegate to either CrawlV5, or CrawlV5_1
 async def do_crawl(boot_info: BootInfo) -> None:
-    logger.info("Crawling!")
 
-    # TODO: use these...
-    boot_info.port: int
-    boot_info.bootnodes: Tuple[ENRAPI]
-    boot_info.private_key: Optional[keys.PrivateKey]
-    boot_info.listen_on
+    if boot_info.protocol_version is not ProtocolVersion.v5:
+        raise Exception(f"Currently crawling is only supported on the v5 network.")
 
-    # TODO: Use v5 or v5.1 where appropriate
-    # TODO: support UPNP?
+    crawler = Crawler(concurrency=32, boot_info=boot_info)
 
-    sock = trio.socket.socket(
-        family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM
-    )
-
-    # Bind to a socket and try to bond with a single bootnode
-
-    test_bootnode = DEFAULT_BOOTNODES[0]
-    test_bootnode = "enr:-IS4QHoI1sHKaPmcfDU3m0KXBeoWK8uidDvvnUOy01oigUs3a0HQjx2U701KvBG0Dg5OAsU3A5f6W2CvdZEIGFXcxhgDgmlkgnY0gmlwhAAAAACJc2VjcDI1NmsxoQLgn7ZgocyVfD0cUxGpfI_flyR-Oe8GNqw1V9MeWwxKC4N1ZHCCdl8"
-    logger.info(f"Attempting to bond with: {test_bootnode}")
-    bootnode_enr = ENR.from_repr(test_bootnode, default_identity_scheme_registry)
-
-    # datagram = packet.to_wire_bytes()
-    # send_datagram(sock, datagram, endpoint)
-
-    # you need a Packer, to handle handshakes...
-    # a Packer requires an ENRDatabaseAPI...
-        # I might actually want to use a database, if you re-crawl it might be nice not to
-        # have to handshake all over again?
-    # also a message type registry?
-
-    enr_db = ENRDB(dict(), default_identity_scheme_registry)
-    enr_db.set_enr(bootnode_enr)
-
-    outbound_datagram_channels = trio.open_memory_channel[OutboundDatagram](0)
-    inbound_datagram_channels = trio.open_memory_channel[InboundDatagram](0)
-    outbound_packet_channels = trio.open_memory_channel[OutboundPacket](0)
-    inbound_packet_channels = trio.open_memory_channel[InboundPacket](0)
-    outbound_message_channels = trio.open_memory_channel[AnyOutboundMessage](0)
-    inbound_message_channels = trio.open_memory_channel[AnyInboundMessage](0)
-
-    datagram_sender = DatagramSender(  # type: ignore
-        outbound_datagram_channels[1], sock
-    )
-    datagram_receiver = DatagramReceiver(  # type: ignore
-        sock, inbound_datagram_channels[0]
-    )
-
-    packet_encoder = PacketEncoder(  # type: ignore
-        outbound_packet_channels[1], outbound_datagram_channels[0]
-    )
-    packet_decoder = PacketDecoder(  # type: ignore
-        inbound_datagram_channels[1], inbound_packet_channels[0]
-    )
-
-    local_private_key = get_local_private_key(boot_info)
-    enr_manager = ENRManager(private_key=local_private_key, enr_db=enr_db)
-    enr_manager.update((b"udp", boot_info.port))
-    packer = Packer(
-        local_private_key=local_private_key.to_bytes(),
-        local_node_id=enr_manager.enr.node_id,
-        enr_db=enr_db,
-        message_type_registry=v5_registry,
-        inbound_packet_receive_channel=inbound_packet_channels[1],
-        inbound_message_send_channel=inbound_message_channels[0],
-        outbound_message_receive_channel=outbound_message_channels[1],
-        outbound_packet_send_channel=outbound_packet_channels[0],
-    )
-
-    message_dispatcher = MessageDispatcher(
-        enr_db=enr_db,
-        inbound_message_receive_channel=inbound_message_channels[1],
-        outbound_message_send_channel=outbound_message_channels[0],
-    )
-
-    services = (
-        packet_encoder, datagram_sender,
-        datagram_receiver, packet_decoder,
-        packer,
-        message_dispatcher,
-    )
-
-    async def ping_bootnode():
-        ping = PingMessage(request_id=0, enr_seq=0)
-
-        try:
-            logger.info(f"Sending ping to remote node.")
-            with trio.fail_after(10):
-                resp = await message_dispatcher.request(
-                    bootnode_enr.node_id,
-                    ping
-                )
-                logger.info(f"Received response. resp={resp}")
-        except trio.TooSlowError:
-            logger.error("No response from bootnode")
-
-    class CrawlService(Service):
-        async def run(self) -> None:
-            for service in services:
-                self.manager.run_daemon_child_service(service)
-            self.manager.run_daemon_task(ping_bootnode)
-            await self.manager.wait_finished()
-
-    listen_on = boot_info.listen_on or DEFAULT_LISTEN
-    logger.info(f"About to listen. bind={listen_on}:{boot_info.port}")
-    await sock.bind(("0.0.0.0", boot_info.port))
-
-    with sock:
-        async with background_trio_service(CrawlService()) as manager:
-            await manager.wait_finished()
+    logger.info("Started main process (pid=%d)", os.getpid())
+    async with background_trio_service(crawler) as manager:
+        await manager.wait_finished()

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -32,7 +32,7 @@ async def do_crawl(boot_info: BootInfo) -> None:
     if boot_info.protocol_version is not ProtocolVersion.v5:
         raise Exception(f"Currently crawling is only supported on the v5 network.")
 
-    crawler = Crawler(concurrency=32, boot_info=boot_info)
+    crawler = Crawler(concurrency=4, boot_info=boot_info)
 
     logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(crawler) as manager:

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -1,12 +1,19 @@
 import logging
 import os
 
-from async_service import ServiceAPI, background_trio_service
+from async_service import ServiceAPI, background_trio_service, as_service, Service
+import trio
 
 from ddht.boot_info import BootInfo
 from ddht.constants import ProtocolVersion
 from ddht.v5.app import Application as ApplicationV5
 from ddht.v5_1.app import Application as ApplicationV5_1
+
+from ddht.constants import DEFAULT_LISTEN
+from ddht.datagram import send_datagram, InboundDatagram, DatagramReceiver
+from ddht.v5.channel_services import InboundPacket, PacketDecoder
+from ddht.v5.constants import DEFAULT_BOOTNODES
+from ddht.v5.messages import PingMessage
 
 logger = logging.getLogger("ddht")
 
@@ -25,5 +32,85 @@ async def do_main(boot_info: BootInfo) -> None:
         await manager.wait_finished()
 
 
+async def do_listen(boot_info: BootInfo) -> None:
+    # TODO: respect boot_info.protocol_version
+
+    sock = trio.socket.socket(
+        family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM
+    )
+
+    inbound_datagram_channels = trio.open_memory_channel[InboundDatagram](0)
+    inbound_packet_channels = trio.open_memory_channel[InboundPacket](0)
+
+    datagram_receiver = DatagramReceiver(  # type: ignore
+        sock, inbound_datagram_channels[0]
+    )
+
+    packet_decoder = PacketDecoder(  # type: ignore
+        inbound_datagram_channels[1], inbound_packet_channels[0]
+    )
+
+    listen_on = boot_info.listen_on or DEFAULT_LISTEN
+    logger.info(f"About to listen. bind={listen_on}:{boot_info.port}")
+    await sock.bind((str(listen_on), boot_info.port))
+
+    async def log_received_packets():
+        async for packet in inbound_packet_channels[1]:
+            logger.info(f"Received packet from {packet.sender_endpoint}: {packet}")
+
+    class ListenService(Service):
+        async def run(self) -> None:
+            logger.info("starting listen service")
+            services = [
+                datagram_receiver, packet_decoder, # as_service(log_received_packets)
+            ]
+            for service in services:
+                self.manager.run_daemon_child_service(service)
+            self.manager.run_daemon_task(log_received_packets)
+            await self.manager.wait_finished()
+
+    with sock:
+        async with background_trio_service(ListenService()) as manager:
+            await manager.wait_finished()
+
+
+# TODO: This should probably delegate to either CrawlV5, or CrawlV5_1
 async def do_crawl(boot_info: BootInfo) -> None:
     logger.info("Crawling!")
+
+    # TODO: use these...
+    boot_info.port: int
+    boot_info.bootnodes: Tuple[ENRAPI]
+    boot_info.private_key: Optional[keys.PrivateKey]
+    boot_info.listen_on
+
+    # TODO: Use v5 or v5.1 where appropriate
+    # TODO: support UPNP?
+
+    sock = trio.socket.socket(
+        family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM
+    )
+    await sock.bind(("0.0.0.0", 30306))
+
+    # Bind to a socket and try to bond with a single bootnode
+
+    test_bootnode = DEFAULT_BOOTNODES[0]
+    logger.info(f"Attempting to bond with: {test_bootnode}")
+
+    ping = PingMessage(request_id=0, enr_seq=0)
+
+    # datagram = packet.to_wire_bytes()
+    # send_datagram(sock, datagram, endpoint)
+
+    # you need a Packer, to handle handshakes...
+    # a Packer requires an ENRDatabaseAPI...
+        # I might actually want to use a database, if you re-crawl it might be nice not to
+        # have to handshake all over again?
+    # also a message type registry?
+
+    try:
+        with trio.fail_after(10):
+            pass
+            # inbound_message = await self.message_dispatcher.request(node_id, ping)
+    except trio.TooSlowError:
+        logger.error("No response from bootnode")

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -1,8 +1,7 @@
 import logging
 import os
 
-from async_service import Service, ServiceAPI, as_service, background_trio_service
-import trio
+from async_service import ServiceAPI, background_trio_service
 
 from ddht.boot_info import BootInfo
 from ddht.constants import ProtocolVersion
@@ -30,7 +29,7 @@ async def do_main(boot_info: BootInfo) -> None:
 async def do_crawl(boot_info: BootInfo) -> None:
 
     if boot_info.protocol_version is not ProtocolVersion.v5:
-        raise Exception(f"Currently crawling is only supported on the v5 network.")
+        raise Exception("Currently crawling is only supported on the v5 network.")
 
     crawler = Crawler(concurrency=4, boot_info=boot_info)
 

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -6,7 +6,7 @@ from typing import Any
 from eth_enr import ENR
 
 from ddht import __version__
-from ddht.cli_commands import do_crawl, do_main
+from ddht.cli_commands import do_crawl, do_listen, do_main
 from ddht.constants import ProtocolVersion
 
 parser = argparse.ArgumentParser(description="Discovery V5 DHT")
@@ -142,3 +142,13 @@ crawl_parser = subparser.add_parser(
     help='Attempts to bond with as many nodes as possible and dumps all found ENRs',
 )
 crawl_parser.set_defaults(func=do_crawl)
+
+
+#
+# Listen Subcommand
+#
+listen_parser = subparser.add_parser(
+    'listen',
+    help='Does nothing but bind to a port and log incoming messages',
+)
+listen_parser.set_defaults(func=do_listen)

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -6,7 +6,7 @@ from typing import Any
 from eth_enr import ENR
 
 from ddht import __version__
-from ddht.cli_commands import do_main
+from ddht.cli_commands import do_crawl, do_main
 from ddht.constants import ProtocolVersion
 
 parser = argparse.ArgumentParser(description="Discovery V5 DHT")
@@ -132,3 +132,13 @@ jsonrpc_parser.add_argument(
     type=pathlib.Path,
     help="Path where the IPC socket will be opened for serving JSON-RPC",
 )
+
+
+#
+# Crawl Subcommand
+#
+crawl_parser = subparser.add_parser(
+    'crawl',
+    help='Attempts to bond with as many nodes as possible and dumps all found ENRs',
+)
+crawl_parser.set_defaults(func=do_crawl)

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -138,7 +138,7 @@ jsonrpc_parser.add_argument(
 # Crawl Subcommand
 #
 crawl_parser = subparser.add_parser(
-    'crawl',
-    help='Attempts to bond with as many nodes as possible and dumps all found ENRs',
+    "crawl",
+    help="Attempts to bond with as many nodes as possible and dumps all found ENRs",
 )
 crawl_parser.set_defaults(func=do_crawl)

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -6,7 +6,7 @@ from typing import Any
 from eth_enr import ENR
 
 from ddht import __version__
-from ddht.cli_commands import do_crawl, do_listen, do_main
+from ddht.cli_commands import do_crawl, do_main
 from ddht.constants import ProtocolVersion
 
 parser = argparse.ArgumentParser(description="Discovery V5 DHT")
@@ -142,13 +142,3 @@ crawl_parser = subparser.add_parser(
     help='Attempts to bond with as many nodes as possible and dumps all found ENRs',
 )
 crawl_parser.set_defaults(func=do_crawl)
-
-
-#
-# Listen Subcommand
-#
-listen_parser = subparser.add_parser(
-    'listen',
-    help='Does nothing but bind to a port and log incoming messages',
-)
-listen_parser.set_defaults(func=do_listen)

--- a/ddht/datagram.py
+++ b/ddht/datagram.py
@@ -54,6 +54,12 @@ async def DatagramReceiver(
                 return
 
 
+async def send_datagram(sock, datagram, endpoint):
+    logger = logging.getLogger("ddht.DatagramSender")
+    logger.debug("Sending %d bytes to %s", len(datagram), endpoint)
+    await sock.sendto(datagram, (inet_ntoa(endpoint.ip_address), endpoint.port))
+
+
 @as_service
 async def DatagramSender(
     manager: ManagerAPI,
@@ -61,9 +67,7 @@ async def DatagramSender(
     sock: SocketType,
 ) -> None:
     """Take datagrams from a channel and send them via a socket to their designated receivers."""
-    logger = logging.getLogger("ddht.DatagramSender")
 
     async with outbound_datagram_receive_channel:
         async for datagram, endpoint in outbound_datagram_receive_channel:
-            logger.debug("Sending %d bytes to %s", len(datagram), endpoint)
-            await sock.sendto(datagram, (inet_ntoa(endpoint.ip_address), endpoint.port))
+            await send_datagram(sock, datagram, endpoint)

--- a/ddht/datagram.py
+++ b/ddht/datagram.py
@@ -54,7 +54,7 @@ async def DatagramReceiver(
                 return
 
 
-async def send_datagram(sock, datagram, endpoint):
+async def send_datagram(sock: SocketType, datagram: bytes, endpoint: Endpoint) -> None:
     logger = logging.getLogger("ddht.DatagramSender")
     logger.debug("Sending %d bytes to %s", len(datagram), endpoint)
     await sock.sendto(datagram, (inet_ntoa(endpoint.ip_address), endpoint.port))

--- a/ddht/datagram.py
+++ b/ddht/datagram.py
@@ -68,7 +68,6 @@ async def DatagramSender(
     sock: SocketType,
 ) -> None:
     """Take datagrams from a channel and send them via a socket to their designated receivers."""
-
     async with outbound_datagram_receive_channel:
         async for datagram, endpoint in outbound_datagram_receive_channel:
             await send_datagram(sock, datagram, endpoint)

--- a/ddht/datagram.py
+++ b/ddht/datagram.py
@@ -10,6 +10,8 @@ from trio.socket import SocketType
 from ddht.constants import DISCOVERY_DATAGRAM_BUFFER_SIZE
 from ddht.endpoint import Endpoint
 
+dg_sender_logger = logging.getLogger("ddht.DatagramSender")
+
 
 #
 # Data structures
@@ -55,8 +57,7 @@ async def DatagramReceiver(
 
 
 async def send_datagram(sock: SocketType, datagram: bytes, endpoint: Endpoint) -> None:
-    logger = logging.getLogger("ddht.DatagramSender")
-    logger.debug("Sending %d bytes to %s", len(datagram), endpoint)
+    dg_sender_logger.debug("Sending %d bytes to %s", len(datagram), endpoint)
     await sock.sendto(datagram, (inet_ntoa(endpoint.ip_address), endpoint.port))
 
 

--- a/ddht/v5/client.py
+++ b/ddht/v5/client.py
@@ -1,0 +1,96 @@
+import logging
+
+from async_service import Service
+from eth_enr import ENRDatabaseAPI
+from eth_keys import keys
+import trio
+
+from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
+from ddht.datagram import (
+    DatagramReceiver,
+    DatagramSender,
+    InboundDatagram,
+    OutboundDatagram,
+)
+from ddht.v5.channel_services import (
+    InboundPacket,
+    OutboundPacket,
+    PacketDecoder,
+    PacketEncoder,
+)
+from ddht.v5.message_dispatcher import MessageDispatcher
+from ddht.v5.messages import v5_registry
+from ddht.v5.packer import Packer
+
+
+class Client(Service):
+    logger = logging.getLogger("ddht.Client")
+
+    def __init__(
+        self, local_private_key: keys.PrivateKey, enr_db: ENRDatabaseAPI, node_id, sock
+    ) -> None:
+
+        self.enr_db = enr_db
+
+        outbound_datagram_channels = trio.open_memory_channel[OutboundDatagram](0)
+        inbound_datagram_channels = trio.open_memory_channel[InboundDatagram](0)
+        outbound_packet_channels = trio.open_memory_channel[OutboundPacket](0)
+        inbound_packet_channels = trio.open_memory_channel[InboundPacket](0)
+        outbound_message_channels = trio.open_memory_channel[AnyOutboundMessage](0)
+        inbound_message_channels = trio.open_memory_channel[AnyInboundMessage](0)
+
+        # types ignored due to https://github.com/ethereum/async-service/issues/5
+        datagram_sender = DatagramSender(  # type: ignore
+            outbound_datagram_channels[1], sock
+        )
+        datagram_receiver = DatagramReceiver(  # type: ignore
+            sock, inbound_datagram_channels[0]
+        )
+
+        packet_encoder = PacketEncoder(  # type: ignore
+            outbound_packet_channels[1], outbound_datagram_channels[0]
+        )
+        packet_decoder = PacketDecoder(  # type: ignore
+            inbound_datagram_channels[1], inbound_packet_channels[0]
+        )
+
+        self.packer = Packer(
+            local_private_key=local_private_key.to_bytes(),
+            local_node_id=node_id,
+            enr_db=self.enr_db,
+            message_type_registry=v5_registry,
+            inbound_packet_receive_channel=inbound_packet_channels[1],
+            inbound_message_send_channel=inbound_message_channels[0],
+            outbound_message_receive_channel=outbound_message_channels[1],
+            outbound_packet_send_channel=outbound_packet_channels[0],
+        )
+
+        self.message_dispatcher = MessageDispatcher(
+            enr_db=self.enr_db,
+            inbound_message_receive_channel=inbound_message_channels[1],
+            outbound_message_send_channel=outbound_message_channels[0],
+        )
+
+        self.services = (
+            packet_encoder,
+            datagram_sender,
+            datagram_receiver,
+            packet_decoder,
+            self.packer,
+            self.message_dispatcher,
+        )
+
+        self.outbound_message_send_channel = outbound_message_channels[0]
+
+    def discard_peer(self, remote_node_id) -> None:
+        """
+        Signals that we intend not to send any more messages to the remote peer, stops the
+        service associated with that peer.
+        """
+        if remote_node_id in self.packer.managed_peer_packers:
+            self.packer.managed_peer_packers[remote_node_id].manager.cancel()
+
+    async def run(self) -> None:
+        for service in self.services:
+            self.manager.run_daemon_child_service(service)
+        await self.manager.wait_finished()

--- a/ddht/v5/client.py
+++ b/ddht/v5/client.py
@@ -3,6 +3,7 @@ import logging
 from async_service import Service
 from eth_enr import ENRDatabaseAPI
 from eth_keys import keys
+from eth_typing import NodeID
 import trio
 
 from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
@@ -27,7 +28,11 @@ class Client(Service):
     logger = logging.getLogger("ddht.Client")
 
     def __init__(
-        self, local_private_key: keys.PrivateKey, enr_db: ENRDatabaseAPI, node_id, sock
+        self,
+        local_private_key: keys.PrivateKey,
+        enr_db: ENRDatabaseAPI,
+        node_id: NodeID,
+        sock: trio.socket.SocketType,
     ) -> None:
 
         self.enr_db = enr_db
@@ -82,7 +87,7 @@ class Client(Service):
 
         self.outbound_message_send_channel = outbound_message_channels[0]
 
-    def discard_peer(self, remote_node_id) -> None:
+    def discard_peer(self, remote_node_id: NodeID) -> None:
         """
         Signals that we intend not to send any more messages to the remote peer, stops the
         service associated with that peer.

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from typing import Iterator, Set, Tuple
+from typing import Iterator, Set, Tuple, cast
 
 from eth_enr import ENRAPI, ENRDB, ENRManager, default_identity_scheme_registry
 from eth_enr.exceptions import OldSequenceNumber
@@ -51,7 +51,9 @@ class Crawler(BaseApplication):
             10_000
         )
 
-    async def fetch_enr_bucket(self, remote_enr: ENRAPI, bucket: int) -> Tuple[ENRAPI]:
+    async def fetch_enr_bucket(
+        self, remote_enr: ENRAPI, bucket: int
+    ) -> Tuple[ENRAPI, ...]:
         peer_id = remote_enr.node_id
 
         logger.debug(f"sending FindNode. nodeid={encode_hex(peer_id)} bucket={bucket}")

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-from typing import Iterator, Set, Tuple, cast
+from typing import Iterator, Set, Tuple
 
 from eth_enr import ENRAPI, ENRDB, ENRManager, default_identity_scheme_registry
 from eth_enr.exceptions import OldSequenceNumber

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -13,7 +13,6 @@ from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
 from ddht.constants import DEFAULT_LISTEN
 from ddht.datagram import send_datagram, InboundDatagram, DatagramReceiver, OutboundDatagram, DatagramSender
 from ddht.v5.channel_services import InboundPacket, PacketDecoder, OutboundPacket, PacketEncoder
-from ddht.v5.constants import DEFAULT_BOOTNODES
 from ddht.v5.messages import PingMessage, v5_registry, FindNodeMessage
 from ddht.v5.message_dispatcher import MessageDispatcher
 from ddht.v5.packer import Packer
@@ -178,7 +177,6 @@ class Crawler(BaseApplication):
 
         # TODO: use these...
         boot_info.port: int
-        boot_info.bootnodes: Tuple[ENRAPI]
         boot_info.private_key: Optional[keys.PrivateKey]
         boot_info.listen_on
 
@@ -186,10 +184,7 @@ class Crawler(BaseApplication):
 
         # 1. Queue up some ENRs to be crawled
 
-        to_enr = lambda bootnode: ENR.from_repr(bootnode, default_identity_scheme_registry)
-        bootnodes = [to_enr(bootnode) for bootnode in DEFAULT_BOOTNODES[2:3]]
-
-        for bootnode in bootnodes:
+        for bootnode in boot_info.bootnodes:
             await self.schedule_enr_to_be_visited(bootnode)
 
         listen_on = boot_info.listen_on or DEFAULT_LISTEN

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -154,9 +154,7 @@ class Crawler(BaseApplication):
 
                 # we only send one packet per peer, so do some cleanup now or else we'll
                 # leak memory.
-                await self.packer.managed_peer_packers[
-                    remote_enr.node_id
-                ].manager.stop()
+                self.packer.managed_peer_packers[remote_enr.node_id].manager.cancel()
 
         except trio.TooSlowError:
             logger.debug(
@@ -206,6 +204,8 @@ class Crawler(BaseApplication):
 
     async def schedule_enr_to_be_visited(self, enr):
         if enr.node_id in self.seen_nodeids:
+            # In order to be nicer on the network only send a single packet to each
+            # remote node.
             return
 
         if IP_V4_ADDRESS_ENR_KEY not in enr:

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -4,6 +4,7 @@ import math
 import random
 import secrets
 from socket import inet_aton
+from typing import Iterator, Set
 
 from async_service import Service, background_trio_service
 from async_service.exceptions import DaemonTaskExit
@@ -44,8 +45,6 @@ from ddht.v5.channel_services import (
 from ddht.v5.message_dispatcher import MessageDispatcher
 from ddht.v5.messages import FindNodeMessage, PingMessage, v5_registry
 from ddht.v5.packer import Packer
-
-from typing import Iterator, Set
 
 logger = logging.getLogger("crawler")
 

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -241,7 +241,7 @@ class Crawler(BaseApplication):
 
         listen_on = boot_info.listen_on or DEFAULT_LISTEN
         logger.info(f"About to listen. bind={listen_on}:{boot_info.port}")
-        await self.sock.bind(("0.0.0.0", boot_info.port))
+        await self.sock.bind((str(listen_on), boot_info.port))
 
         with self.sock:
             for service in self.services:

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -198,23 +198,24 @@ class Crawler(BaseApplication):
             await self.schedule_enr_to_be_visited(bootnode)
 
         listen_on = boot_info.listen_on or DEFAULT_LISTEN
-        logger.info(f"about to listen. bind={listen_on}:{boot_info.port}")
+        logger.info(f"about to bind to port. bind={listen_on}:{boot_info.port}")
         await self.sock.bind((str(listen_on), boot_info.port))
 
-        with self.sock:
-            self.manager.run_daemon_child_service(self.client)
+        try:
+            with self.sock:
+                self.manager.run_daemon_child_service(self.client)
 
-            for _ in range(self.concurrency):
-                self.manager.run_daemon_task(self.read_from_queue_until_done)
+                for _ in range(self.concurrency):
+                    self.manager.run_daemon_task(self.read_from_queue_until_done)
 
-            # When it is time to quit one of the `read_from_queue_until_done` tasks will
-            # notice and trigger a shutdown.
-            await self.manager.wait_finished()
-
-        logger.info(
-            f"scaning finished. found_peers={len(self.seen_nodeids)} "
-            f"responsive_peers={len(self.responsive_peers)} "
-        )
+                # When it is time to quit one of the `read_from_queue_until_done` tasks will
+                # notice and trigger a shutdown.
+                await self.manager.wait_finished()
+        finally:
+            logger.info(
+                f"scaning finished. found_peers={len(self.seen_nodeids)} "
+                f"responsive_peers={len(self.responsive_peers)} "
+            )
 
 
 class ActiveTaskCounter:

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -111,6 +111,10 @@ class Crawler(BaseApplication):
                     self.responsive_peers.add(peerid)
                     consecutive_empty_buckets = 0
 
+                # as we get deeper into the peer's routing table the chance that there are
+                # any peers in the given bucket decreases exponentially. we save some time
+                # by moving on to the next peer once we notice that the buckets have
+                # started to think out.
                 if consecutive_empty_buckets >= 5:
                     return
 

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -1,0 +1,283 @@
+import logging
+import math
+from socket import inet_aton
+import secrets
+import trio
+from async_service import Service, background_trio_service
+
+from ddht.app import BaseApplication
+
+from ddht.v5.app import get_local_private_key
+from eth_enr import ENRDB, default_identity_scheme_registry, ENRManager, ENR, UnsignedENR
+from ddht.base_message import AnyInboundMessage, AnyOutboundMessage
+from ddht.constants import DEFAULT_LISTEN
+from ddht.datagram import send_datagram, InboundDatagram, DatagramReceiver, OutboundDatagram, DatagramSender
+from ddht.v5.channel_services import InboundPacket, PacketDecoder, OutboundPacket, PacketEncoder
+from ddht.v5.constants import DEFAULT_BOOTNODES
+from ddht.v5.messages import PingMessage, v5_registry, FindNodeMessage
+from ddht.v5.message_dispatcher import MessageDispatcher
+from ddht.v5.packer import Packer
+from ddht.endpoint import Endpoint
+
+from eth_keys import keys
+from eth_utils import decode_hex, encode_hex
+from eth_enr.exceptions import OldSequenceNumber
+from trio.lowlevel import ParkingLot
+from ddht.exceptions import UnexpectedMessage
+from ddht.constants import IP_V4_ADDRESS_ENR_KEY
+from async_service.exceptions import DaemonTaskExit
+
+from ddht.boot_info import BootInfo
+
+import contextvars
+import random
+
+
+logger = logging.getLogger("crawler")
+
+
+current_task = contextvars.ContextVar('current_task')
+
+
+def get_current_task():
+    if current_task.get(None) is None:
+        random_id = hex(random.getrandbits(16))
+        current_task.set(random_id)
+
+    return current_task.get()
+
+
+class Crawler(BaseApplication):
+    def __init__(self, concurrency, boot_info):
+        super().__init__(boot_info)
+        self.concurrency = concurrency
+
+    async def run(self) -> None:
+        logger.info("Crawling!")
+        await do_crawl(self._boot_info)
+
+
+async def do_crawl(boot_info: BootInfo) -> None:
+
+    # TODO: use these...
+    boot_info.port: int
+    boot_info.bootnodes: Tuple[ENRAPI]
+    boot_info.private_key: Optional[keys.PrivateKey]
+    boot_info.listen_on
+
+    # TODO: support UPNP?
+
+    sock = trio.socket.socket(
+        family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM
+    )
+
+    enr_db = ENRDB(dict(), default_identity_scheme_registry)
+
+    local_private_key = get_local_private_key(boot_info)
+
+    enr_manager = ENRManager(private_key=local_private_key, enr_db=enr_db)
+    enr_manager.update((b"udp", boot_info.port))
+
+    outbound_datagram_channels = trio.open_memory_channel[OutboundDatagram](0)
+    inbound_datagram_channels = trio.open_memory_channel[InboundDatagram](0)
+    outbound_packet_channels = trio.open_memory_channel[OutboundPacket](0)
+    inbound_packet_channels = trio.open_memory_channel[InboundPacket](0)
+    outbound_message_channels = trio.open_memory_channel[AnyOutboundMessage](0)
+    inbound_message_channels = trio.open_memory_channel[AnyInboundMessage](0)
+
+    datagram_sender = DatagramSender(  # type: ignore
+        outbound_datagram_channels[1], sock
+    )
+    datagram_receiver = DatagramReceiver(  # type: ignore
+        sock, inbound_datagram_channels[0]
+    )
+
+    packet_encoder = PacketEncoder(  # type: ignore
+        outbound_packet_channels[1], outbound_datagram_channels[0]
+    )
+    packet_decoder = PacketDecoder(  # type: ignore
+        inbound_datagram_channels[1], inbound_packet_channels[0]
+    )
+
+    packer = Packer(
+        local_private_key=local_private_key.to_bytes(),
+        local_node_id=enr_manager.enr.node_id,
+        enr_db=enr_db,
+        message_type_registry=v5_registry,
+        inbound_packet_receive_channel=inbound_packet_channels[1],
+        inbound_message_send_channel=inbound_message_channels[0],
+        outbound_message_receive_channel=outbound_message_channels[1],
+        outbound_packet_send_channel=outbound_packet_channels[0],
+    )
+
+    message_dispatcher = MessageDispatcher(
+        enr_db=enr_db,
+        inbound_message_receive_channel=inbound_message_channels[1],
+        outbound_message_send_channel=outbound_message_channels[0],
+    )
+
+    services = (
+        packet_encoder, datagram_sender,
+        datagram_receiver, packet_decoder,
+        packer,
+        message_dispatcher,
+    )
+
+    CONCURRENCY = 32
+    queue = ENRQueue(CONCURRENCY)
+
+    # 1. Queue up some ENRs to be crawled
+
+    seen_nodeids = set()
+
+    async def queue_enr_to_be_visited(enr):
+        task = get_current_task()
+
+        if enr.node_id in seen_nodeids:
+            return
+
+        if IP_V4_ADDRESS_ENR_KEY not in enr:
+            logger.info(f"[{task}] Dropping ENR without IP address enr={enr} kv={enr.items()}")
+            return
+
+        seen_nodeids.add(enr.node_id)
+
+        try:
+            enr_db.set_enr(enr)
+        except OldSequenceNumber:
+            logger.info(f"[{task}] Dropping old ENR. enr={enr} kv={enr.items()}")
+            return
+
+        logger.info(f"[{task}] Found ENR. count={len(seen_nodeids)} enr={enr} kv={enr.items()}")
+
+        await queue.send(enr)
+
+    to_enr = lambda bootnode: ENR.from_repr(bootnode, default_identity_scheme_registry)
+    bootnodes = [to_enr(bootnode) for bootnode in DEFAULT_BOOTNODES[2:3]]
+
+    for bootnode in bootnodes:
+        await queue_enr_to_be_visited(bootnode)
+
+    bad_enr_count = 0
+
+    async def visit_enr(remote_enr):
+        nonlocal bad_enr_count
+
+        task = get_current_task()
+
+        logger.info(f"[{task}] sending FindNode(256). nodeid={encode_hex(remote_enr.node_id)}")
+        try:
+            with trio.fail_after(2):
+                find_node = FindNodeMessage(request_id=0, distance=256)
+
+                responses = await message_dispatcher.request_nodes(
+                    remote_enr.node_id, find_node
+                )
+
+                logger.info(f"[{task}] successful handshake and response from peer.  nodeid={encode_hex(remote_enr.node_id)} enr={remote_enr}")
+
+                for resp in responses:
+                    enr_count = resp.message.total
+                    received_enrs = resp.message.enrs
+                    logger.info(f"[{task}] Received response. enr_count={enr_count}")
+
+                    for enr in received_enrs:
+                        await queue_enr_to_be_visited(enr)
+
+                # we only send one packet per peer, so do some cleanup now or else we'll
+                # leak memory.
+                await packer.managed_peer_packers[remote_enr.node_id].manager.stop()
+
+        except trio.TooSlowError:
+            logger.error(f"[{task}] no response from peer. nodeid={encode_hex(remote_enr.node_id)} enr={remote_enr}")
+            bad_enr_count += 1
+        except UnexpectedMessage as error:
+            # TODO: Nodes sometimes send us Nodes messages with an unexpectedly large
+            # number of peers. 12 or 15 of them. We should probably accept these messages!
+            logger.exception("[{task}] Received a bad message from the peer.  nodeid={encode_hex(remote_enr.node_id)} enr={remote_enr}")
+            bad_enr_count += 1
+
+    async def visitor(manager):
+        task = get_current_task()
+        async for enr in queue:
+            await visit_enr(enr)
+        await manager.stop()
+
+    class CrawlService(Service):
+        async def run(self) -> None:
+            for service in services:
+                self.manager.run_daemon_child_service(service)
+            for _ in range(CONCURRENCY):
+                self.manager.run_daemon_task(visitor, self.manager)
+            await self.manager.wait_finished()
+
+    listen_on = boot_info.listen_on or DEFAULT_LISTEN
+    logger.info(f"About to listen. bind={listen_on}:{boot_info.port}")
+    await sock.bind(("0.0.0.0", boot_info.port))
+
+    with sock:
+        async with background_trio_service(CrawlService()) as manager:
+            await manager.wait_finished()
+
+    successes = len(seen_nodeids) - bad_enr_count
+    logger.info(f"Finished crawling. found_enrs={len(seen_nodeids)} bad_enrs={bad_enr_count} successful_connects={successes}")
+
+
+class ENRQueue:
+    """
+    The script should quit when there is nothing left to crawl.
+
+    However, it can't quit when the ENR queue is empty, because the ENR queue might
+    be temporarily empty while some packets are still in-flight.
+
+    It is time to quit when every coro is waiting on a new ENR from the queue. Not only is
+    the queue empty, but there is no work in progress.
+
+    Note that this class takes no responsibility for shutting down some corors if one
+    of them crashes. If a coro crashes then this class will cause the others to hang
+    forever, so you probably want to put them into some kind of nursury which handles
+    cancellation.
+    """
+    logger = logging.getLogger("enrqueue")
+
+    def __init__(self, concurrency_count):
+        self.lot = ParkingLot()
+        self.concurrency_count = concurrency_count
+        self.done = trio.Event()
+
+        self._send, self._recv = trio.open_memory_channel[ENR](math.inf)
+
+    async def send(self, enr: ENR):
+        if self.done.is_set():
+            raise Exception('cannot add ENR, Queue has already finished')
+
+        await self._send.send(enr)
+        self.lot.unpark_all()
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        task = get_current_task()
+
+        if self.done.is_set():
+            raise Exception(f'[{task}] cannot add ENR, Queue has already finished')
+
+        while True:
+            try:
+                return self._recv.receive_nowait()
+            except trio.WouldBlock:
+                pass
+
+            if len(self.lot) + 1 >= self.concurrency_count:
+                # Every coro is waiting in new data. That means we're done!
+                self.done.set()
+                self.logger.debug(f'[{task}] exiting because everyone is waiting.')
+                raise StopAsyncIteration
+
+            # wait for more data to come in.
+            await self.lot.park()
+
+            if self.done.is_set():
+                self.logger.debug(f'[{task}] exiting because someone else decided it was time')
+                raise StopAsyncIteration

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -175,14 +175,8 @@ class Crawler(BaseApplication):
 
         boot_info = self._boot_info
 
-        # TODO: use these...
-        boot_info.port: int
-        boot_info.private_key: Optional[keys.PrivateKey]
-        boot_info.listen_on
-
-        # TODO: support UPNP?
-
-        # 1. Queue up some ENRs to be crawled
+        if boot_info.is_upnp_enabled:
+            logger.info("UPNP will not be used; crawling does not require listening for incoming connections.")
 
         for bootnode in boot_info.bootnodes:
             await self.schedule_enr_to_be_visited(bootnode)


### PR DESCRIPTION
Implements #93.

Starting at the bootnodes, recursively asks for the contents of each node's routing table and then asks the found nodes for *their* routing tables. Logs every found ENR; also logs which peers are and aren't responsive.

#### Cute Animal Picture

![crawling-sloth](https://user-images.githubusercontent.com/466333/96202788-f76fe480-0f14-11eb-8e4c-17edd4b278ce.png)
