### PR TITLE
Fix race condition during shutdown of Network/Client/Dispatcher

### DIFF
--- a/ddht/v5_1/dispatcher.py
+++ b/ddht/v5_1/dispatcher.py
@@ -352,7 +352,12 @@ class Dispatcher(Service, DispatcherAPI):
     async def send_message(self, message: AnyOutboundMessage) -> None:
         if message.receiver_node_id == self._pool.local_node_id:
             raise Exception("Cannot send message to self")
-        await self._outbound_message_send_channel.send(message)
+        try:
+            await self._outbound_message_send_channel.send(message)
+        except trio.BrokenResourceError:
+            if self.manager.is_cancelled:
+                await trio.sleep(1)
+            raise
 
     #
     # Request Response


### PR DESCRIPTION
fixes #133

## What was wrong?

We have long running processes in the `NetworkAPI` that interact with the `DispatcherAPI`.  During shutdown, the dispatcher is shut down first, which means that sometimes the network API tries to interact with the dispatcher API when it has already started closing channels.

## How was it fixed?

Somewhat hacky, but effective is to detect this within the external facing dispatcher API and if the error occurs **and** we are in the process of shutting down, we introduce a small sleep.  Since we're in the process of shutting down, in normal situations the sleep will be interrupted by a cancellation, and no error will occur.


#### Cute Animal Picture

![12991778_768x1024](https://user-images.githubusercontent.com/824194/96913655-2b8d5d00-1461-11eb-8d0c-c6418f0f24a8.jpg)

