### PR TITLE
Catch EndOfChannel error and raise TooSlowError instead

### DIFF
--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -215,7 +215,11 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
                 )
                 try:
                     async with receive_channel:
-                        yield receive_channel
+                        try:
+                            yield receive_channel
+                        # Wrap EOC error with TSE to make the timeouts obvious
+                        except trio.EndOfChannel as err:
+                            raise trio.TooSlowError from err
                 finally:
                     nursery.cancel_scope.cancel()
 

--- a/ddht/v5_1/dispatcher.py
+++ b/ddht/v5_1/dispatcher.py
@@ -383,7 +383,11 @@ class Dispatcher(Service, DispatcherAPI):
             )
             try:
                 async with receive_channel:
-                    yield receive_channel
+                    try:
+                        yield receive_channel
+                    # Wrap EOC error with TSE to make the timeouts obvious
+                    except trio.EndOfChannel as err:
+                        raise trio.TooSlowError from err
             finally:
                 nursery.cancel_scope.cancel()
 

--- a/newsfragments/139.bugfix.rst
+++ b/newsfragments/139.bugfix.rst
@@ -1,0 +1,1 @@
+Update dispatcher timeouts to wrap EndOfChannel errors as TooSlowError.

--- a/tests/core/v5_1/alexandria/test_alexandria_client.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_client.py
@@ -131,6 +131,16 @@ async def test_alexandria_client_send_find_nodes(
         assert message.payload.distances == (0, 255, 254)
 
 
+@pytest.mark.trio
+async def test_alexandria_client_find_nodes_timeout(
+    bob, alice_alexandria_client, autojump_clock,
+):
+    with pytest.raises(trio.TooSlowError):
+        await alice_alexandria_client.find_nodes(
+            bob.node_id, bob.endpoint, distances=(0, 255, 254),
+        )
+
+
 @pytest.mark.parametrize(
     "enrs",
     (

--- a/tests/core/v5_1/test_client.py
+++ b/tests/core/v5_1/test_client.py
@@ -196,7 +196,7 @@ async def test_client_request_response_ping_pong(alice, bob, alice_client, bob_c
 @pytest.mark.trio
 async def test_client_ping_timeout(alice, bob_client, autojump_clock):
     with trio.fail_after(60):
-        with pytest.raises(trio.EndOfChannel):
+        with pytest.raises(trio.TooSlowError):
             await bob_client.ping(alice.node_id, alice.endpoint)
 
 
@@ -288,7 +288,7 @@ async def test_client_talk_request_response(alice, bob, alice_client, bob_client
 @pytest.mark.trio
 async def test_client_talk_request_response_timeout(alice, bob_client, autojump_clock):
     with trio.fail_after(60):
-        with pytest.raises(trio.EndOfChannel):
+        with pytest.raises(trio.TooSlowError):
             await bob_client.talk(
                 alice.node_id,
                 alice.endpoint,

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -350,7 +350,7 @@ async def test_network_responds_to_unhandled_protocol_messages(
 
         alice_network.add_talk_protocol(ProtocolA())
 
-        with pytest.raises(trio.EndOfChannel):
+        with pytest.raises(trio.TooSlowError):
             response = await bob_client.talk(
                 node_id=alice.node_id,
                 protocol=ProtocolA.protocol_id,


### PR DESCRIPTION
## What was wrong?
Fixes https://github.com/ethereum/ddht/issues/115

## How was it fixed?

Summary of approach.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/97585799-8a098c80-19c7-11eb-9471-969718c14e46.png)
