### PR TITLE
Fix broken logging message in KademliaRoutingTable

### DIFF
--- a/ddht/kademlia.py
+++ b/ddht/kademlia.py
@@ -262,7 +262,7 @@ class KademliaRoutingTable(RoutingTableAPI):
 
         if not in_bucket and not in_replacement_cache:
             self.logger.debug(
-                "Not removing %s as it is neither present in the bucket nor the replacement cache",
+                "Not removing %s as it is neither present in bucket-%d nor the replacement cache",
                 encode_hex(node_id),
                 bucket_index,
             )


### PR DESCRIPTION
## What was wrong?

One of the logging statements in the `KademliaRoutingTable` was broken, supplying more arguments than there were placeholders.

## How was it fixed?

Fixed string to also have a placeholder for the bucket index.

#### Cute Animal Picture

![slide_314094_2829162_free](https://user-images.githubusercontent.com/824194/96914090-c423dd00-1461-11eb-82da-dc2c6d8d97c6.jpg)
