### PR TITLE
Convert alexandria client to be a service api

### DIFF
--- a/ddht/_utils.py
+++ b/ddht/_utils.py
@@ -7,14 +7,17 @@ import socket
 from typing import (
     Any,
     AsyncGenerator,
+    AsyncIterator,
     Awaitable,
     Callable,
     Iterable,
     Optional,
     Tuple,
+    TypeVar,
     Union,
 )
 
+from async_generator import asynccontextmanager
 from eth_keys import keys
 from eth_typing import NodeID
 from eth_utils import humanize_hash
@@ -121,3 +124,11 @@ def get_open_port() -> int:
         port = s.getsockname()[1]
         s.close()
     return port
+
+
+TEnterValue = TypeVar("TEnterValue")
+
+
+@asynccontextmanager
+async def asyncnullcontext(enter_value: TEnterValue) -> AsyncIterator[TEnterValue]:
+    yield enter_value

--- a/ddht/tools/driver/_utils.py
+++ b/ddht/tools/driver/_utils.py
@@ -1,6 +1,7 @@
 import functools
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, AsyncIterator, Callable, Optional, TypeVar, cast
 
+from async_generator import asynccontextmanager
 import trio
 
 HANG_TIMEOUT = 10
@@ -16,3 +17,33 @@ def no_hang(fn: TCallable) -> TCallable:
             return await fn(*args, **kwargs)
 
     return cast(TCallable, wrapper)
+
+
+class NamedLock:
+    """
+    A thin wrapper around a lock that also attributes a *name* to the current
+    owner.  Used to make debugging tests easier when someone accidentally tries
+    to use two parts of the `NodeAPI` which cannot be used concurrently
+    (such as when both would try to open a socket on the same port).
+    """
+
+    _listen_lock: trio.Lock
+    _lock_owner: Optional[str]
+
+    def __init__(self) -> None:
+        self._listen_lock = trio.Lock()
+        self._lock_owner = None
+
+    @asynccontextmanager
+    async def acquire(self, owner: str) -> AsyncIterator[None]:
+        try:
+            self._listen_lock.acquire_nowait()
+        except trio.WouldBlock:
+            raise Exception(f"Locked: owner={self._lock_owner}  acquiring-for={owner}")
+        else:
+            self._lock_owner = owner
+            try:
+                yield
+            finally:
+                self._lock_owner = None
+                self._listen_lock.release()

--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -16,10 +16,24 @@ from ddht.v5_1.abc import (
     PoolAPI,
     SessionAPI,
 )
-from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI
+from ddht.v5_1.alexandria.abc import AlexandriaClientAPI, AlexandriaNetworkAPI
 from ddht.v5_1.envelope import InboundEnvelope, OutboundEnvelope
 from ddht.v5_1.messages import PingMessage, PongMessage
 from ddht.v5_1.packets import AnyPacket
+
+
+class AlexandriaNodeAPI(ABC):
+    @abstractmethod
+    def client(
+        self, network: Optional[NetworkAPI] = None
+    ) -> AsyncContextManager[AlexandriaClientAPI]:
+        ...
+
+    @abstractmethod
+    def network(
+        self, network: Optional[NetworkAPI] = None
+    ) -> AsyncContextManager[AlexandriaNetworkAPI]:
+        ...
 
 
 class NodeAPI(ABC):
@@ -27,6 +41,7 @@ class NodeAPI(ABC):
     enr: ENRAPI
     enr_db: ENRDatabaseAPI
     events: EventsAPI
+    alexandria: AlexandriaNodeAPI
 
     @property
     @abstractmethod
@@ -46,12 +61,6 @@ class NodeAPI(ABC):
     def network(
         self, bootnodes: Collection[ENRAPI] = ()
     ) -> AsyncContextManager[NetworkAPI]:
-        ...
-
-    @abstractmethod
-    def alexandria(
-        self, network: Optional[NetworkAPI] = None
-    ) -> AsyncContextManager[AlexandriaNetworkAPI]:
         ...
 
 

--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -1,0 +1,58 @@
+from typing import AsyncContextManager, AsyncIterator, Optional
+
+from async_generator import asynccontextmanager
+from async_service import background_trio_service
+
+from ddht._utils import asyncnullcontext
+from ddht.tools.driver._utils import NamedLock
+from ddht.tools.driver.abc import AlexandriaNodeAPI, NodeAPI
+from ddht.v5_1.abc import NetworkAPI
+from ddht.v5_1.alexandria.abc import AlexandriaClientAPI, AlexandriaNetworkAPI
+from ddht.v5_1.alexandria.client import AlexandriaClient
+from ddht.v5_1.alexandria.network import AlexandriaNetwork
+
+
+class AlexandriaNode(AlexandriaNodeAPI):
+    _lock: NamedLock
+
+    def __init__(self, node: NodeAPI) -> None:
+        self.node = node
+        self._lock = NamedLock()
+
+    @asynccontextmanager
+    async def client(
+        self, network: Optional[NetworkAPI] = None,
+    ) -> AsyncIterator[AlexandriaClientAPI]:
+        network_context: AsyncContextManager[NetworkAPI]
+
+        if network is None:
+            network_context = self.node.network()
+        else:
+            # unclear why the typing isn't work for `asyncnullcontext`
+            network_context = asyncnullcontext(network)  # type: ignore
+
+        async with self._lock.acquire("AlexandriaNode.client(...)"):
+            async with network_context as network:
+                alexandria_client = AlexandriaClient(network)
+                network.add_talk_protocol(alexandria_client)
+                async with background_trio_service(alexandria_client):
+                    yield alexandria_client
+
+    @asynccontextmanager
+    async def network(
+        self, network: Optional[NetworkAPI] = None,
+    ) -> AsyncIterator[AlexandriaNetworkAPI]:
+        network_context: AsyncContextManager[NetworkAPI]
+
+        if network is None:
+            network_context = self.node.network()
+        else:
+            # unclear why the typing isn't work for `asyncnullcontext`
+            network_context = asyncnullcontext(network)  # type: ignore
+
+        async with self._lock.acquire("AlexandriaNode.network(...)"):
+            async with network_context as network:
+                alexandria_network = AlexandriaNetwork(network)
+                network.add_talk_protocol(alexandria_network)
+                async with background_trio_service(alexandria_network):
+                    yield alexandria_network

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -1,10 +1,17 @@
-from typing import Any, Optional, Set, Type
+import functools
+import logging
+from typing import Any, AsyncContextManager, AsyncIterator, Optional, Set, Type
 
+from async_generator import asynccontextmanager
+from async_service import Service
 from eth_typing import NodeID
+import trio
 
+from ddht.base_message import InboundMessage
 from ddht.endpoint import Endpoint
 from ddht.exceptions import DecodingError
 from ddht.request_tracker import RequestTracker
+from ddht.subscription_manager import SubscriptionManager
 from ddht.v5_1.abc import NetworkAPI
 from ddht.v5_1.alexandria.abc import AlexandriaClientAPI
 from ddht.v5_1.alexandria.constants import ALEXANDRIA_PROTOCOL_ID
@@ -16,9 +23,13 @@ from ddht.v5_1.alexandria.messages import (
     decode_message,
 )
 from ddht.v5_1.alexandria.payloads import PingPayload, PongPayload
+from ddht.v5_1.constants import REQUEST_RESPONSE_TIMEOUT
+from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
 
 
-class AlexandriaClient(AlexandriaClientAPI):
+class AlexandriaClient(Service, AlexandriaClientAPI):
+    logger = logging.getLogger("ddht.AlexandriaClient")
+
     protocol_id = ALEXANDRIA_PROTOCOL_ID
 
     _active_request_ids: Set[bytes]
@@ -26,8 +37,18 @@ class AlexandriaClient(AlexandriaClientAPI):
     def __init__(self, network: NetworkAPI) -> None:
         self.network = network
         self.request_tracker = RequestTracker()
+        self.subscription_manager = SubscriptionManager()
 
         self._active_request_ids = set()
+
+    #
+    # Service API
+    #
+    async def run(self) -> None:
+        self.manager.run_daemon_task(self._feed_talk_requests)
+        self.manager.run_daemon_task(self._feed_talk_responses)
+
+        await self.manager.wait_finished()
 
     #
     # Request/Response message sending primatives
@@ -66,7 +87,7 @@ class AlexandriaClient(AlexandriaClientAPI):
     async def _request(
         self,
         node_id: NodeID,
-        endpoint: Optional[Endpoint],
+        endpoint: Endpoint,
         request: AlexandriaMessage[Any],
         response_class: Type[TAlexandriaMessage],
     ) -> TAlexandriaMessage:
@@ -110,6 +131,106 @@ class AlexandriaClient(AlexandriaClientAPI):
             )
         return response  # type: ignore
 
+    def subscribe(
+        self,
+        message_type: Type[TAlexandriaMessage],
+        endpoint: Optional[Endpoint] = None,
+        node_id: Optional[NodeID] = None,
+    ) -> AsyncContextManager[
+        trio.abc.ReceiveChannel[InboundMessage[TAlexandriaMessage]]
+    ]:
+        return self.subscription_manager.subscribe(message_type, endpoint, node_id,)  # type: ignore
+
+    @asynccontextmanager
+    async def subscribe_request(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        request: AlexandriaMessage[Any],
+        response_message_type: Type[TAlexandriaMessage],
+        request_id: Optional[bytes],
+    ) -> AsyncIterator[trio.abc.ReceiveChannel[InboundMessage[TAlexandriaMessage]]]:
+        send_channel, receive_channel = trio.open_memory_channel[
+            InboundMessage[TAlexandriaMessage]
+        ](256)
+
+        #
+        # START
+        #
+        # There cannot be any `await/async` calls between here and the `END`
+        # marker, otherwise we will be subject to a race condition where
+        # another request could collide with this request id.
+        #
+        if request_id is None:
+            request_id = self.network.client.request_tracker.get_free_request_id(
+                node_id
+            )
+
+        self.logger.debug(
+            "Sending request: %s with request id %s", request, request_id.hex(),
+        )
+
+        with self.request_tracker.reserve_request_id(node_id, request_id):
+            #
+            # END
+            #
+            async with trio.open_nursery() as nursery:
+                # The use of `functools.partial` below is due to an inadequacy
+                # in the type hinting of `trio.Nursery.start_soon` which
+                # doesn't support more than 4 positional argumeents.
+                nursery.start_soon(
+                    functools.partial(
+                        self._manage_request_response,
+                        node_id,
+                        endpoint,
+                        request,
+                        response_message_type,
+                        send_channel,
+                        request_id,
+                    )
+                )
+                try:
+                    async with receive_channel:
+                        yield receive_channel
+                finally:
+                    nursery.cancel_scope.cancel()
+
+    async def _manage_request_response(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        request: AlexandriaMessage[Any],
+        response_message_type: Type[AlexandriaMessage[Any]],
+        send_channel: trio.abc.SendChannel[InboundMessage[AlexandriaMessage[Any]]],
+        request_id: bytes,
+    ) -> None:
+        with trio.move_on_after(REQUEST_RESPONSE_TIMEOUT) as scope:
+            subscription_ctx = self.subscription_manager.subscribe(
+                response_message_type, endpoint, node_id,
+            )
+            async with subscription_ctx as subscription:
+                self.logger.debug(
+                    "Sending request with request id %s", request_id.hex(),
+                )
+                # Send the request
+                await self._send_request(
+                    node_id, endpoint, request, request_id=request_id
+                )
+
+                # Wait for the response
+                async with send_channel:
+                    async for response in subscription:
+                        if response.request_id != request_id:
+                            continue
+                        else:
+                            await send_channel.send(response)
+        if scope.cancelled_caught:
+            self.logger.warning(
+                "Abandoned request response monitor: request=%s message_type=%s",
+                request,
+                response_message_type,
+            )
+
     #
     # Low Level Message Sending
     #
@@ -135,9 +256,59 @@ class AlexandriaClient(AlexandriaClientAPI):
     #
     # High Level Request/Response
     #
-    async def ping(
-        self, node_id: NodeID, endpoint: Optional[Endpoint] = None,
-    ) -> PongMessage:
+    async def ping(self, node_id: NodeID, endpoint: Endpoint) -> PongMessage:
         request = PingMessage(PingPayload(self.network.enr_manager.enr.sequence_number))
         response = await self._request(node_id, endpoint, request, PongMessage)
         return response
+
+    #
+    # Long Running Processes to manage subscriptions
+    #
+    async def _feed_talk_requests(self) -> None:
+        async with self.network.client.dispatcher.subscribe(
+            TalkRequestMessage
+        ) as subscription:
+            async for request in subscription:
+                if request.message.protocol != self.protocol_id:
+                    continue
+
+                try:
+                    message = decode_message(request.message.payload)
+                except DecodingError:
+                    pass
+                else:
+                    self.subscription_manager.feed_subscriptions(
+                        InboundMessage(
+                            message=message,
+                            sender_node_id=request.sender_node_id,
+                            sender_endpoint=request.sender_endpoint,
+                            explicit_request_id=request.message.request_id,
+                        )
+                    )
+
+    async def _feed_talk_responses(self) -> None:
+        async with self.network.client.dispatcher.subscribe(
+            TalkResponseMessage
+        ) as subscription:
+            async for response in subscription:
+                is_known_request_id = self.request_tracker.is_request_id_active(
+                    response.sender_node_id, response.request_id,
+                )
+                if not is_known_request_id:
+                    continue
+                elif not response.message.payload:
+                    continue
+
+                try:
+                    message = decode_message(response.message.payload)
+                except DecodingError:
+                    pass
+                else:
+                    self.subscription_manager.feed_subscriptions(
+                        InboundMessage(
+                            message=message,
+                            sender_node_id=response.sender_node_id,
+                            sender_endpoint=response.sender_endpoint,
+                            explicit_request_id=response.request_id,
+                        )
+                    )

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -1,25 +1,16 @@
 import logging
-from typing import AsyncContextManager, Optional, Type
+from typing import Optional
 
 from async_service import Service
-from eth_enr import ENRManagerAPI
+from eth_enr import ENRDatabaseAPI, ENRManagerAPI
 from eth_typing import NodeID
-import trio
 
-from ddht.base_message import InboundMessage
 from ddht.endpoint import Endpoint
-from ddht.exceptions import DecodingError
-from ddht.subscription_manager import SubscriptionManager
 from ddht.v5_1.abc import NetworkAPI
-from ddht.v5_1.alexandria.abc import AlexandriaClientAPI, AlexandriaNetworkAPI
+from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI
 from ddht.v5_1.alexandria.client import AlexandriaClient
-from ddht.v5_1.alexandria.messages import (
-    PingMessage,
-    TAlexandriaMessage,
-    decode_message,
-)
+from ddht.v5_1.alexandria.messages import PingMessage
 from ddht.v5_1.alexandria.payloads import PongPayload
-from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
 
 
 class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
@@ -28,34 +19,23 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
     # Delegate to the AlexandriaClient for determining `protocol_id`
     protocol_id = AlexandriaClient.protocol_id
 
-    _alexandria_client: AlexandriaClientAPI
-
-    def __init__(self, client: AlexandriaClientAPI) -> None:
-        self._alexandria_client = client
-
-        self.subscription_manager = SubscriptionManager()
+    def __init__(self, network: NetworkAPI) -> None:
+        self.client = AlexandriaClient(network)
 
     @property
     def network(self) -> NetworkAPI:
-        return self._alexandria_client.network
+        return self.client.network
 
     @property
     def enr_manager(self) -> ENRManagerAPI:
-        return self._alexandria_client.network.enr_manager
+        return self.client.network.enr_manager
 
-    def subscribe(
-        self,
-        message_type: Type[TAlexandriaMessage],
-        endpoint: Optional[Endpoint] = None,
-        node_id: Optional[NodeID] = None,
-    ) -> AsyncContextManager[
-        trio.abc.ReceiveChannel[InboundMessage[TAlexandriaMessage]]
-    ]:
-        return self.subscription_manager.subscribe(message_type, endpoint, node_id)  # type: ignore
+    @property
+    def enr_db(self) -> ENRDatabaseAPI:
+        return self.client.network.enr_db
 
     async def run(self) -> None:
-        self.manager.run_daemon_task(self._feed_talk_requests)
-        self.manager.run_daemon_task(self._feed_talk_responses)
+        self.manager.run_daemon_child_service(self.client)
         self.manager.run_daemon_task(self._pong_when_pinged)
 
         await self.manager.wait_finished()
@@ -66,66 +46,27 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
     async def ping(
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
     ) -> PongPayload:
-        response = await self._alexandria_client.ping(node_id, endpoint=endpoint)
+        if endpoint is None:
+            endpoint = self._endpoint_for_node_id(node_id)
+        response = await self.client.ping(node_id, endpoint=endpoint)
         return response.payload
 
     #
     # Long Running Processes
     #
     async def _pong_when_pinged(self) -> None:
-        async with self.subscribe(PingMessage) as subscription:
+        async with self.client.subscribe(PingMessage) as subscription:
             async for request in subscription:
-                await self._alexandria_client.send_pong(
+                await self.client.send_pong(
                     request.sender_node_id,
                     request.sender_endpoint,
                     enr_seq=self.enr_manager.enr.sequence_number,
                     request_id=request.request_id,
                 )
 
-    async def _feed_talk_requests(self) -> None:
-        async with self.network.client.dispatcher.subscribe(
-            TalkRequestMessage
-        ) as subscription:
-            async for request in subscription:
-                if request.message.protocol != self.protocol_id:
-                    continue
-
-                try:
-                    message = decode_message(request.message.payload)
-                except DecodingError:
-                    pass
-                else:
-                    self.subscription_manager.feed_subscriptions(
-                        InboundMessage(
-                            message=message,
-                            sender_node_id=request.sender_node_id,
-                            sender_endpoint=request.sender_endpoint,
-                            explicit_request_id=request.message.request_id,
-                        )
-                    )
-
-    async def _feed_talk_responses(self) -> None:
-        async with self.network.client.dispatcher.subscribe(
-            TalkResponseMessage
-        ) as subscription:
-            async for response in subscription:
-                is_known_request_id = self._alexandria_client.request_tracker.is_request_id_active(
-                    response.sender_node_id, response.request_id,
-                )
-                if not is_known_request_id:
-                    continue
-                elif not response.message.payload:
-                    continue
-
-                try:
-                    message = decode_message(response.message.payload)
-                except DecodingError:
-                    pass
-                else:
-                    self.subscription_manager.feed_subscriptions(
-                        InboundMessage(
-                            message=message,
-                            sender_node_id=response.sender_node_id,
-                            sender_endpoint=response.sender_endpoint,
-                        )
-                    )
+    #
+    # Utility
+    #
+    def _endpoint_for_node_id(self, node_id: NodeID) -> Endpoint:
+        enr = self.enr_db.get_enr(node_id)
+        return Endpoint.from_enr(enr)

--- a/tests/core/v5_1/alexandria/conftest.py
+++ b/tests/core/v5_1/alexandria/conftest.py
@@ -2,12 +2,24 @@ import pytest
 
 
 @pytest.fixture
-async def alice_alexandria(alice, alice_network):
-    async with alice.alexandria(alice_network) as alice_alexandria:
+async def alice_alexandria_client(alice, alice_network):
+    async with alice.alexandria.client(alice_network) as alice_alexandria_client:
+        yield alice_alexandria_client
+
+
+@pytest.fixture
+async def bob_alexandria_client(bob, bob_network):
+    async with bob.alexandria.client(bob_network) as bob_alexandria_client:
+        yield bob_alexandria_client
+
+
+@pytest.fixture
+async def alice_alexandria_network(alice, alice_network):
+    async with alice.alexandria.network(alice_network) as alice_alexandria:
         yield alice_alexandria
 
 
 @pytest.fixture
-async def bob_alexandria(bob, bob_network):
-    async with bob.alexandria(bob_network) as bob_alexandria:
+async def bob_alexandria_network(bob, bob_network):
+    async with bob.alexandria.network(bob_network) as bob_alexandria:
         yield bob_alexandria

--- a/tests/core/v5_1/alexandria/test_alexandria_client.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_client.py
@@ -1,17 +1,14 @@
 import pytest
 import trio
 
-from ddht.v5_1.alexandria.client import AlexandriaClient
 from ddht.v5_1.alexandria.messages import PingMessage, PongMessage, decode_message
 from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
 
 
 @pytest.mark.trio
-async def test_alexandria_api_send_ping(alice_network, bob, bob_network):
-    alexandria_client = AlexandriaClient(alice_network)
-
+async def test_alexandria_client_send_ping(bob, bob_network, alice_alexandria_client):
     async with bob_network.dispatcher.subscribe(TalkRequestMessage) as subscription:
-        await alexandria_client.send_ping(bob.node_id, bob.endpoint, enr_seq=100)
+        await alice_alexandria_client.send_ping(bob.node_id, bob.endpoint, enr_seq=100)
         with trio.fail_after(1):
             talk_response = await subscription.receive()
         message = decode_message(talk_response.message.payload)
@@ -20,11 +17,9 @@ async def test_alexandria_api_send_ping(alice_network, bob, bob_network):
 
 
 @pytest.mark.trio
-async def test_alexandria_api_send_pong(alice_network, bob, bob_network):
-    alexandria_client = AlexandriaClient(alice_network)
-
+async def test_alexandria_client_send_pong(bob, bob_network, alice_alexandria_client):
     async with bob_network.dispatcher.subscribe(TalkResponseMessage) as subscription:
-        await alexandria_client.send_pong(
+        await alice_alexandria_client.send_pong(
             bob.node_id, bob.endpoint, enr_seq=100, request_id=b"\x01\x02"
         )
         with trio.fail_after(1):
@@ -35,15 +30,9 @@ async def test_alexandria_api_send_pong(alice_network, bob, bob_network):
 
 
 @pytest.mark.trio
-async def test_alexandria_api_ping_request_response(
-    alice_network, alice, bob, bob_network,
+async def test_alexandria_client_ping_request_response(
+    alice, bob, bob_network, alice_alexandria_client, bob_alexandria_client,
 ):
-    alexandria_client = AlexandriaClient(alice_network)
-    alice_network.add_talk_protocol(alexandria_client)
-
-    bob_alexandria_client = AlexandriaClient(bob_network)
-    bob_network.add_talk_protocol(bob_alexandria_client)
-
     async def _respond():
         request = await subscription.receive()
         await bob_alexandria_client.send_pong(
@@ -58,21 +47,23 @@ async def test_alexandria_api_ping_request_response(
             nursery.start_soon(_respond)
 
             with trio.fail_after(1):
-                pong_message = await alexandria_client.ping(bob.node_id, bob.endpoint)
+                pong_message = await alice_alexandria_client.ping(
+                    bob.node_id, bob.endpoint
+                )
                 assert isinstance(pong_message, PongMessage)
                 assert pong_message.payload.enr_seq == bob.enr.sequence_number
 
 
 @pytest.mark.trio
 async def test_alexandria_api_ping_request_response_request_id_mismatch(
-    alice_network, alice, bob, bob_network, autojump_clock,
+    alice_network,
+    alice,
+    bob,
+    bob_network,
+    autojump_clock,
+    bob_alexandria_client,
+    alice_alexandria_client,
 ):
-    alexandria_client = AlexandriaClient(alice_network)
-    alice_network.add_talk_protocol(alexandria_client)
-
-    bob_alexandria_client = AlexandriaClient(bob_network)
-    bob_network.add_talk_protocol(bob_alexandria_client)
-
     async def _respond_wrong_request_id():
         await subscription.receive()
         await bob_alexandria_client.send_pong(
@@ -90,4 +81,4 @@ async def test_alexandria_api_ping_request_response_request_id_mismatch(
 
             with pytest.raises(trio.TooSlowError):
                 with trio.fail_after(1):
-                    await alexandria_client.ping(bob.node_id, bob.endpoint)
+                    await alice_alexandria_client.ping(bob.node_id, bob.endpoint)

--- a/tests/core/v5_1/conftest.py
+++ b/tests/core/v5_1/conftest.py
@@ -26,6 +26,20 @@ async def driver(tester, alice, bob):
 
 
 @pytest.fixture
+async def alice_client(alice, bob):
+    alice.enr_db.set_enr(bob.enr)
+    async with alice.client() as alice_client:
+        yield alice_client
+
+
+@pytest.fixture
+async def bob_client(alice, bob):
+    bob.enr_db.set_enr(alice.enr)
+    async with bob.client() as bob_client:
+        yield bob_client
+
+
+@pytest.fixture
 async def alice_network(alice, bob):
     alice.enr_db.set_enr(bob.enr)
     async with alice.network() as alice_network:


### PR DESCRIPTION
Builds from #121 

## What was wrong?

I was *hopeful* that the `AlexandriaClientAPI` could avoid being a `ServiceAPI`, however, while implementing `FINDNODES/FOUNDNODES` the need for subscriptions to be managed at that level arose.  This is so that we can get a multi-response from for the FOUNDNODES response.

## How was it fixed?

Moved the `AlexandriaNetworkAPI.subscription_manager` down to the `AlexandriaClientAPI` as well as the related functionality.  Also ended up needing to do some copy/pasta from `ddht.v5_1.dispatcher.Dispatcher` for the `subscribe_request` implementation.

#### Cute Animal Picture

![unlikely-animal-friends-7](https://user-images.githubusercontent.com/824194/96299516-68fd7080-0fb1-11eb-9b42-90cba4f4fd39.jpg)

