### PR TITLE
Implement alexandria client

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -1,0 +1,43 @@
+from abc import abstractmethod
+from typing import Optional
+
+from eth_typing import NodeID
+
+from ddht.abc import RequestTrackerAPI
+from ddht.endpoint import Endpoint
+from ddht.v5_1.abc import NetworkAPI, TalkProtocolAPI
+from ddht.v5_1.alexandria.messages import PongMessage
+
+
+class AlexandriaClientAPI(TalkProtocolAPI):
+    network: NetworkAPI
+    request_tracker: RequestTrackerAPI
+
+    #
+    # Low Level Message Sending
+    #
+    @abstractmethod
+    async def send_ping(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        enr_seq: int,
+        request_id: Optional[bytes] = None,
+    ) -> bytes:
+        ...
+
+    @abstractmethod
+    async def send_pong(
+        self, node_id: NodeID, endpoint: Endpoint, *, enr_seq: int, request_id: bytes,
+    ) -> None:
+        ...
+
+    #
+    # High Level Request/Response
+    #
+    @abstractmethod
+    async def ping(
+        self, node_id: NodeID, endpoint: Optional[Endpoint] = None,
+    ) -> PongMessage:
+        ...

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -1,0 +1,143 @@
+from typing import Any, Optional, Set, Type
+
+from eth_typing import NodeID
+
+from ddht.endpoint import Endpoint
+from ddht.exceptions import DecodingError
+from ddht.request_tracker import RequestTracker
+from ddht.v5_1.abc import NetworkAPI
+from ddht.v5_1.alexandria.abc import AlexandriaClientAPI
+from ddht.v5_1.alexandria.constants import ALEXANDRIA_PROTOCOL_ID
+from ddht.v5_1.alexandria.messages import (
+    AlexandriaMessage,
+    PingMessage,
+    PongMessage,
+    TAlexandriaMessage,
+    decode_message,
+)
+from ddht.v5_1.alexandria.payloads import PingPayload, PongPayload
+
+
+class AlexandriaClient(AlexandriaClientAPI):
+    protocol_id = ALEXANDRIA_PROTOCOL_ID
+
+    _active_request_ids: Set[bytes]
+
+    def __init__(self, network: NetworkAPI) -> None:
+        self.network = network
+        self.request_tracker = RequestTracker()
+
+        self._active_request_ids = set()
+
+    #
+    # Request/Response message sending primatives
+    #
+    async def _send_request(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        message: AlexandriaMessage[Any],
+        *,
+        request_id: Optional[bytes] = None,
+    ) -> bytes:
+        data_payload = message.to_wire_bytes()
+        request_id = await self.network.client.send_talk_request(
+            node_id,
+            endpoint,
+            protocol=ALEXANDRIA_PROTOCOL_ID,
+            payload=data_payload,
+            request_id=request_id,
+        )
+        return request_id
+
+    async def _send_response(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        message: AlexandriaMessage[Any],
+        *,
+        request_id: bytes,
+    ) -> None:
+        data_payload = message.to_wire_bytes()
+        await self.network.client.send_talk_response(
+            node_id, endpoint, payload=data_payload, request_id=request_id,
+        )
+
+    async def _request(
+        self,
+        node_id: NodeID,
+        endpoint: Optional[Endpoint],
+        request: AlexandriaMessage[Any],
+        response_class: Type[TAlexandriaMessage],
+    ) -> TAlexandriaMessage:
+        #
+        # Request ID Shenanigans
+        #
+        # We need a subscription API for alexandria messages in order to be
+        # able to cleanly implement functionality like responding to ping
+        # messages with pong messages.
+        #
+        # We accomplish this by monitoring all TALKREQUEST and TALKRESPONSE
+        # messages that occur on the alexandria protocol. For TALKREQUEST based
+        # messages we can naively monitor incoming messages and match them
+        # against the protocol_id. For the TALKRESPONSE however, the only way
+        # for us to know that an incoming message belongs to this protocol is
+        # to match it against an in-flight request (which we implicitely know
+        # is part of the alexandria protocol).
+        #
+        # In order to do this, we need to know which request ids are active for
+        # Alexandria protocol messages. We do this by using a separate
+        # RequestTrackerAPI. The `request_id` for messages is still acquired
+        # from the core tracker located on the base protocol `ClientAPI`.  We
+        # then feed this into our local tracker, which allows us to query it
+        # upon receiving an incoming TALKRESPONSE to see if the response is to
+        # a message from this protocol.
+        request_id = self.network.client.request_tracker.get_free_request_id(node_id)
+        request_data = request.to_wire_bytes()
+        with self.request_tracker.reserve_request_id(node_id, request_id):
+            response_data = await self.network.talk(
+                node_id,
+                protocol=ALEXANDRIA_PROTOCOL_ID,
+                payload=request_data,
+                endpoint=endpoint,
+                request_id=request_id,
+            )
+
+        response = decode_message(response_data)
+        if type(response) is not response_class:
+            raise DecodingError(
+                f"Invalid response. expected={response_class}  got={type(response)}"
+            )
+        return response  # type: ignore
+
+    #
+    # Low Level Message Sending
+    #
+    async def send_ping(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        enr_seq: int,
+        request_id: Optional[bytes] = None,
+    ) -> bytes:
+        message = PingMessage(PingPayload(enr_seq))
+        return await self._send_request(
+            node_id, endpoint, message, request_id=request_id
+        )
+
+    async def send_pong(
+        self, node_id: NodeID, endpoint: Endpoint, *, enr_seq: int, request_id: bytes,
+    ) -> None:
+        message = PongMessage(PongPayload(enr_seq))
+        await self._send_response(node_id, endpoint, message, request_id=request_id)
+
+    #
+    # High Level Request/Response
+    #
+    async def ping(
+        self, node_id: NodeID, endpoint: Optional[Endpoint] = None,
+    ) -> PongMessage:
+        request = PingMessage(PingPayload(self.network.enr_manager.enr.sequence_number))
+        response = await self._request(node_id, endpoint, request, PongMessage)
+        return response

--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -1,0 +1,1 @@
+ALEXANDRIA_PROTOCOL_ID = b"alexandria"

--- a/tests/core/v5_1/alexandria/test_alexandria_client.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_client.py
@@ -1,0 +1,93 @@
+import pytest
+import trio
+
+from ddht.v5_1.alexandria.client import AlexandriaClient
+from ddht.v5_1.alexandria.messages import PingMessage, PongMessage, decode_message
+from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
+
+
+@pytest.mark.trio
+async def test_alexandria_api_send_ping(alice_network, bob, bob_network):
+    alexandria_client = AlexandriaClient(alice_network)
+
+    async with bob_network.dispatcher.subscribe(TalkRequestMessage) as subscription:
+        await alexandria_client.send_ping(bob.node_id, bob.endpoint, enr_seq=100)
+        with trio.fail_after(1):
+            talk_response = await subscription.receive()
+        message = decode_message(talk_response.message.payload)
+        assert isinstance(message, PingMessage)
+        assert message.payload.enr_seq == 100
+
+
+@pytest.mark.trio
+async def test_alexandria_api_send_pong(alice_network, bob, bob_network):
+    alexandria_client = AlexandriaClient(alice_network)
+
+    async with bob_network.dispatcher.subscribe(TalkResponseMessage) as subscription:
+        await alexandria_client.send_pong(
+            bob.node_id, bob.endpoint, enr_seq=100, request_id=b"\x01\x02"
+        )
+        with trio.fail_after(1):
+            talk_response = await subscription.receive()
+        message = decode_message(talk_response.message.payload)
+        assert isinstance(message, PongMessage)
+        assert message.payload.enr_seq == 100
+
+
+@pytest.mark.trio
+async def test_alexandria_api_ping_request_response(
+    alice_network, alice, bob, bob_network,
+):
+    alexandria_client = AlexandriaClient(alice_network)
+    alice_network.add_talk_protocol(alexandria_client)
+
+    bob_alexandria_client = AlexandriaClient(bob_network)
+    bob_network.add_talk_protocol(bob_alexandria_client)
+
+    async def _respond():
+        request = await subscription.receive()
+        await bob_alexandria_client.send_pong(
+            alice.node_id,
+            alice.endpoint,
+            enr_seq=bob.enr.sequence_number,
+            request_id=request.request_id,
+        )
+
+    async with bob_network.dispatcher.subscribe(TalkRequestMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(_respond)
+
+            with trio.fail_after(1):
+                pong_message = await alexandria_client.ping(bob.node_id, bob.endpoint)
+                assert isinstance(pong_message, PongMessage)
+                assert pong_message.payload.enr_seq == bob.enr.sequence_number
+
+
+@pytest.mark.trio
+async def test_alexandria_api_ping_request_response_request_id_mismatch(
+    alice_network, alice, bob, bob_network, autojump_clock,
+):
+    alexandria_client = AlexandriaClient(alice_network)
+    alice_network.add_talk_protocol(alexandria_client)
+
+    bob_alexandria_client = AlexandriaClient(bob_network)
+    bob_network.add_talk_protocol(bob_alexandria_client)
+
+    async def _respond_wrong_request_id():
+        await subscription.receive()
+        await bob_alexandria_client.send_pong(
+            alice.node_id,
+            alice.endpoint,
+            enr_seq=bob.enr.sequence_number,
+            request_id=alice_network.client.request_tracker.get_free_request_id(
+                bob.node_id
+            ),
+        )
+
+    async with bob_network.dispatcher.subscribe(TalkRequestMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(_respond_wrong_request_id)
+
+            with pytest.raises(trio.TooSlowError):
+                with trio.fail_after(1):
+                    await alexandria_client.ping(bob.node_id, bob.endpoint)

--- a/tests/core/v5_1/conftest.py
+++ b/tests/core/v5_1/conftest.py
@@ -23,3 +23,17 @@ async def bob(tester):
 @pytest.fixture
 async def driver(tester, alice, bob):
     return tester.session_pair(alice, bob)
+
+
+@pytest.fixture
+async def alice_network(alice, bob):
+    alice.enr_db.set_enr(bob.enr)
+    async with alice.network() as alice_network:
+        yield alice_network
+
+
+@pytest.fixture
+async def bob_network(alice, bob):
+    bob.enr_db.set_enr(alice.enr)
+    async with bob.network() as bob_network:
+        yield bob_network


### PR DESCRIPTION
Builds from #116 

## What was wrong?

For Alexandria we need a *low level* API for message sending.

## How was it fixed?

Implemented `AlexandriaClientAPI` which implements the low level message sending for `PingMessage` and `PongMessage`

#### Cute Animal Picture

![unlikely_animal_friendships_02](https://user-images.githubusercontent.com/824194/96028958-361f7500-0e17-11eb-85ee-6209cef8130c.jpg)

