### PR TITLE
Pin rlp library to fix dependency problems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,8 @@ setup(
         "lru-dict>=1.1.6,<2.0",
         "plyvel>=1.2.0,<1.3",
         "py-evm==0.3.0a19",
-        "rlp>=2.0.0a1,<3.0.0",
+        # TODO: unpin once the dependency problems are resolved
+        "rlp==2.0.0a1",
         "trio>=0.16.0,<0.17",
         "trio-typing>=0.5.0,<0.6",
         "upnp-port-forward>=0.1.1,<0.2",


### PR DESCRIPTION
## What was wrong?

Currently the `rlp` library has some dependency issues.

## How was it fixed?

Pin to the `2.0.0a1` which currently seems to be working.


#### Cute Animal Picture

![unlikely-animal-friendships-8](https://user-images.githubusercontent.com/824194/95619317-abf89a80-0a2b-11eb-8164-b055c86bbf02.jpeg)

