### PR TITLE
Register talk protocol in AlexandriaClient.__init__

### DIFF
--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -35,7 +35,6 @@ class AlexandriaNode(AlexandriaNodeAPI):
         async with self._lock.acquire("AlexandriaNode.client(...)"):
             async with network_context as network:
                 alexandria_client = AlexandriaClient(network)
-                network.add_talk_protocol(alexandria_client)
                 async with background_trio_service(alexandria_client):
                     yield alexandria_client
 
@@ -56,6 +55,5 @@ class AlexandriaNode(AlexandriaNodeAPI):
         async with self._lock.acquire("AlexandriaNode.network(...)"):
             async with network_context as network:
                 alexandria_network = AlexandriaNetwork(network, ())
-                network.add_talk_protocol(alexandria_network)
                 async with background_trio_service(alexandria_network):
                     yield alexandria_network

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -61,6 +61,8 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         self.request_tracker = RequestTracker()
         self.subscription_manager = SubscriptionManager()
 
+        network.add_talk_protocol(self)
+
         self._active_request_ids = set()
 
     #


### PR DESCRIPTION
## What was wrong?

The registering of the Alexandria `TalkProtocolAPI` with the `NetworkAPI` needs to happen reliably.

## How was it fixed?

Added logic to `AlexandriaClient.__init__` to register the protocol.

#### Cute Animal Picture

![Unlikely-Animal-Friends-10](https://user-images.githubusercontent.com/824194/96908094-67242900-1459-11eb-9e2f-12781037ac77.jpg)

