### PR TITLE
Alexandria: Network api for find nodes and add tests

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -31,7 +31,9 @@ class AlexandriaNodeAPI(ABC):
 
     @abstractmethod
     def network(
-        self, network: Optional[NetworkAPI] = None
+        self,
+        network: Optional[NetworkAPI] = None,
+        bootnodes: Optional[Collection[ENRAPI]] = None,
     ) -> AsyncContextManager[AlexandriaNetworkAPI]:
         ...
 

--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -1,7 +1,8 @@
-from typing import AsyncContextManager, AsyncIterator, Optional
+from typing import AsyncContextManager, AsyncIterator, Collection, Optional
 
 from async_generator import asynccontextmanager
 from async_service import background_trio_service
+from eth_enr import ENRAPI
 
 from ddht._utils import asyncnullcontext
 from ddht.tools.driver._utils import NamedLock
@@ -40,7 +41,9 @@ class AlexandriaNode(AlexandriaNodeAPI):
 
     @asynccontextmanager
     async def network(
-        self, network: Optional[NetworkAPI] = None,
+        self,
+        network: Optional[NetworkAPI] = None,
+        bootnodes: Optional[Collection[ENRAPI]] = None,
     ) -> AsyncIterator[AlexandriaNetworkAPI]:
         network_context: AsyncContextManager[NetworkAPI]
 
@@ -52,7 +55,7 @@ class AlexandriaNode(AlexandriaNodeAPI):
 
         async with self._lock.acquire("AlexandriaNode.network(...)"):
             async with network_context as network:
-                alexandria_network = AlexandriaNetwork(network)
+                alexandria_network = AlexandriaNetwork(network, ())
                 network.add_talk_protocol(alexandria_network)
                 async with background_trio_service(alexandria_network):
                     yield alexandria_network

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -6,7 +6,7 @@ from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
 from eth_typing import NodeID
 import trio
 
-from ddht.abc import RequestTrackerAPI, SubscriptionManagerAPI
+from ddht.abc import RequestTrackerAPI, RoutingTableAPI, SubscriptionManagerAPI
 from ddht.base_message import InboundMessage
 from ddht.endpoint import Endpoint
 from ddht.v5_1.abc import NetworkAPI, TalkProtocolAPI
@@ -101,10 +101,16 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
 
 class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     client: AlexandriaClientAPI
+    routing_table: RoutingTableAPI
 
     @property
     @abstractmethod
     def network(self) -> NetworkAPI:
+        ...
+
+    @property
+    @abstractmethod
+    def local_node_id(self) -> NodeID:
         ...
 
     @property
@@ -124,4 +130,24 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     async def ping(
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
     ) -> PongPayload:
+        ...
+
+    @abstractmethod
+    async def find_nodes(
+        self,
+        node_id: NodeID,
+        *distances: int,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
+    ) -> Tuple[ENRAPI, ...]:
+        ...
+
+    @abstractmethod
+    async def get_enr(
+        self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
+    ) -> ENRAPI:
+        ...
+
+    @abstractmethod
+    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         ...

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -1,15 +1,27 @@
+import itertools
 import logging
-from typing import Optional
+from typing import Collection, List, Optional, Set, Tuple
 
 from async_service import Service
-from eth_enr import ENRDatabaseAPI, ENRManagerAPI
+from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
+from eth_enr.exceptions import OldSequenceNumber
 from eth_typing import NodeID
+from eth_utils.toolz import take
+import trio
 
+from ddht._utils import humanize_node_id, reduce_enrs
+from ddht.constants import ROUTING_TABLE_BUCKET_SIZE
 from ddht.endpoint import Endpoint
+from ddht.kademlia import (
+    KademliaRoutingTable,
+    compute_distance,
+    compute_log_distance,
+    iter_closest_nodes,
+)
 from ddht.v5_1.abc import NetworkAPI
 from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI
 from ddht.v5_1.alexandria.client import AlexandriaClient
-from ddht.v5_1.alexandria.messages import PingMessage
+from ddht.v5_1.alexandria.messages import FindNodesMessage, PingMessage
 from ddht.v5_1.alexandria.payloads import PongPayload
 
 
@@ -19,24 +31,35 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
     # Delegate to the AlexandriaClient for determining `protocol_id`
     protocol_id = AlexandriaClient.protocol_id
 
-    def __init__(self, network: NetworkAPI) -> None:
+    def __init__(self, network: NetworkAPI, bootnodes: Collection[ENRAPI]) -> None:
+        self._bootnodes = tuple(bootnodes)
+
         self.client = AlexandriaClient(network)
+
+        self.routing_table = KademliaRoutingTable(
+            self.enr_manager.enr.node_id, ROUTING_TABLE_BUCKET_SIZE,
+        )
 
     @property
     def network(self) -> NetworkAPI:
         return self.client.network
 
     @property
+    def local_node_id(self) -> NodeID:
+        return self.network.local_node_id
+
+    @property
     def enr_manager(self) -> ENRManagerAPI:
-        return self.client.network.enr_manager
+        return self.network.enr_manager
 
     @property
     def enr_db(self) -> ENRDatabaseAPI:
-        return self.client.network.enr_db
+        return self.network.enr_db
 
     async def run(self) -> None:
         self.manager.run_daemon_child_service(self.client)
         self.manager.run_daemon_task(self._pong_when_pinged)
+        self.manager.run_daemon_task(self._serve_find_nodes)
 
         await self.manager.wait_finished()
 
@@ -51,6 +74,118 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         response = await self.client.ping(node_id, endpoint=endpoint)
         return response.payload
 
+    async def find_nodes(
+        self,
+        node_id: NodeID,
+        *distances: int,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
+    ) -> Tuple[ENRAPI, ...]:
+        if not distances:
+            raise TypeError("Must provide at least one distance")
+
+        if endpoint is None:
+            endpoint = self._endpoint_for_node_id(node_id)
+        responses = await self.client.find_nodes(
+            node_id, endpoint, distances=distances, request_id=request_id
+        )
+        return tuple(
+            enr for response in responses for enr in response.message.payload.enrs
+        )
+
+    async def get_enr(
+        self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
+    ) -> ENRAPI:
+        try:
+            enr = self.enr_db.get_enr(node_id)
+        except KeyError:
+            enr = await self._fetch_enr(node_id, endpoint=endpoint)
+            self.enr_db.set_enr(enr)
+        else:
+            if enr_seq > enr.sequence_number:
+                enr = await self._fetch_enr(node_id, endpoint=endpoint)
+                self.enr_db.set_enr(enr)
+
+        return enr
+
+    async def _fetch_enr(
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint]
+    ) -> ENRAPI:
+        enrs = await self.find_nodes(node_id, 0, endpoint=endpoint)
+        if not enrs:
+            raise Exception("Invalid response")
+        # This reduce accounts for
+        return reduce_enrs(enrs)[0]
+
+    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
+        self.logger.debug("Recursive find nodes: %s", humanize_node_id(target))
+
+        queried_node_ids = set()
+        unresponsive_node_ids = set()
+        received_enrs: List[ENRAPI] = []
+        received_node_ids: Set[NodeID] = set()
+
+        async def do_lookup(node_id: NodeID) -> None:
+            queried_node_ids.add(node_id)
+
+            distance = compute_log_distance(node_id, target)
+            try:
+                enrs = await self.find_nodes(node_id, distance)
+            except trio.EndOfChannel:
+                unresponsive_node_ids.add(node_id)
+                return
+
+            for enr in enrs:
+                received_node_ids.add(enr.node_id)
+                try:
+                    self.enr_db.set_enr(enr)
+                except OldSequenceNumber:
+                    received_enrs.append(self.enr_db.get_enr(enr.node_id))
+                else:
+                    received_enrs.append(enr)
+
+        for lookup_round_counter in itertools.count():
+            candidates = iter_closest_nodes(
+                target, self.routing_table, received_node_ids
+            )
+            responsive_candidates = itertools.dropwhile(
+                lambda node: node in unresponsive_node_ids, candidates
+            )
+            closest_k_candidates = take(
+                self.routing_table.bucket_size, responsive_candidates
+            )
+            closest_k_unqueried_candidates = (
+                candidate
+                for candidate in closest_k_candidates
+                if candidate not in queried_node_ids and candidate != self.local_node_id
+            )
+            nodes_to_query = tuple(take(3, closest_k_unqueried_candidates))
+
+            if nodes_to_query:
+                self.logger.debug(
+                    "Starting lookup round %d for %s",
+                    lookup_round_counter + 1,
+                    humanize_node_id(target),
+                )
+                async with trio.open_nursery() as nursery:
+                    for peer in nodes_to_query:
+                        nursery.start_soon(do_lookup, peer)
+            else:
+                self.logger.debug(
+                    "Lookup for %s finished in %d rounds",
+                    humanize_node_id(target),
+                    lookup_round_counter,
+                )
+                break
+
+        # now sort and return the ENR records in order of closesness to the target.
+        return tuple(
+            sorted(
+                reduce_enrs(received_enrs),
+                key=lambda enr: compute_distance(enr.node_id, target),
+            )
+        )
+
     #
     # Long Running Processes
     #
@@ -61,6 +196,55 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                     request.sender_node_id,
                     request.sender_endpoint,
                     enr_seq=self.enr_manager.enr.sequence_number,
+                    request_id=request.request_id,
+                )
+
+    async def _serve_find_nodes(self) -> None:
+        async with self.client.subscribe(FindNodesMessage) as subscription:
+            async for request in subscription:
+                response_enrs: List[ENRAPI] = []
+                distances = set(request.message.payload.distances)
+                if len(distances) != len(request.message.payload.distances):
+                    self.logger.debug(
+                        "Ignoring invalid FindNodesMessage from %s@%s: duplicate distances",
+                        humanize_node_id(request.sender_node_id),
+                        request.sender_endpoint,
+                    )
+                    continue
+                elif not distances:
+                    self.logger.debug(
+                        "Ignoring invalid FindNodesMessage from %s@%s: empty distances",
+                        humanize_node_id(request.sender_node_id),
+                        request.sender_endpoint,
+                    )
+                    continue
+                elif any(
+                    distance > self.routing_table.num_buckets for distance in distances
+                ):
+                    self.logger.debug(
+                        "Ignoring invalid FindNodesMessage from %s@%s: distances: %s",
+                        humanize_node_id(request.sender_node_id),
+                        request.sender_endpoint,
+                        distances,
+                    )
+                    continue
+
+                for distance in distances:
+                    if distance == 0:
+                        response_enrs.append(self.enr_manager.enr)
+                    elif distance <= self.routing_table.num_buckets:
+                        node_ids_at_distance = self.routing_table.get_nodes_at_log_distance(
+                            distance,
+                        )
+                        for node_id in node_ids_at_distance:
+                            response_enrs.append(self.enr_db.get_enr(node_id))
+                    else:
+                        raise Exception("Should be unreachable")
+
+                await self.client.send_found_nodes(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    enrs=response_enrs,
                     request_id=request.request_id,
                 )
 

--- a/tests/core/v5_1/alexandria/test_alexandria_network.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_network.py
@@ -1,0 +1,104 @@
+from eth_enr.tools.factories import ENRFactory
+import pytest
+import trio
+
+from ddht.constants import ROUTING_TABLE_BUCKET_SIZE
+from ddht.kademlia import KademliaRoutingTable, compute_log_distance
+from ddht.v5_1.alexandria.messages import FindNodesMessage
+
+
+@pytest.mark.trio
+async def test_alexandria_network_ping_api(
+    alice, bob, alice_alexandria_network, bob_alexandria_network
+):
+    with trio.fail_after(2):
+        pong = await alice_alexandria_network.ping(bob.node_id)
+
+    assert pong.enr_seq == bob.enr.sequence_number
+
+
+@pytest.mark.trio
+async def test_alexandria_network_responds_to_pings(
+    alice, bob, alice_alexandria_network, bob_alexandria_network
+):
+    with trio.fail_after(2):
+        pong_message = await alice_alexandria_network.client.ping(
+            bob.node_id, bob.endpoint
+        )
+
+    assert pong_message.payload.enr_seq == bob.enr.sequence_number
+
+
+@pytest.mark.trio
+async def test_alexandria_network_find_nodes_api(
+    alice, bob, alice_alexandria_network, bob_alexandria_client
+):
+    distances = {0}
+
+    bob_alexandria_routing_table = KademliaRoutingTable(
+        bob.enr.node_id, ROUTING_TABLE_BUCKET_SIZE
+    )
+
+    for _ in range(200):
+        enr = ENRFactory()
+        bob.enr_db.set_enr(enr)
+        bob_alexandria_routing_table.update(enr.node_id)
+        distances.add(compute_log_distance(enr.node_id, bob.node_id))
+        if distances.issuperset({0, 256, 255}):
+            break
+    else:
+        raise Exception("failed")
+
+    async with bob_alexandria_client.subscribe(FindNodesMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+
+            async def _respond():
+                request = await subscription.receive()
+                response_enrs = []
+                for distance in request.message.payload.distances:
+                    if distance == 0:
+                        response_enrs.append(bob.enr)
+                    else:
+                        for (
+                            node_id
+                        ) in bob_alexandria_routing_table.get_nodes_at_log_distance(
+                            distance
+                        ):
+                            response_enrs.append(bob.enr_db.get_enr(node_id))
+                await bob_alexandria_client.send_found_nodes(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    enrs=response_enrs,
+                    request_id=request.request_id,
+                )
+
+            nursery.start_soon(_respond)
+
+            with trio.fail_after(2):
+                enrs = await alice_alexandria_network.find_nodes(
+                    bob.node_id, 0, 255, 256
+                )
+
+    assert any(enr.node_id == bob.node_id for enr in enrs)
+    response_distances = {
+        compute_log_distance(enr.node_id, bob.node_id)
+        for enr in enrs
+        if enr.node_id != bob.node_id
+    }
+    assert response_distances == {256, 255}
+
+
+@pytest.mark.trio
+async def test_alexandria_network_responds_to_find_nodes(
+    alice, bob, alice_alexandria_network, bob_alexandria_network,
+):
+    enr = ENRFactory()
+    bob.enr_db.set_enr(enr)
+    bob_alexandria_network.routing_table.update(enr.node_id)
+    enr_distance = compute_log_distance(enr.node_id, bob.node_id)
+
+    with trio.fail_after(2):
+        enrs = await alice_alexandria_network.find_nodes(bob.node_id, enr_distance,)
+
+    assert len(enrs) >= 1
+    assert any(enr.node_id == enr.node_id for enr in enrs)


### PR DESCRIPTION
builds on #122 

## What was wrong?

#122 implements the client APIs for doing FINDNODES/FOUNDNODES in Alexandria.  We still however need the high level APIs.

## How was it fixed?

Implement high level `AlexandriaNetworkAPI.find_nodes` and `AlexandriaNetworkAPI.recursive_find_nodes`.

Currently these are heavy on the code-duplication front.  After this has been merged, my plan is to go back and see about "drying" out these two independent implementations into something standardized.

This also implements tests for the `AlexandriaNetworkAPI` which were previously missing.

#### Cute Animal Picture

![unusual-animal-friendship-cat-iguana__700](https://user-images.githubusercontent.com/824194/96474633-3f7e5800-11f0-11eb-93dc-9b7524ca6aab.jpg)

