### PR TITLE
NetworkAPI.talk raises ProtocolNotSupported

### DIFF
--- a/ddht/v5_1/exceptions.py
+++ b/ddht/v5_1/exceptions.py
@@ -1,2 +1,9 @@
-class SessionNotFound(Exception):
+from ddht.exceptions import BaseDDHTError
+
+
+class SessionNotFound(BaseDDHTError):
+    pass
+
+
+class ProtocolNotSupported(BaseDDHTError):
     pass

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -31,6 +31,7 @@ from ddht.v5_1.abc import (
     TalkProtocolAPI,
 )
 from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE
+from ddht.v5_1.exceptions import ProtocolNotSupported
 from ddht.v5_1.messages import (
     FindNodeMessage,
     PingMessage,
@@ -187,6 +188,9 @@ class Network(Service, NetworkAPI):
         response = await self.client.talk(
             node_id, endpoint, protocol, payload, request_id=request_id
         )
+        payload = response.message.payload
+        if not payload:
+            raise ProtocolNotSupported(protocol)
         return response.message.payload
 
     async def lookup_enr(


### PR DESCRIPTION
## What was wrong?

The TALKREQ and TALKRESP protocol rules specify that an empty response is used to signal that the client does not support the protocol.  We should not treat these as valid responses, however `NetworkAPI.talk` would return them as the empty bytestring.

## How was it fixed?

Changed `NetworkAPI.talk` to raise a new `ddht.v5_1.exceptions.ProtocolNotSupported` exception in this case.

#### Cute Animal Picture

![unlikely-animal-friendships-alliances-6](https://user-images.githubusercontent.com/824194/96906096-92f1df80-1456-11eb-8acc-ccfa8d2487d5.jpg)

