### PR TITLE
Expand remaining AlexandriaNetworkAPI long running tasks

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -127,6 +127,12 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     # High Level Request/Response
     #
     @abstractmethod
+    async def bond(
+        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
+    ) -> bool:
+        ...
+
+    @abstractmethod
     async def ping(
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
     ) -> PongPayload:
@@ -143,7 +149,7 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         ...
 
     @abstractmethod
-    async def get_enr(
+    async def lookup_enr(
         self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
     ) -> ENRAPI:
         ...

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -101,6 +101,10 @@ class Network(Service, NetworkAPI):
     async def bond(
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
     ) -> bool:
+        self.logger.debug(
+            "Bonding with %s", node_id.hex(),
+        )
+
         try:
             pong = await self.ping(node_id, endpoint=endpoint)
         except trio.EndOfChannel:
@@ -118,6 +122,10 @@ class Network(Service, NetworkAPI):
             return False
 
         self.routing_table.update(enr.node_id)
+
+        self.logger.debug(
+            "Bonded with %s successfully", node_id.hex(),
+        )
 
         self._routing_table_ready.set()
         return True


### PR DESCRIPTION
## What was wrong?

The alexandria network needs to maintain the routing table in the same manner as the base protocol.  Not all of that functionality has been ported over.

## How was it fixed?

Largely just a copy/pasta from `NetworkAPI` implementation with only superficial updates.

I explicitely didn't copy over any tests that are currently being applied to the equivalent functionality under the `NetworkAPI` because those tests are largely flakey/fragile and I don't want to expand that problem.


#### Cute Animal Picture

![1302607266418](https://user-images.githubusercontent.com/824194/96938218-07dd0d80-1487-11eb-9d4a-9a5238279c7d.jpeg)

