### PR TITLE
Fix log level setup when using 0 as level

### DIFF
--- a/ddht/logging.py
+++ b/ddht/logging.py
@@ -59,8 +59,10 @@ def environment_to_log_levels(raw_levels: Optional[str]) -> Dict[Optional[str], 
 def setup_logging(
     logfile: pathlib.Path, file_log_level: int, stderr_level: int = None
 ) -> None:
-    stderr_level = stderr_level or logging.INFO
-    file_log_level = file_log_level or logging.DEBUG
+    if stderr_level is None:
+        stderr_level = logging.INFO
+    if file_log_level is None:
+        file_log_level = logging.DEBUG
 
     raw_environ_log_levels = os.environ.get("LOGLEVEL", None)
     environ_log_levels = environment_to_log_levels(raw_environ_log_levels)
@@ -81,6 +83,7 @@ def setup_stderr_logging(level: int) -> logging.StreamHandler:
     handler_stream.setFormatter(LOG_FORMATTER)
 
     logger = logging.getLogger()
+    logger.setLevel(level)
     logger.addHandler(handler_stream)
 
     return handler_stream


### PR DESCRIPTION
## What was wrong?

The logic used to determine log levels was not behaving correctly when the log level was set to `0`.

## How was it fixed?

Updated the logic to do an explicit `is None`.

#### Cute Animal Picture

![ss-111014-unlikely-friends-elephant-sheep ss_full-1__880](https://user-images.githubusercontent.com/824194/96798781-d7ca3780-13be-11eb-8956-cb9f6a7f1cc8.jpg)

