### PR TITLE
Add ssz chunking implementation

### DIFF
--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -3,3 +3,10 @@ from typing import Tuple
 ALEXANDRIA_PROTOCOL_ID = b"alexandria"
 
 DEFAULT_BOOTNODES: Tuple[str, ...] = ()
+
+# 1 gigabyte
+GB = 1024 * 1024 * 1024  # 2**30
+
+
+# All of the powers of two
+POWERS_OF_TWO = tuple(2 ** n for n in range(256))

--- a/ddht/v5_1/alexandria/partials/_utils.py
+++ b/ddht/v5_1/alexandria/partials/_utils.py
@@ -1,0 +1,49 @@
+from typing import Iterable
+
+from eth_utils import to_tuple
+from ssz.constants import CHUNK_SIZE
+
+from ddht.v5_1.alexandria.constants import POWERS_OF_TWO
+
+from .typing import TreePath
+
+
+def display_path(path: TreePath) -> str:
+    """
+    Converts a tree path to a string of 1s and 0s for more legible display.
+    """
+    return "".join((str(int(bit)) for bit in path))
+
+
+@to_tuple
+def decompose_into_powers_of_two(value: int) -> Iterable[int]:
+    for i in range(value.bit_length()):
+        power_of_two = POWERS_OF_TWO[i]
+        if value & power_of_two:
+            yield power_of_two
+
+
+@to_tuple
+def get_longest_common_path(*paths: TreePath) -> Iterable[bool]:
+    """
+    Return the longs common prefix for the provided paths.
+    """
+    if not paths:
+        return
+    elif len(paths) == 1:
+        yield from paths[0]
+        return
+    elif not any(paths):
+        return
+
+    for crumbs in zip(*paths):
+        if all(crumbs) or not any(crumbs):
+            yield crumbs[0]
+        else:
+            break
+
+
+def get_chunk_count_for_data_length(length: int) -> int:
+    if length == 0:
+        return 0
+    return (length + CHUNK_SIZE - 1) // CHUNK_SIZE  # type: ignore

--- a/ddht/v5_1/alexandria/partials/chunking.py
+++ b/ddht/v5_1/alexandria/partials/chunking.py
@@ -1,0 +1,221 @@
+import itertools
+from typing import Iterable, List, Sequence, Tuple
+
+from eth_typing import Hash32
+from eth_utils import to_tuple
+from eth_utils.toolz import sliding_window
+from ssz.constants import CHUNK_SIZE, ZERO_BYTES32
+
+from ddht.v5_1.alexandria.constants import GB, POWERS_OF_TWO
+from ddht.v5_1.alexandria.partials.typing import TreePath
+
+
+@to_tuple
+def compute_chunks(data: bytes) -> Iterable[Hash32]:
+    """
+    An optimized version of SSZ chunk computation specifically for byte
+    strings.
+    """
+    if not data:
+        yield ZERO_BYTES32
+        return
+    elif len(data) > GB:
+        raise Exception("too big")
+    data_length = len(data)
+    if data_length % CHUNK_SIZE == 0:
+        padded_data = data
+    else:
+        padding_byte_count = CHUNK_SIZE - data_length % CHUNK_SIZE
+        padded_data = data + b"\x00" * padding_byte_count
+
+    padded_length = len(padded_data)
+    for left_boundary, right_boundary in sliding_window(
+        2, range(0, padded_length + 1, CHUNK_SIZE)
+    ):
+        yield Hash32(padded_data[left_boundary:right_boundary])
+
+
+@to_tuple
+def chunk_index_to_path(index: int, path_bit_size: int) -> Iterable[bool]:
+    """
+    Given a chunk index, convert it to the path into the binary tree where the
+    chunk is located.
+    """
+    for power_of_two in reversed(POWERS_OF_TWO[:path_bit_size]):
+        yield bool(index & power_of_two)
+
+
+def path_to_left_chunk_index(path: TreePath, path_bit_size: int) -> int:
+    """
+    Given a path, convert it to a chunk index.  In the case where the path is
+    to an intermediate tree node, return the chunk index on the leftmost branch
+    of the subtree.
+    """
+    return sum(
+        power_of_two
+        for path_bit, power_of_two in itertools.zip_longest(
+            path, reversed(POWERS_OF_TWO[:path_bit_size]), fillvalue=False,
+        )
+        if path_bit
+    )
+
+
+@to_tuple
+def group_by_subtree(
+    first_chunk_index: int, num_chunks: int
+) -> Iterable[Tuple[int, ...]]:
+    r"""
+    Group the paths into groups that belong to the same subtree.
+
+    This helper function is used when constructing partial proofs. After
+    setting aside the leaf nodes that correspond to the data we wish to prove,
+    the remaining leaf nodes can be replaced by the hashes of the largest
+    subtrees that contains them.
+
+    Given a 4-bit tree like this
+
+    0:                           0
+                                / \
+                              /     \
+                            /         \
+                          /             \
+                        /                 \
+                      /                     \
+                    /                         \
+    1:             0                           1
+                 /   \                       /   \
+               /       \                   /       \
+             /           \               /           \
+    2:      0             1             0             1
+          /   \         /   \         /   \         /   \
+    3:   0     1       0     1       0     1       0     1
+        / \   / \     / \   / \     / \   / \     / \   / \
+    4: A   B C   D   E   F G   H   I   J K   L   M   N O   P
+
+                |-------------------------|
+
+    If we are given the chunks D-K which map to indices 3-10 we want them
+    divided up into the largest subgroups that all belong in the same subtree.
+
+    2:      0             1             0             1
+          /   \         /   \         /   \         /   \
+    3:   0     1       0     1       0     1       0     1
+        / \   / \     / \   / \     / \   / \     / \   / \
+    4: A   B C   D   E   F G   H   I   J K   L   M   N O   P
+                |-| |-----------| |-----|-|
+
+    These groups are
+
+    - D
+    - E, F, G, H
+    - I, J
+    - K
+
+    The algorithm for doing this is as follows:
+
+    1) Find the largest power of 2 that can fit into the chunk range.  This is
+    referred to as the `group_size`.  For this example the number is 8 since we
+    have a span of 8 items.  Divide the range up into groups aligned with this
+    value.
+
+
+    3:   0     1       0     1       0     1       0     1
+        / \   / \     / \   / \     / \   / \     / \   / \
+    4: A   B C   D   E   F G   H   I   J K   L   M   N O   P
+
+                |-------------------------|
+                (D, E, F, G, H)    (I, J, K)
+       <=========(0-7)=========>   <=========8-16==========>
+
+    2) Any group that is the full lenght (in this case 8) is final.  All groups
+    that are not full move onto the next round. In this case none of the groups
+    are final.
+
+    3) Now we change our group size to the previous power of two which is 4 in
+    this case. Again we divide the range up into groups of this size.
+
+
+    3:   0     1       0     1       0     1       0     1
+        / \   / \     / \   / \     / \   / \     / \   / \
+    4: A   B C   D   E   F G   H   I   J K   L   M   N O   P
+
+                |-------------------------|
+                (D)  (E, F, G, H)  (I, J, K)
+       <==(0-3)==>   <==(4-7)==>   <==(8-11)=>   <=(12-15)=>
+
+    4) In this case the group `(E, F, G, H)` is full so it moves into the
+    *final* category, leaving the range (D,) and (I, J, K) for the next round
+    which uses 2 as the group size.
+
+    3:   0     1       0     1       0     1       0     1
+        / \   / \     / \   / \     / \   / \     / \   / \
+    4: A   B C   D   E   F G   H   I   J K   L   M   N O   P
+
+                |-------------------------|
+                (D)                (I, J) (K)
+       <0-1> <2-3>   <4-5> <6-7>   <8-9> <10-11> ...
+
+    5) At group size 2 we finalize (I, J). All remaining groups will finalize
+    at group size 1.
+
+    """
+    last_chunk_index = first_chunk_index + num_chunks
+
+    chunk_indices = tuple(range(first_chunk_index, last_chunk_index))
+    chunks_to_process: Sequence[Tuple[int, ...]] = (chunk_indices,)
+
+    # The largest power of two that could fit between the chunk range.
+    max_bucket_bit_size = num_chunks.bit_length() - 1
+
+    final_groups: List[Tuple[int, ...]] = []
+
+    # Now we iterate downwards through the powers of two, splitting each group
+    # up by the bucket boundaries at that level.  Any full buckets are
+    # considered final, leaving the remaining ranges for smaller buckets.  The
+    # final bucket size of `1` acts as a catch all for any ranges that cannot
+    # be grouped.
+    for bucket_bit_size in range(max_bucket_bit_size, -1, -1):
+        if not chunks_to_process:
+            break
+
+        next_chunks_to_process: List[Tuple[int, ...]] = []
+
+        for chunk in chunks_to_process:
+            chunk_start_index = chunk[0]
+            chunk_end_index = chunk[-1]
+
+            bucket_size = 2 ** bucket_bit_size
+
+            # Compute the start and end indices for the buckets at this bucket size.
+            bucket_start_at = chunk_start_index - (chunk_start_index % bucket_size)
+            bucket_end_at = chunk_end_index + (
+                bucket_size - chunk_end_index % bucket_size
+            )
+
+            # Split the chunk up into groups aligned with the buckets at this
+            # level.
+            group_candidates = tuple(
+                chunk[
+                    max(0, start_at - chunk_start_index) : start_at
+                    - chunk_start_index
+                    + bucket_size
+                ]  # noqa: E501
+                for start_at in range(bucket_start_at, bucket_end_at + 1, bucket_size)
+            )
+
+            # Any groups that are "full" are final.
+            final_groups.extend(
+                tuple(group for group in group_candidates if len(group) == bucket_size)
+            )
+
+            # All remaining groups move onto the next round (filtering out
+            # empty groups that occur due to how they are sliced)
+            next_chunks_to_process.extend(
+                filter(
+                    bool,
+                    (group for group in group_candidates if len(group) < bucket_size),
+                )
+            )
+        chunks_to_process = next_chunks_to_process
+
+    return tuple(sorted(final_groups))

--- a/ddht/v5_1/alexandria/partials/chunking.py
+++ b/ddht/v5_1/alexandria/partials/chunking.py
@@ -13,8 +13,11 @@ from ddht.v5_1.alexandria.partials.typing import TreePath
 @to_tuple
 def compute_chunks(data: bytes) -> Iterable[Hash32]:
     """
-    An optimized version of SSZ chunk computation specifically for byte
+    An optimized version of SSZ chunking specifically for byte
     strings.
+
+    Takes the data and splits it into chunks of length 32.  The last chunk is
+    padded out to 32 bytes with null bytes `0x00` if it is not full.
     """
     if not data:
         yield ZERO_BYTES32

--- a/ddht/v5_1/alexandria/partials/typing.py
+++ b/ddht/v5_1/alexandria/partials/typing.py
@@ -1,0 +1,5 @@
+from typing import Tuple
+
+# TODO: look into using https://github.com/ilanschnell/bitarray once we have a
+# benchmarking suite in place to evaluate impact.
+TreePath = Tuple[bool, ...]

--- a/tests/core/v5_1/alexandria/test_partial_utils.py
+++ b/tests/core/v5_1/alexandria/test_partial_utils.py
@@ -2,6 +2,7 @@ import pytest
 
 from ddht.v5_1.alexandria.partials._utils import (
     decompose_into_powers_of_two,
+    display_path,
     get_chunk_count_for_data_length,
     get_longest_common_path,
 )
@@ -56,4 +57,21 @@ def test_decompose_into_powers_of_two(value, expected):
 )
 def test_get_chunk_count_for_data_length(length, expected):
     actual = get_chunk_count_for_data_length(length)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    (
+        (p(), ""),
+        (p(0), "0"),
+        (p(1), "1"),
+        (p(0, 1), "01"),
+        (p(1, 0), "10"),
+        (p(1, 0, 1, 0, 1, 0, 1), "1010101"),
+        (p(0, 1, 0, 1, 0, 1, 0), "0101010"),
+    ),
+)
+def test_display_path(path, expected):
+    actual = display_path(path)
     assert actual == expected

--- a/tests/core/v5_1/alexandria/test_partial_utils.py
+++ b/tests/core/v5_1/alexandria/test_partial_utils.py
@@ -1,0 +1,59 @@
+import pytest
+
+from ddht.v5_1.alexandria.partials._utils import (
+    decompose_into_powers_of_two,
+    get_chunk_count_for_data_length,
+    get_longest_common_path,
+)
+
+
+def p(*crumbs):
+    return tuple(bool(crumb) for crumb in crumbs)
+
+
+@pytest.mark.parametrize(
+    "paths,expected",
+    (
+        ((), (),),  # no paths
+        ((p(0, 1, 0),), p(0, 1, 0),),  # single path
+        (((),), (),),  # single empty path
+        (((), ()), (),),  # all empty paths
+        ((p(1, 1, 1), p(0, 0, 0)), (),),  # no common crumbs
+        ((p(0, 1, 1), p(0, 0, 0)), p(0,),),  # single crumb in common
+        ((p(0, 0, 1), p(0, 0, 0)), p(0, 0),),  # multiple crumbs in common
+        ((p(0, 0, 0), p(0, 0, 0)), p(0, 0, 0),),  # all crumbs in common
+    ),
+)
+def test_get_longest_common_path(paths, expected):
+    common_path = get_longest_common_path(*paths)
+    assert common_path == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    (
+        (1, (1,)),
+        (2, (2,)),
+        (3, (1, 2)),
+        (4, (4,)),
+        (5, (1, 4)),
+        (6, (2, 4)),
+        (7, (1, 2, 4)),
+        (8, (8,)),
+        (9, (1, 8)),
+        (31, (1, 2, 4, 8, 16)),
+        (33, (1, 32)),
+    ),
+)
+def test_decompose_into_powers_of_two(value, expected):
+    actual = decompose_into_powers_of_two(value)
+    assert actual == expected
+    assert sum(actual) == value
+
+
+@pytest.mark.parametrize(
+    "length,expected", ((0, 0), (1, 1), (31, 1), (32, 1), (33, 2),),
+)
+def test_get_chunk_count_for_data_length(length, expected):
+    actual = get_chunk_count_for_data_length(length)
+    assert actual == expected

--- a/tests/core/v5_1/alexandria/test_ssz_chunking.py
+++ b/tests/core/v5_1/alexandria/test_ssz_chunking.py
@@ -42,7 +42,7 @@ def test_ssz_compute_chunks(content):
         start_at = chunk_index * CHUNK_SIZE
         end_at = min(len(content), start_at + CHUNK_SIZE)
 
-        assert chunk == content[start_at:end_at].ljust(32, b"\x00")
+        assert chunk == content[start_at:end_at].ljust(CHUNK_SIZE, b"\x00")
 
         if chunk_index == expected_chunk_count - 1:
             padding_start_idx = len(content) % CHUNK_SIZE

--- a/tests/core/v5_1/alexandria/test_ssz_chunking.py
+++ b/tests/core/v5_1/alexandria/test_ssz_chunking.py
@@ -1,0 +1,130 @@
+from hypothesis import example, given, settings
+from hypothesis import strategies as st
+import pytest
+from ssz.constants import CHUNK_SIZE
+
+from ddht.v5_1.alexandria.constants import GB
+from ddht.v5_1.alexandria.partials._utils import get_chunk_count_for_data_length
+from ddht.v5_1.alexandria.partials.chunking import (
+    chunk_index_to_path,
+    compute_chunks,
+    group_by_subtree,
+    path_to_left_chunk_index,
+)
+
+
+@settings(max_examples=1000)
+@example(content=b"\x00" * 31)
+@example(content=b"\x00" * 32)
+@example(content=b"\x00" * 33)
+@example(content=b"\x01" * 31)
+@example(content=b"\x01" * 32)
+@example(content=b"\x01" * 33)
+@example(
+    content=b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00"  # noqa: E501
+)
+@given(content=st.binary(min_size=0, max_size=GB))
+def test_ssz_compute_chunks(content):
+    # TODO: clear up this discrepancy.  When the content is the empty
+    # bytestring, we actually have zero chunks, but most of the code treats it
+    # as if there is always one chunk, even though there technically is only
+    # padding in the tree.
+    if len(content):
+        expected_chunk_count = get_chunk_count_for_data_length(len(content))
+    else:
+        expected_chunk_count = 1
+
+    chunks = compute_chunks(content)
+
+    assert len(chunks) == expected_chunk_count
+
+    for chunk_index, chunk in enumerate(chunks):
+        start_at = chunk_index * CHUNK_SIZE
+        end_at = min(len(content), start_at + CHUNK_SIZE)
+
+        assert chunk == content[start_at:end_at].ljust(32, b"\x00")
+
+        if chunk_index == expected_chunk_count - 1:
+            padding_start_idx = len(content) % CHUNK_SIZE
+            if padding_start_idx:
+                padding = chunk[padding_start_idx:]
+                assert all(tuple(byte == 0 for byte in padding))
+
+
+def p(*crumbs):
+    return tuple(bool(crumb) for crumb in crumbs)
+
+
+@pytest.mark.parametrize(
+    "chunk_index,expected",
+    ((0, p(0, 0, 0, 0)), (1, p(0, 0, 0, 1)), (3, p(0, 0, 1, 1)), (15, p(1, 1, 1, 1)),),
+)
+def test_chunk_index_to_path(chunk_index, expected):
+    path = chunk_index_to_path(chunk_index, 4)
+    assert path == expected
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    (
+        (p(0, 0, 0, 0), 0),
+        (p(0, 0, 0), 0),
+        (p(0, 0), 0),
+        (p(0,), 0),
+        (p(0, 0, 0, 1), 1),
+        (p(0, 0, 1, 1), 3),
+        (p(0, 0, 1), 2),
+        (p(1, 1, 1, 1), 15),
+        (p(1, 1, 1), 14),
+        (p(1, 1), 12),
+        (p(1,), 8),
+    ),
+)
+def test_path_to_left_chunk_index(path, expected):
+    chunk_index = path_to_left_chunk_index(path, 4)
+    assert chunk_index == expected
+
+
+@pytest.mark.parametrize(
+    "first_chunk_index,num_chunks,expected",
+    (
+        # Tree for reference
+        #
+        # 0:                            0
+        #                              / \
+        #                            /     \
+        #                          /         \
+        #                        /             \
+        #                      /                 \
+        #                    /                     \
+        #                  /                         \
+        # 1:              0                           1
+        #               /   \                       /   \
+        #             /       \                   /       \
+        #           /           \               /           \
+        # 2:       0             1             0             1
+        #        /   \         /   \         /   \         /   \
+        # 3:    0     1       0     1       0     1       0     1
+        #      / \   / \     / \   / \     / \   / \     / \   / \
+        # 4:  A   B C   D   E   F G   H   I   J K   L   M   N O   P
+        #
+        # Indices:
+        #     0   1 2   3   4   5 6   7   8   9 1   1   1   1 1   1
+        #                                       0   1   2   3 4   5
+        (0, 1, ((0,),)),
+        (1, 1, ((1,),)),
+        (2, 1, ((2,),)),
+        (3, 1, ((3,),)),
+        (4, 1, ((4,),)),
+        (5, 1, ((5,),)),
+        (6, 1, ((6,),)),
+        (7, 1, ((7,),)),
+        (8, 1, ((8,),)),
+        (9, 1, ((9,),)),
+        (9, 4, ((9,), (10, 11), (12,))),
+        (3, 8, ((3,), (4, 5, 6, 7), (8, 9), (10,),),),
+    ),
+)
+def test_groub_by_subtree(first_chunk_index, num_chunks, expected):
+    actual = group_by_subtree(first_chunk_index, num_chunks)
+    assert actual == expected


### PR DESCRIPTION
## What was wrong?

In order to support verifiable transmission of content over multiple messages we need proofs.

## How was it fixed?

Using SSZ as the spec for merklization, this implements a chunking implementation that is optimized for strings of bytes.

#### Cute Animal Picture

![bwct6e-1](https://user-images.githubusercontent.com/824194/97735353-d88a5a00-1a9f-11eb-8b27-455f1bbd3dbc.jpg)

