### PR TITLE
Rename get_enr -> lookup_enr

### DIFF
--- a/ddht/exceptions.py
+++ b/ddht/exceptions.py
@@ -44,3 +44,11 @@ class DuplicateProtocol(BaseDDHTError):
     """
 
     pass
+
+
+class EmptyFindNodesResponse(BaseDDHTError):
+    """
+    Raised when we ask a remote node for its ENR and it returns nothing.
+    """
+
+    pass

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -491,7 +491,7 @@ class NetworkAPI(ServiceAPI):
         ...
 
     @abstractmethod
-    async def get_enr(
+    async def lookup_enr(
         self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
     ) -> ENRAPI:
         ...

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -192,7 +192,9 @@ class Network(Service, NetworkAPI):
         enrs = await self.find_nodes(node_id, 0, endpoint=endpoint)
         if not enrs:
             raise Exception("Invalid response")
-        # This reduce accounts for
+
+        # Assuming we're given enrs for a single node, this reduce returns the enr for
+        # that node with the highest sequence number
         return _reduce_enrs(enrs)[0]
 
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -110,7 +110,7 @@ class Network(Service, NetworkAPI):
             return False
 
         try:
-            enr = await self.get_enr(node_id, enr_seq=pong.enr_seq, endpoint=endpoint)
+            enr = await self.lookup_enr(node_id, enr_seq=pong.enr_seq, endpoint=endpoint)
         except trio.EndOfChannel:
             self.logger.debug(
                 "Bonding with %s timed out during ENR retrieval",
@@ -171,7 +171,7 @@ class Network(Service, NetworkAPI):
         )
         return response.message.payload
 
-    async def get_enr(
+    async def lookup_enr(
         self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
     ) -> ENRAPI:
         try:

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -16,7 +16,7 @@ import trio
 from ddht._utils import every, humanize_node_id
 from ddht.constants import ROUTING_TABLE_BUCKET_SIZE
 from ddht.endpoint import Endpoint
-from ddht.exceptions import DuplicateProtocol
+from ddht.exceptions import DuplicateProtocol, EmptyFindNodesResponse
 from ddht.kademlia import (
     KademliaRoutingTable,
     compute_distance,
@@ -197,7 +197,8 @@ class Network(Service, NetworkAPI):
     ) -> ENRAPI:
         enrs = await self.find_nodes(node_id, 0, endpoint=endpoint)
         if not enrs:
-            raise Exception("Invalid response")
+            h_node_id = humanize_node_id(node_id)
+            raise EmptyFindNodesResponse(f"{h_node_id} did not return its ENR")
 
         # Assuming we're given enrs for a single node, this reduce returns the enr for
         # that node with the highest sequence number

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -176,15 +176,11 @@ class Network(Service, NetworkAPI):
     async def lookup_enr(
         self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
     ) -> ENRAPI:
-        try:
-            enr = self.enr_db.get_enr(node_id)
-        except KeyError:
+        enr = self.enr_db.get_enr(node_id)
+
+        if enr_seq > enr.sequence_number:
             enr = await self._fetch_enr(node_id, endpoint=endpoint)
             self.enr_db.set_enr(enr)
-        else:
-            if enr_seq > enr.sequence_number:
-                enr = await self._fetch_enr(node_id, endpoint=endpoint)
-                self.enr_db.set_enr(enr)
 
         return enr
 

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -110,7 +110,9 @@ class Network(Service, NetworkAPI):
             return False
 
         try:
-            enr = await self.lookup_enr(node_id, enr_seq=pong.enr_seq, endpoint=endpoint)
+            enr = await self.lookup_enr(
+                node_id, enr_seq=pong.enr_seq, endpoint=endpoint
+            )
         except trio.EndOfChannel:
             self.logger.debug(
                 "Bonding with %s timed out during ENR retrieval",
@@ -385,7 +387,7 @@ class Network(Service, NetworkAPI):
                         )
                     )
                 )
-                enr = await self.get_enr(
+                enr = await self.lookup_enr(
                     request.sender_node_id,
                     enr_seq=request.message.enr_seq,
                     endpoint=request.sender_endpoint,

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -168,7 +168,7 @@ async def test_network_lookup_many_enr_response(alice, alice_network, bob, bob_c
 
     second_enr = enr_manager.enr
 
-    async def return_normal_response():
+    async def return_duplicate_enr_response():
         async with bob.events.find_nodes_received.subscribe() as subscription:
             find_nodes = await subscription.receive()
 
@@ -180,7 +180,7 @@ async def test_network_lookup_many_enr_response(alice, alice_network, bob, bob_c
             )
 
     async with trio.open_nursery() as nursery:
-        nursery.start_soon(return_normal_response)
+        nursery.start_soon(return_duplicate_enr_response)
 
         enr = await alice_network.lookup_enr(bob.node_id)
         assert enr == second_enr  # the one with the highest sequence number

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -2,6 +2,7 @@ import collections
 from contextlib import AsyncExitStack
 import secrets
 
+from eth_enr import ENRManager
 from eth_enr.tools.factories import ENRFactory
 import pytest
 import trio
@@ -98,6 +99,91 @@ async def test_network_find_nodes_api(alice, bob):
         if enr.node_id != bob.node_id
     }
     assert response_distances == {256, 255}
+
+
+@pytest.fixture
+async def bob_client(alice, bob):
+    bob.enr_db.set_enr(alice.enr)
+    async with bob.client() as bob_client:
+        yield bob_client
+
+
+@pytest.fixture
+async def alice_network(alice):
+    async with alice.network() as alice_network:
+        yield alice_network
+
+
+@pytest.mark.trio
+async def test_network_lookup_empty_response(alice, alice_network, bob, bob_client):
+    async def return_empty_response():
+        async with bob.events.find_nodes_received.subscribe() as subscription:
+            find_nodes = await subscription.receive()
+
+            await bob_client.send_found_nodes(
+                alice.endpoint,
+                alice.node_id,
+                enrs=[],
+                request_id=find_nodes.message.request_id,
+            )
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(return_empty_response)
+
+        with pytest.raises(Exception):
+            await alice_network.lookup_enr(bob.node_id)
+
+
+@pytest.mark.trio
+async def test_network_lookup_normal_response(alice, alice_network, bob, bob_client):
+    async def return_normal_response():
+        async with bob.events.find_nodes_received.subscribe() as subscription:
+            find_nodes = await subscription.receive()
+
+            await bob_client.send_found_nodes(
+                alice.endpoint,
+                alice.node_id,
+                enrs=[bob.enr],
+                request_id=find_nodes.message.request_id,
+            )
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(return_normal_response)
+
+        enr = await alice_network.lookup_enr(bob.node_id)
+        assert enr == bob.enr
+
+
+@pytest.mark.trio
+async def test_network_lookup_many_enr_response(alice, alice_network, bob, bob_client):
+
+    enr_manager = ENRManager(private_key=bob.private_key, enr_db=bob.enr_db,)
+    enr_manager.update(
+        (b"udp", bob.endpoint.port), (b"ip", bob.endpoint.ip_address),
+    )
+
+    first_enr = enr_manager.enr
+
+    enr_manager.update((b"eth2", b"\x00\x00"))
+
+    second_enr = enr_manager.enr
+
+    async def return_normal_response():
+        async with bob.events.find_nodes_received.subscribe() as subscription:
+            find_nodes = await subscription.receive()
+
+            await bob_client.send_found_nodes(
+                alice.endpoint,
+                alice.node_id,
+                enrs=[second_enr, first_enr],
+                request_id=find_nodes.message.request_id,
+            )
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(return_normal_response)
+
+        enr = await alice_network.lookup_enr(bob.node_id)
+        assert enr == second_enr  # the one with the highest sequence number
 
 
 @pytest.mark.trio

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -7,7 +7,7 @@ from eth_enr.tools.factories import ENRFactory
 import pytest
 import trio
 
-from ddht.exceptions import DuplicateProtocol
+from ddht.exceptions import DuplicateProtocol, EmptyFindNodesResponse
 from ddht.kademlia import compute_log_distance
 from ddht.v5_1.abc import TalkProtocolAPI
 from ddht.v5_1.messages import FoundNodesMessage, TalkRequestMessage
@@ -130,7 +130,7 @@ async def test_network_lookup_empty_response(bob, alice_network, alice, bob_clie
         async with trio.open_nursery() as nursery:
             nursery.start_soon(return_empty_response)
 
-            with pytest.raises(Exception):
+            with pytest.raises(EmptyFindNodesResponse):
                 await alice_network.lookup_enr(bob.node_id, enr_seq=101)
 
 
@@ -168,6 +168,9 @@ async def test_network_lookup_many_enr_response(bob, alice_network, alice, bob_c
     enr_manager.update((b"eth2", b"\x00\x00"))
 
     second_enr = enr_manager.enr
+
+    # quick sanity check, if these are equal the next assertion would be testing nothing
+    assert first_enr != second_enr
 
     async def return_duplicate_enr_response():
         async with bob.events.find_nodes_received.subscribe() as subscription:


### PR DESCRIPTION
## What was wrong?

I use grep to navigate our codebases and having two methods called `get_enr` (`ENRDB.get_enr`) makes this codebase a little harder for me to navigate.

It feels weird for submit this because the right answer is to use better tools, but I don't think better tools exist for Python.

#### Cute Animal Picture

A tiny bird for a tiny PR

![tiny-bird](https://user-images.githubusercontent.com/466333/95823693-e93a8200-0ce2-11eb-8c4f-8f3fc9122cfa.jpg)
