### PR TITLE
Implement alexandria find and found nodes client apis

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -1,8 +1,8 @@
 from abc import abstractmethod
-from typing import Any, AsyncContextManager, Optional, Type
+from typing import Any, AsyncContextManager, Collection, Optional, Sequence, Tuple, Type
 
 from async_service import ServiceAPI
-from eth_enr import ENRDatabaseAPI, ENRManagerAPI
+from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
 from eth_typing import NodeID
 import trio
 
@@ -12,6 +12,7 @@ from ddht.endpoint import Endpoint
 from ddht.v5_1.abc import NetworkAPI, TalkProtocolAPI
 from ddht.v5_1.alexandria.messages import (
     AlexandriaMessage,
+    FoundNodesMessage,
     PongMessage,
     TAlexandriaMessage,
 )
@@ -57,11 +58,44 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     ) -> None:
         ...
 
+    @abstractmethod
+    async def send_find_nodes(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        distances: Collection[int],
+        request_id: Optional[bytes] = None,
+    ) -> bytes:
+        ...
+
+    @abstractmethod
+    async def send_found_nodes(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        enrs: Sequence[ENRAPI],
+        request_id: bytes,
+    ) -> int:
+        ...
+
     #
     # High Level Request/Response
     #
     @abstractmethod
-    async def ping(self, node_id: NodeID, endpoint: Endpoint,) -> PongMessage:
+    async def ping(self, node_id: NodeID, endpoint: Endpoint) -> PongMessage:
+        ...
+
+    @abstractmethod
+    async def find_nodes(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        distances: Collection[int],
+        *,
+        request_id: Optional[bytes] = None,
+    ) -> Tuple[InboundMessage[FoundNodesMessage], ...]:
         ...
 
 

--- a/ddht/v5_1/alexandria/messages.py
+++ b/ddht/v5_1/alexandria/messages.py
@@ -5,8 +5,18 @@ from ssz import BaseSedes
 
 from ddht.constants import UINT8_TO_BYTES
 from ddht.exceptions import DecodingError
-from ddht.v5_1.alexandria.payloads import PingPayload, PongPayload
-from ddht.v5_1.alexandria.sedes import PingSedes, PongSedes
+from ddht.v5_1.alexandria.payloads import (
+    FindNodesPayload,
+    FoundNodesPayload,
+    PingPayload,
+    PongPayload,
+)
+from ddht.v5_1.alexandria.sedes import (
+    FindNodesSedes,
+    FoundNodesSedes,
+    PingSedes,
+    PongSedes,
+)
 
 TPayload = TypeVar("TPayload")
 
@@ -77,6 +87,34 @@ class PongMessage(AlexandriaMessage[PongPayload]):
     payload_type = PongPayload
 
     payload: PongPayload
+
+
+@register
+class FindNodesMessage(AlexandriaMessage[FindNodesPayload]):
+    message_id = 3
+    sedes = FindNodesSedes
+    payload_type = FindNodesPayload
+
+    payload: FindNodesPayload
+
+    @classmethod
+    def from_payload_args(
+        cls: Type[TAlexandriaMessage], payload_args: Any
+    ) -> TAlexandriaMessage:
+        # py-ssz uses an internal type for decoded `ssz.sedes.List` types that
+        # we don't need or want so we force it to a normal tuple type here.
+        distances = tuple(payload_args[0])
+        payload = cls.payload_type(distances)
+        return cls(payload)
+
+
+@register
+class FoundNodesMessage(AlexandriaMessage[FoundNodesPayload]):
+    message_id = 4
+    sedes = FoundNodesSedes
+    payload_type = FoundNodesPayload
+
+    payload: FoundNodesPayload
 
 
 def decode_message(data: bytes) -> AlexandriaMessage[Any]:

--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -1,4 +1,7 @@
-from typing import NamedTuple
+from typing import NamedTuple, Sequence, Tuple
+
+from eth_enr import ENR, ENRAPI
+import rlp
 
 
 class PingPayload(NamedTuple):
@@ -7,3 +10,23 @@ class PingPayload(NamedTuple):
 
 class PongPayload(NamedTuple):
     enr_seq: int
+
+
+class FindNodesPayload(NamedTuple):
+    distances: Tuple[int, ...]
+
+
+class FoundNodesPayload(NamedTuple):
+    total: int
+    encoded_enrs: Tuple[bytes, ...]
+
+    @property
+    def enrs(self) -> Tuple[ENRAPI]:
+        return tuple(  # type: ignore
+            rlp.decode(raw_enr, sedes=ENR) for raw_enr in self.encoded_enrs
+        )
+
+    @classmethod
+    def from_enrs(cls, total: int, enrs: Sequence[ENRAPI]) -> "FoundNodesPayload":
+        encoded_enrs = tuple(rlp.encode(enr) for enr in enrs)
+        return cls(total, encoded_enrs)

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -1,4 +1,21 @@
-from ssz.sedes import Container, uint32
+from ssz.sedes import Container, List, uint8, uint16, uint32
+
+
+class ByteList(List):  # type: ignore
+    def __init__(self, max_length: int) -> None:
+        super().__init__(element_sedes=uint8, max_length=max_length)
+
+    def serialize(self, value: bytes) -> bytes:
+        return value
+
+    def deserialize(self, value: bytes) -> bytes:
+        return value
+
+
+byte_list = ByteList(max_length=2048)
+
 
 PingSedes = Container(field_sedes=(uint32,))
 PongSedes = Container(field_sedes=(uint32,))
+FindNodesSedes = Container(field_sedes=(List(uint16, max_length=256),))
+FoundNodesSedes = Container(field_sedes=(uint8, List(byte_list, max_length=32)))

--- a/tests/core/v5_1/alexandria/test_alexandria_client.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_client.py
@@ -1,7 +1,16 @@
+import itertools
+
+from eth_enr.tools.factories import ENRFactory
 import pytest
 import trio
 
-from ddht.v5_1.alexandria.messages import PingMessage, PongMessage, decode_message
+from ddht.kademlia import KademliaRoutingTable
+from ddht.v5_1.alexandria.messages import (
+    FindNodesMessage,
+    PingMessage,
+    PongMessage,
+    decode_message,
+)
 from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
 
 
@@ -56,13 +65,13 @@ async def test_alexandria_client_ping_request_response(
 
 @pytest.mark.trio
 async def test_alexandria_api_ping_request_response_request_id_mismatch(
-    alice_network,
     alice,
     bob,
+    alice_network,
     bob_network,
-    autojump_clock,
-    bob_alexandria_client,
     alice_alexandria_client,
+    bob_alexandria_client,
+    autojump_clock,
 ):
     async def _respond_wrong_request_id():
         await subscription.receive()
@@ -82,3 +91,108 @@ async def test_alexandria_api_ping_request_response_request_id_mismatch(
             with pytest.raises(trio.TooSlowError):
                 with trio.fail_after(1):
                     await alice_alexandria_client.ping(bob.node_id, bob.endpoint)
+
+
+@pytest.mark.trio
+async def test_alexandria_client_send_find_nodes(
+    alice, bob, bob_client, alice_alexandria_client
+):
+    async with bob_client.dispatcher.subscribe(TalkRequestMessage) as subscription:
+        await alice_alexandria_client.send_find_nodes(
+            bob.node_id, bob.endpoint, distances=(0, 255, 254),
+        )
+        with trio.fail_after(1):
+            talk_request = await subscription.receive()
+        message = decode_message(talk_request.message.payload)
+        assert isinstance(message, FindNodesMessage)
+        assert message.payload.distances == (0, 255, 254)
+
+
+@pytest.mark.parametrize(
+    "enrs",
+    (
+        ENRFactory.create_batch(1),
+        ENRFactory.create_batch(2),
+        ENRFactory.create_batch(10),
+        ENRFactory.create_batch(50),
+    ),
+)
+@pytest.mark.trio
+async def test_alexandria_client_send_found_nodes(
+    bob, bob_client, enrs, alice_alexandria_client
+):
+    with trio.fail_after(2):
+        async with bob_client.dispatcher.subscribe(TalkResponseMessage) as subscription:
+            await alice_alexandria_client.send_found_nodes(
+                bob.node_id, bob.endpoint, enrs=enrs, request_id=b"\x01\x02",
+            )
+
+            with trio.fail_after(2):
+                first_message = await subscription.receive()
+                decoded_first_message = decode_message(first_message.message.payload)
+                remaining_messages = []
+                for _ in range(decoded_first_message.payload.total - 1):
+                    remaining_messages.append(await subscription.receive())
+
+        all_decoded_messages = (decoded_first_message,) + tuple(
+            decode_message(message.message.payload) for message in remaining_messages
+        )
+        all_received_enrs = tuple(
+            itertools.chain(*(message.payload.enrs for message in all_decoded_messages))
+        )
+        expected_enrs_by_node_id = {enr.node_id: enr for enr in enrs}
+        assert len(expected_enrs_by_node_id) == len(enrs)
+        actual_enrs_by_node_id = {enr.node_id: enr for enr in all_received_enrs}
+
+        assert expected_enrs_by_node_id == actual_enrs_by_node_id
+
+
+@pytest.mark.trio
+async def test_client_request_response_find_nodes_found_nodes(
+    alice, bob, alice_alexandria_client, bob_alexandria_client,
+):
+    table = KademliaRoutingTable(bob.node_id, 256)
+    for i in range(1000):
+        enr = ENRFactory()
+        table.update(enr.node_id)
+        bob.enr_db.set_enr(enr)
+
+    checked_bucket_indexes = []
+
+    for distance in range(256, 0, -1):
+        bucket = table.buckets[distance - 1]
+        if not len(bucket):
+            break
+
+        async with trio.open_nursery() as nursery:
+            async with bob_alexandria_client.subscribe(
+                FindNodesMessage
+            ) as subscription:
+                expected_enrs = tuple(bob.enr_db.get_enr(node_id) for node_id in bucket)
+
+                async def _send_response():
+                    request = await subscription.receive()
+                    checked_bucket_indexes.append(distance)
+                    await bob_alexandria_client.send_found_nodes(
+                        alice.node_id,
+                        alice.endpoint,
+                        enrs=expected_enrs,
+                        request_id=request.request_id,
+                    )
+
+                nursery.start_soon(_send_response)
+
+                with trio.fail_after(2):
+                    found_nodes_messages = await alice_alexandria_client.find_nodes(
+                        bob.node_id, bob.endpoint, distances=[distance],
+                    )
+
+                found_node_ids = {
+                    enr.node_id
+                    for message in found_nodes_messages
+                    for enr in message.message.payload.enrs
+                }
+                expected_node_ids = {enr.node_id for enr in expected_enrs}
+                assert found_node_ids == expected_node_ids
+
+    assert len(checked_bucket_indexes) > 4

--- a/tests/core/v5_1/test_client.py
+++ b/tests/core/v5_1/test_client.py
@@ -213,12 +213,12 @@ async def test_client_request_response_find_nodes_found_nodes(
     checked_bucket_indexes = []
 
     for distance in range(256, 1, -1):
+        bucket = table.buckets[distance - 1]
+        if not len(bucket):
+            break
+
         async with trio.open_nursery() as nursery:
             async with bob.events.find_nodes_received.subscribe() as subscription:
-                bucket = table.buckets[distance - 1]
-                if not len(bucket):
-                    break
-
                 expected_enrs = tuple(bob.enr_db.get_enr(node_id) for node_id in bucket)
 
                 async def _send_response():


### PR DESCRIPTION
## What was wrong?

The Alexandria network will need to maintain it's own overlay routing table containing only nodes that participate in the Alexandria protocol.  To do this we need the FINDNODES/FOUNDNODES message pairs and corresponding functionality.

## How was it fixed?

Implemented the base units for this functionality in `AlexandriaClientAPI`

#### Cute Animal Picture

![unlikely-animal-friends](https://user-images.githubusercontent.com/824194/96309465-8be45080-0fc2-11eb-8b78-b55b376d995f.jpg)

