### PR TITLE
Include cli args in Application initialization

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import argparse
 from collections import UserDict
 from typing import (
     TYPE_CHECKING,
@@ -303,5 +304,5 @@ class RequestTrackerAPI(ABC):
 
 class ApplicationAPI(ServiceAPI):
     @abstractmethod
-    def __init__(self, boot_info: BootInfo) -> None:
+    def __init__(self, args: argparse.Namespace, boot_info: BootInfo) -> None:
         ...

--- a/ddht/app.py
+++ b/ddht/app.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 
 from async_service import Service
@@ -9,7 +10,9 @@ from ddht.boot_info import BootInfo
 class BaseApplication(Service, ApplicationAPI):
     logger = logging.getLogger("ddht.DDHT")
 
+    _args: argparse.Namespace
     _boot_info: BootInfo
 
-    def __init__(self, boot_info: BootInfo) -> None:
+    def __init__(self, args: argparse.Namespace, boot_info: BootInfo) -> None:
+        self._args = args
         self._boot_info = boot_info

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -32,7 +32,7 @@ async def do_crawl(args: argparse.Namespace, boot_info: BootInfo) -> None:
     if boot_info.protocol_version is not ProtocolVersion.v5:
         raise ValueError("Currently crawling is only supported on the v5 network.")
 
-    crawler = Crawler(args, boot_info, concurrency=32)
+    crawler = Crawler(args, boot_info)
 
     logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(crawler) as manager:

--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 
@@ -12,12 +13,12 @@ from ddht.v5_1.app import Application as ApplicationV5_1
 logger = logging.getLogger("ddht")
 
 
-async def do_main(boot_info: BootInfo) -> None:
+async def do_main(args: argparse.Namespace, boot_info: BootInfo) -> None:
     app: ServiceAPI
     if boot_info.protocol_version is ProtocolVersion.v5:
-        app = ApplicationV5(boot_info)
+        app = ApplicationV5(args, boot_info)
     elif boot_info.protocol_version is ProtocolVersion.v5_1:
-        app = ApplicationV5_1(boot_info)
+        app = ApplicationV5_1(args, boot_info)
     else:
         raise Exception(f"Unsupported protocol version: {boot_info.protocol_version}")
 
@@ -26,12 +27,12 @@ async def do_main(boot_info: BootInfo) -> None:
         await manager.wait_finished()
 
 
-async def do_crawl(boot_info: BootInfo) -> None:
+async def do_crawl(args: argparse.Namespace, boot_info: BootInfo) -> None:
 
     if boot_info.protocol_version is not ProtocolVersion.v5:
         raise ValueError("Currently crawling is only supported on the v5 network.")
 
-    crawler = Crawler(concurrency=32, boot_info=boot_info)
+    crawler = Crawler(args, boot_info, concurrency=32)
 
     logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(crawler) as manager:

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -142,9 +142,29 @@ crawl_parser = subparser.add_parser(
     help="Attempts to bond with as many nodes as possible and dumps all found ENRs",
 )
 crawl_parser.set_defaults(func=do_crawl)
+
+
+class ValidateConcurrency(argparse.Action):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        value: Any,
+        option_string: str = None,
+    ) -> None:
+        if value < 1:
+            parser.error(
+                "The value for --concurrency must be a a non-zero positive integer"
+            )
+            return
+
+        setattr(namespace, self.dest, value)
+
+
 crawl_parser.add_argument(
     "--concurrency",
     type=int,
+    action=ValidateConcurrency,
     help="The concurrency level for crawling the network",
     default=32,
     dest="crawl_concurrency",

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -142,3 +142,10 @@ crawl_parser = subparser.add_parser(
     help="Attempts to bond with as many nodes as possible and dumps all found ENRs",
 )
 crawl_parser.set_defaults(func=do_crawl)
+crawl_parser.add_argument(
+    "--concurrency",
+    type=int,
+    help="The concurrency level for crawling the network",
+    default=32,
+    dest="crawl_concurrency",
+)

--- a/ddht/main.py
+++ b/ddht/main.py
@@ -48,7 +48,7 @@ async def main() -> None:
     logger.info(DDHT_HEADER)
 
     try:
-        await args.func(boot_info)
+        await args.func(args, boot_info)
     finally:
         if boot_info.is_ephemeral:
             shutil.rmtree(boot_info.base_dir)

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -1,3 +1,4 @@
+import argparse
 import contextlib
 import logging
 from typing import Iterator, Set, Tuple
@@ -24,8 +25,10 @@ class _StopScanning(Exception):
 
 
 class Crawler(BaseApplication):
-    def __init__(self, concurrency: int, boot_info: BootInfo) -> None:
-        super().__init__(boot_info)
+    def __init__(
+        self, args: argparse.Namespace, boot_info: BootInfo, concurrency: int
+    ) -> None:
+        super().__init__(args, boot_info)
         self.concurrency = concurrency
 
         self.enr_db = ENRDB(dict(), default_identity_scheme_registry)

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -28,10 +28,6 @@ class Crawler(BaseApplication):
     def __init__(self, args: argparse.Namespace, boot_info: BootInfo) -> None:
         super().__init__(args, boot_info)
         self.concurrency = args.crawl_concurrency
-        if not self.concurrency > 0:
-            raise ValueError(
-                f"Concurrency value while crawling must be > 0: {self.concurrency}"
-            )
 
         self.enr_db = ENRDB(dict(), default_identity_scheme_registry)
 

--- a/ddht/v5/crawl.py
+++ b/ddht/v5/crawl.py
@@ -25,11 +25,13 @@ class _StopScanning(Exception):
 
 
 class Crawler(BaseApplication):
-    def __init__(
-        self, args: argparse.Namespace, boot_info: BootInfo, concurrency: int
-    ) -> None:
+    def __init__(self, args: argparse.Namespace, boot_info: BootInfo) -> None:
         super().__init__(args, boot_info)
-        self.concurrency = concurrency
+        self.concurrency = args.crawl_concurrency
+        if not self.concurrency > 0:
+            raise ValueError(
+                f"Concurrency value while crawling must be > 0: {self.concurrency}"
+            )
 
         self.enr_db = ENRDB(dict(), default_identity_scheme_registry)
 


### PR DESCRIPTION
## What was wrong?

When building up the CLI entry point for Alexandria I ended up needing access to the original `argparse.Namespace` object to be able to pull additional information off of the parser.

## How was it fixed?

Changed the `ApplicationAPI.__init__` signature to also include the parsed CLI args `argparse.Namespace` object.

I also changed the `Crawl` implementation to pull the concurrency value from CLI args rather than needing to change the initialization signature.


#### Cute Animal Picture

![mouse-frog](https://user-images.githubusercontent.com/824194/96907878-101e5400-1459-11eb-9dcd-0c5baadbc37b.jpeg)

