### PR TITLE
Add LEB128 parser and encoder

### DIFF
--- a/ddht/exceptions.py
+++ b/ddht/exceptions.py
@@ -14,6 +14,14 @@ class DecodingError(BaseDDHTError):
     pass
 
 
+class ParseError(BaseDDHTError):
+    """
+    Raised as a generic error when trying to parse something.
+    """
+
+    pass
+
+
 class DecryptionError(BaseDDHTError):
     """
     Raised when a message could not be decrypted.

--- a/ddht/v5_1/alexandria/leb128.py
+++ b/ddht/v5_1/alexandria/leb128.py
@@ -1,0 +1,59 @@
+import functools
+import itertools
+import math
+import operator
+from typing import IO, Iterable
+
+from ddht.exceptions import ParseError
+
+LOW_MASK = 2 ** 7 - 1
+HIGH_MASK = 2 ** 7
+
+
+def encode_leb128(value: int) -> bytes:
+    return bytes(bytearray(_encode_leb128(value)))
+
+
+def _encode_leb128(value: int) -> Iterable[int]:
+    while True:
+        byte = value & LOW_MASK
+
+        value >>= 7
+
+        if value == 0:
+            yield byte
+            break
+        else:
+            yield byte | HIGH_MASK
+
+
+def parse_leb128(stream: IO[bytes]) -> int:
+    """
+    https://en.wikipedia.org/wiki/LEB128
+    """
+    return functools.reduce(operator.or_, _parse_leb128(stream), 0,)
+
+
+# The maximum shift width for a 64 bit integer.  We shouldn't have to decode
+# integers larger than this.
+SHIFT_64_BIT_MAX = int(math.ceil(64 / 7)) * 7
+
+
+def _parse_leb128(stream: IO[bytes]) -> Iterable[int]:
+    for shift in itertools.count(0, 7):
+        if shift > SHIFT_64_BIT_MAX:
+            raise ParseError("Decoded integer exceeds maximum decodable size...")
+
+        byte = stream.read(1)
+
+        try:
+            value = byte[0]
+        except IndexError:
+            raise ParseError(
+                "Unexpected end of stream while parsing LEB128 encoded integer"
+            )
+
+        yield (value & LOW_MASK) << shift
+
+        if not value & HIGH_MASK:
+            break

--- a/tests/core/v5_1/alexandria/test_leb128.py
+++ b/tests/core/v5_1/alexandria/test_leb128.py
@@ -1,0 +1,30 @@
+import io
+
+from hypothesis import given
+from hypothesis import strategies as st
+import pytest
+
+from ddht.v5_1.alexandria.leb128 import encode_leb128, parse_leb128
+
+
+@pytest.mark.parametrize(
+    "value,expected", ((b"\x00", 0), (b"\xe5\x8e\x26", 624485),),
+)
+def test_parse_leb128(value, expected):
+    actual = parse_leb128(io.BytesIO(value))
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected", ((0, b"\x00"), (624485, b"\xe5\x8e\x26"),),
+)
+def test_encode_leb128(value, expected):
+    actual = encode_leb128(value)
+    assert actual == expected
+
+
+@given(value=st.integers(min_value=0, max_value=2 ** 32 - 1))
+def test_leb128_encoding_round_trip(value):
+    encoded_value = encode_leb128(value)
+    decoded_value = parse_leb128(io.BytesIO(encoded_value))
+    assert decoded_value == value


### PR DESCRIPTION
## What was wrong?

We need tools for dealing with LEB128 encoded integers as part of the SSZ partial proofs used for content transmission in the Alexandria network.

## How was it fixed?

Copy/Pasta for the most part from the [implementation in py-wasm](https://github.com/ethereum/py-wasm/blob/41a6d07a620dfc4f590463dd038dffe4efe0c8c6/wasm/parsers/leb128.py)

#### Cute Animal Picture

![motherhengoldenpup](https://user-images.githubusercontent.com/824194/97595323-34ce7a80-19c9-11eb-9cf1-4fa4ee7b408c.jpeg)

