### PR TITLE
Implement CLI entrypoint for Alexandria

### DIFF
--- a/ddht/cli_commands.py
+++ b/ddht/cli_commands.py
@@ -1,20 +1,22 @@
 import argparse
 import logging
-import os
 
-from async_service import ServiceAPI, background_trio_service
+from async_service import background_trio_service
 
+from ddht.abc import ApplicationAPI
 from ddht.boot_info import BootInfo
 from ddht.constants import ProtocolVersion
 from ddht.v5.app import Application as ApplicationV5
 from ddht.v5.crawl import Crawler
+from ddht.v5_1.alexandria.app import AlexandriaApplication
 from ddht.v5_1.app import Application as ApplicationV5_1
 
 logger = logging.getLogger("ddht")
 
 
 async def do_main(args: argparse.Namespace, boot_info: BootInfo) -> None:
-    app: ServiceAPI
+    app: ApplicationAPI
+
     if boot_info.protocol_version is ProtocolVersion.v5:
         app = ApplicationV5(args, boot_info)
     elif boot_info.protocol_version is ProtocolVersion.v5_1:
@@ -22,7 +24,6 @@ async def do_main(args: argparse.Namespace, boot_info: BootInfo) -> None:
     else:
         raise Exception(f"Unsupported protocol version: {boot_info.protocol_version}")
 
-    logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(app) as manager:
         await manager.wait_finished()
 
@@ -34,6 +35,12 @@ async def do_crawl(args: argparse.Namespace, boot_info: BootInfo) -> None:
 
     crawler = Crawler(args, boot_info)
 
-    logger.info("Started main process (pid=%d)", os.getpid())
     async with background_trio_service(crawler) as manager:
+        await manager.wait_finished()
+
+
+async def do_alexandria(args: argparse.Namespace, boot_info: BootInfo) -> None:
+    app = AlexandriaApplication(args, boot_info)
+
+    async with background_trio_service(app) as manager:
         await manager.wait_finished()

--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -6,18 +6,13 @@ from typing import Any
 from eth_enr import ENR
 
 from ddht import __version__
-from ddht.cli_commands import do_crawl, do_main
+from ddht.cli_commands import do_alexandria, do_crawl, do_main
 from ddht.constants import ProtocolVersion
 
 parser = argparse.ArgumentParser(description="Discovery V5 DHT")
 parser.set_defaults(func=do_main)
 
 parser.add_argument("--version", action="version", version=__version__)
-
-#
-# subparser for sub commands
-#
-subparser = parser.add_subparsers(dest="subcommand")
 
 #
 # Argument Groups
@@ -134,6 +129,15 @@ jsonrpc_parser.add_argument(
 )
 
 
+#############################
+#                           #
+# Subcommands go BELOW here #
+#                           #
+#############################
+
+subparser = parser.add_subparsers(dest="subcommand")
+
+
 #
 # Crawl Subcommand
 #
@@ -168,4 +172,30 @@ crawl_parser.add_argument(
     help="The concurrency level for crawling the network",
     default=32,
     dest="crawl_concurrency",
+)
+
+
+#
+# Alexandria Subcommand
+#
+alexandria_parser = subparser.add_parser(
+    "alexandria", help="Run the client as a node on the Alexandria network",
+)
+
+
+alexandria_parser.set_defaults(func=do_alexandria)
+
+alexandria_bootnodes_parser_group = alexandria_parser.add_mutually_exclusive_group()
+alexandria_bootnodes_parser_group.add_argument(
+    "--bootnode",
+    action=NormalizeAndAppendENR,
+    help="ENR for custom bootnode",
+    dest="alexandria_bootnodes",
+)
+alexandria_bootnodes_parser_group.add_argument(
+    "--no-bootstrap",
+    help="Start without any bootnodes",
+    action="store_const",
+    const=(),
+    dest="alexandria_bootnodes",
 )

--- a/ddht/main.py
+++ b/ddht/main.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 
 from ddht.boot_info import BootInfo
@@ -46,6 +47,8 @@ async def main() -> None:
     setup_logging(log_file, args.log_level_file, args.log_level_stderr)
 
     logger.info(DDHT_HEADER)
+
+    logger.info("Started main process (pid=%d)", os.getpid())
 
     try:
         await args.func(args, boot_info)

--- a/ddht/rpc.py
+++ b/ddht/rpc.py
@@ -166,7 +166,7 @@ fallback_handler = UnknownMethodHandler()
 
 
 class RPCServer(Service):
-    logger = logging.getLogger("alexandria.rpc.RPCServer")
+    logger = logging.getLogger("ddht.RPCServer")
     _handlers: Dict[str, RPCHandlerAPI]
 
     def __init__(

--- a/ddht/v5_1/alexandria/app.py
+++ b/ddht/v5_1/alexandria/app.py
@@ -1,0 +1,32 @@
+import argparse
+
+from ddht.app import BaseApplication
+from ddht.boot_info import BootInfo
+from ddht.v5_1.alexandria.boot_info import AlexandriaBootInfo
+from ddht.v5_1.alexandria.network import AlexandriaNetwork
+from ddht.v5_1.app import Application
+
+
+class AlexandriaApplication(BaseApplication):
+    base_protocol_app: Application
+
+    def __init__(self, args: argparse.Namespace, boot_info: BootInfo) -> None:
+        super().__init__(args, boot_info)
+        self._alexandria_boot_info = AlexandriaBootInfo.from_namespace(self._args)
+        self.base_protocol_app = Application(self._args, self._boot_info)
+
+    async def run(self) -> None:
+        self.manager.run_daemon_child_service(self.base_protocol_app)
+
+        await self.base_protocol_app.wait_ready()
+
+        alexandria_network = AlexandriaNetwork(
+            network=self.base_protocol_app.network,
+            bootnodes=self._alexandria_boot_info.bootnodes,
+        )
+
+        self.manager.run_daemon_child_service(alexandria_network)
+
+        self.logger.info("Starting Alexandria...")
+
+        await self.manager.wait_finished()

--- a/ddht/v5_1/alexandria/boot_info.py
+++ b/ddht/v5_1/alexandria/boot_info.py
@@ -1,0 +1,39 @@
+import argparse
+from dataclasses import dataclass
+from typing import Sequence, Tuple, TypedDict
+
+from eth_enr import ENR
+from eth_enr.abc import ENRAPI
+
+from ddht.v5_1.alexandria.constants import DEFAULT_BOOTNODES
+
+
+class AlexandriaBootInfoKwargs(TypedDict, total=False):
+    bootnodes: Tuple[ENRAPI, ...]
+
+
+def _cli_args_to_boot_info_kwargs(args: argparse.Namespace) -> AlexandriaBootInfoKwargs:
+    if args.alexandria_bootnodes is None:
+        bootnodes = tuple(ENR.from_repr(enr_repr) for enr_repr in DEFAULT_BOOTNODES)
+    else:
+        bootnodes = args.alexandria_bootnodes
+
+    return AlexandriaBootInfoKwargs(bootnodes=bootnodes,)
+
+
+@dataclass(frozen=True)
+class AlexandriaBootInfo:
+    bootnodes: Tuple[ENRAPI, ...]
+
+    @classmethod
+    def from_cli_args(cls, args: Sequence[str]) -> "AlexandriaBootInfo":
+        # Import here to prevent circular imports
+        from ddht.cli_parser import parser
+
+        namespace = parser.parse_args(args)
+        return cls.from_namespace(namespace)
+
+    @classmethod
+    def from_namespace(cls, args: argparse.Namespace) -> "AlexandriaBootInfo":
+        kwargs = _cli_args_to_boot_info_kwargs(args)
+        return cls(**kwargs)

--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -1,1 +1,5 @@
+from typing import Tuple
+
 ALEXANDRIA_PROTOCOL_ID = b"alexandria"
+
+DEFAULT_BOOTNODES: Tuple[str, ...] = ()

--- a/newsfragments/140.feature.rst
+++ b/newsfragments/140.feature.rst
@@ -1,0 +1,1 @@
+Implement CLI entry point for running Alexandria client.


### PR DESCRIPTION
## What was wrong?

We need a CLI entry point for the Alexandria client

## How was it fixed?

Wired up an `ApplicationAPI` instance that runs both the base v5.1 network and the AlexandriaNetwork on top of it.

#### Cute Animal Picture

![6a00d8341bf8f353ef0154325cdbc0970c-800wi](https://user-images.githubusercontent.com/824194/97589249-ea49ff80-19c2-11eb-838c-0e7a1d65c811.jpeg)

