### PR TITLE
Implement alexandria network api

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -16,6 +16,7 @@ from ddht.v5_1.abc import (
     PoolAPI,
     SessionAPI,
 )
+from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI
 from ddht.v5_1.envelope import InboundEnvelope, OutboundEnvelope
 from ddht.v5_1.messages import PingMessage, PongMessage
 from ddht.v5_1.packets import AnyPacket
@@ -45,6 +46,12 @@ class NodeAPI(ABC):
     def network(
         self, bootnodes: Collection[ENRAPI] = ()
     ) -> AsyncContextManager[NetworkAPI]:
+        ...
+
+    @abstractmethod
+    def alexandria(
+        self, network: Optional[NetworkAPI] = None
+    ) -> AsyncContextManager[AlexandriaNetworkAPI]:
         ...
 
 

--- a/ddht/tools/driver/node.py
+++ b/ddht/tools/driver/node.py
@@ -12,6 +12,9 @@ from eth_utils import humanize_hash
 from ddht.endpoint import Endpoint
 from ddht.tools.driver.abc import NodeAPI
 from ddht.v5_1.abc import ClientAPI, EventsAPI, NetworkAPI
+from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI
+from ddht.v5_1.alexandria.client import AlexandriaClient
+from ddht.v5_1.alexandria.network import AlexandriaNetwork
 from ddht.v5_1.client import Client
 from ddht.v5_1.events import Events
 from ddht.v5_1.network import Network
@@ -74,3 +77,19 @@ class Node(NodeAPI):
         async with background_trio_service(network):
             await client.wait_listening()
             yield network
+
+    @asynccontextmanager
+    async def alexandria(
+        self, network: Optional[NetworkAPI] = None,
+    ) -> AsyncIterator[AlexandriaNetworkAPI]:
+        if network is None:
+            async with self.network() as network:
+                alexandria = AlexandriaNetwork(AlexandriaClient(network))
+                network.add_talk_protocol(alexandria)
+                async with background_trio_service(alexandria):
+                    yield alexandria
+        else:
+            alexandria = AlexandriaNetwork(AlexandriaClient(network))
+            network.add_talk_protocol(alexandria)
+            async with background_trio_service(alexandria):
+                yield alexandria

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -1,0 +1,131 @@
+import logging
+from typing import AsyncContextManager, Optional, Type
+
+from async_service import Service
+from eth_enr import ENRManagerAPI
+from eth_typing import NodeID
+import trio
+
+from ddht.base_message import InboundMessage
+from ddht.endpoint import Endpoint
+from ddht.exceptions import DecodingError
+from ddht.subscription_manager import SubscriptionManager
+from ddht.v5_1.abc import NetworkAPI
+from ddht.v5_1.alexandria.abc import AlexandriaClientAPI, AlexandriaNetworkAPI
+from ddht.v5_1.alexandria.client import AlexandriaClient
+from ddht.v5_1.alexandria.messages import (
+    PingMessage,
+    TAlexandriaMessage,
+    decode_message,
+)
+from ddht.v5_1.alexandria.payloads import PongPayload
+from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
+
+
+class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
+    logger = logging.getLogger("ddht.Alexandria")
+
+    # Delegate to the AlexandriaClient for determining `protocol_id`
+    protocol_id = AlexandriaClient.protocol_id
+
+    _alexandria_client: AlexandriaClientAPI
+
+    def __init__(self, client: AlexandriaClientAPI) -> None:
+        self._alexandria_client = client
+
+        self.subscription_manager = SubscriptionManager()
+
+    @property
+    def network(self) -> NetworkAPI:
+        return self._alexandria_client.network
+
+    @property
+    def enr_manager(self) -> ENRManagerAPI:
+        return self._alexandria_client.network.enr_manager
+
+    def subscribe(
+        self,
+        message_type: Type[TAlexandriaMessage],
+        endpoint: Optional[Endpoint] = None,
+        node_id: Optional[NodeID] = None,
+    ) -> AsyncContextManager[
+        trio.abc.ReceiveChannel[InboundMessage[TAlexandriaMessage]]
+    ]:
+        return self.subscription_manager.subscribe(message_type, endpoint, node_id)  # type: ignore
+
+    async def run(self) -> None:
+        self.manager.run_daemon_task(self._feed_talk_requests)
+        self.manager.run_daemon_task(self._feed_talk_responses)
+        self.manager.run_daemon_task(self._pong_when_pinged)
+
+        await self.manager.wait_finished()
+
+    #
+    # High Level API
+    #
+    async def ping(
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
+    ) -> PongPayload:
+        response = await self._alexandria_client.ping(node_id, endpoint=endpoint)
+        return response.payload
+
+    #
+    # Long Running Processes
+    #
+    async def _pong_when_pinged(self) -> None:
+        async with self.subscribe(PingMessage) as subscription:
+            async for request in subscription:
+                await self._alexandria_client.send_pong(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    enr_seq=self.enr_manager.enr.sequence_number,
+                    request_id=request.request_id,
+                )
+
+    async def _feed_talk_requests(self) -> None:
+        async with self.network.client.dispatcher.subscribe(
+            TalkRequestMessage
+        ) as subscription:
+            async for request in subscription:
+                if request.message.protocol != self.protocol_id:
+                    continue
+
+                try:
+                    message = decode_message(request.message.payload)
+                except DecodingError:
+                    pass
+                else:
+                    self.subscription_manager.feed_subscriptions(
+                        InboundMessage(
+                            message=message,
+                            sender_node_id=request.sender_node_id,
+                            sender_endpoint=request.sender_endpoint,
+                            explicit_request_id=request.message.request_id,
+                        )
+                    )
+
+    async def _feed_talk_responses(self) -> None:
+        async with self.network.client.dispatcher.subscribe(
+            TalkResponseMessage
+        ) as subscription:
+            async for response in subscription:
+                is_known_request_id = self._alexandria_client.request_tracker.is_request_id_active(
+                    response.sender_node_id, response.request_id,
+                )
+                if not is_known_request_id:
+                    continue
+                elif not response.message.payload:
+                    continue
+
+                try:
+                    message = decode_message(response.message.payload)
+                except DecodingError:
+                    pass
+                else:
+                    self.subscription_manager.feed_subscriptions(
+                        InboundMessage(
+                            message=message,
+                            sender_node_id=response.sender_node_id,
+                            sender_endpoint=response.sender_endpoint,
+                        )
+                    )

--- a/tests/core/v5_1/alexandria/conftest.py
+++ b/tests/core/v5_1/alexandria/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.fixture
+async def alice_alexandria(alice, alice_network):
+    async with alice.alexandria(alice_network) as alice_alexandria:
+        yield alice_alexandria
+
+
+@pytest.fixture
+async def bob_alexandria(bob, bob_network):
+    async with bob.alexandria(bob_network) as bob_alexandria:
+        yield bob_alexandria

--- a/tests/core/v5_1/alexandria/test_subscriptions.py
+++ b/tests/core/v5_1/alexandria/test_subscriptions.py
@@ -1,0 +1,69 @@
+import pytest
+import trio
+
+from ddht.v5_1.alexandria.messages import PingMessage, PongMessage
+from ddht.v5_1.alexandria.payloads import PingPayload, PongPayload
+
+
+@pytest.mark.trio
+async def test_alexandria_subscription_via_talk_request(
+    alice_alexandria, alice, bob, bob_alexandria
+):
+    async with bob_alexandria.subscribe(PingMessage) as subscription:
+        await alice_alexandria.ping(bob.node_id)
+
+        with trio.fail_after(1):
+            message = await subscription.receive()
+
+        assert isinstance(message.message, PingMessage)
+        assert message.message.payload.enr_seq == alice.enr.sequence_number
+
+
+@pytest.mark.trio
+async def test_alexandria_subscription_via_talk_response(
+    alice_alexandria, alice, bob_alexandria
+):
+    async with bob_alexandria.subscribe(PongMessage) as subscription:
+        with trio.fail_after(1):
+            await bob_alexandria.ping(alice.node_id)
+
+            message = await subscription.receive()
+
+        assert isinstance(message.message, PongMessage)
+        assert message.message.payload.enr_seq == alice.enr.sequence_number
+
+
+@pytest.mark.trio
+async def test_alexandria_subscription_via_talk_request_protocol_mismatch(
+    alice_network, alice, bob, bob_alexandria, autojump_clock
+):
+    async with bob_alexandria.subscribe(PingMessage) as subscription:
+        message = PingMessage(PingPayload(alice.enr.sequence_number))
+        data_payload = message.to_wire_bytes()
+        await alice_network.client.send_talk_request(
+            bob.node_id,
+            bob.endpoint,
+            protocol=b"wrong-protocol-id",
+            payload=data_payload,
+        )
+        with pytest.raises(trio.TooSlowError):
+            with trio.fail_after(1):
+                message = await subscription.receive()
+
+
+@pytest.mark.trio
+async def test_alexandria_subscription_via_talk_response_unknown_request_id(
+    alice_network, alice, bob, bob_alexandria, autojump_clock
+):
+    async with bob_alexandria.subscribe(PongMessage) as subscription:
+        message = PongMessage(PongPayload(alice.enr.sequence_number))
+        data_payload = message.to_wire_bytes()
+        await alice_network.client.send_talk_response(
+            bob.node_id,
+            bob.endpoint,
+            payload=data_payload,
+            request_id=b"\x01\x02\x03",  # unknown/unexpected request_id
+        )
+        with pytest.raises(trio.TooSlowError):
+            with trio.fail_after(1):
+                message = await subscription.receive()


### PR DESCRIPTION
Builds on #116 and #117

## What was wrong?

Need a high level API for interacting with the Alexandria network

## How was it fixed?

Implemented `AlexandriaNetworkAPI`

This handles both high level message sending as well as the ability to subscribe to sub-protocol messages.


#### Cute Animal Picture

![Unusual-animal-friendships-11](https://user-images.githubusercontent.com/824194/96031310-6a486500-0e1a-11eb-8ad3-0ef1dbec0251.jpeg)

