### PR TITLE
Implement proof tree

### DIFF
--- a/ddht/v5_1/alexandria/partials/chunking.py
+++ b/ddht/v5_1/alexandria/partials/chunking.py
@@ -202,7 +202,7 @@ def group_by_subtree(
                     max(0, start_at - chunk_start_index) : start_at
                     - chunk_start_index
                     + bucket_size
-                ]  # noqa: E501
+                ]
                 for start_at in range(bucket_start_at, bucket_end_at + 1, bucket_size)
             )
 

--- a/ddht/v5_1/alexandria/partials/proof.py
+++ b/ddht/v5_1/alexandria/partials/proof.py
@@ -1,0 +1,144 @@
+from dataclasses import dataclass
+import operator
+from typing import Any, Collection, Iterable, Optional, Sequence, Tuple
+
+from eth_typing import Hash32
+from eth_utils import to_tuple
+from ssz.constants import CHUNK_SIZE, ZERO_HASHES
+from ssz.sedes import List as ListSedes
+
+from ddht.v5_1.alexandria.partials._utils import (
+    decompose_into_powers_of_two,
+    display_path,
+)
+from ddht.v5_1.alexandria.partials.chunking import chunk_index_to_path, compute_chunks
+from ddht.v5_1.alexandria.partials.tree import ProofTree, construct_node_tree
+from ddht.v5_1.alexandria.partials.typing import TreePath
+
+
+@dataclass(frozen=True)
+class ProofElement:
+    path: TreePath
+    value: Hash32
+
+    @property
+    def depth(self) -> int:
+        return len(self.path)
+
+    def __str__(self) -> str:
+        return f"{display_path(self.path)}: {self.value.hex()}"
+
+
+class Proof:
+    """
+    Representation of a merkle proof for an SSZ byte string (aka List[uint8,
+    max_length=...]).
+    """
+
+    # TODO: look at where `self.sedes` is actually used and figure out if it belongs in this class.
+    sedes: ListSedes
+    # TODO: footgun.  Without performing verification (validate_proof(proof))
+    # we don't know this value is actually valid.
+    hash_tree_root: Hash32
+    elements: Tuple[ProofElement, ...]
+
+    _tree_cache: Optional[ProofTree] = None
+
+    def __init__(
+        self,
+        hash_tree_root: Hash32,
+        elements: Collection[ProofElement],
+        sedes: ListSedes,
+        tree: Optional[ProofTree] = None,
+    ) -> None:
+        self.hash_tree_root = hash_tree_root
+        self.elements = tuple(sorted(elements, key=operator.attrgetter("path")))
+        self.sedes = sedes
+        self._tree_cache = tree
+
+    def __eq__(self, other: Any) -> bool:
+        if type(self) is not type(other):
+            return False
+        else:
+            return (  # type: ignore
+                self.hash_tree_root == other.hash_tree_root
+                and self.elements == other.elements
+            )
+
+    @property
+    def path_bit_length(self) -> int:
+        return self.sedes.chunk_count.bit_length()  # type: ignore
+
+    def get_tree(self) -> ProofTree:
+        # TODO: Measure cost of tree construction.  The tree is useful for
+        # proof construction but it's probably more expensive than is necessary
+        # for verifying state root.  Also, it uses a lot of recursive
+        # algorithms which aren't very efficient.
+        if self._tree_cache is None:
+            tree_data = tuple((el.path, el.value) for el in self.elements)
+            root_node = construct_node_tree(tree_data, (), self.path_bit_length)
+            self._tree_cache = ProofTree(root_node)
+        return self._tree_cache
+
+
+@to_tuple
+def compute_proof_elements(
+    chunks: Sequence[Hash32], chunk_count: int
+) -> Iterable[ProofElement]:
+    """
+    Compute all of the proof elements, including the right hand padding
+    elements for a proof over the given chunks.
+    """
+    # By using the full bit-length here we leave room for the length which gets
+    # mixed in at the root of the tree.
+    path_bit_length = chunk_count.bit_length()
+
+    for idx, chunk in enumerate(chunks):
+        path = chunk_index_to_path(idx, path_bit_length)
+        yield ProofElement(path, chunk)
+
+    start_index = len(chunks) - 1
+    num_padding_chunks = chunk_count - len(chunks)
+
+    yield from get_padding_elements(start_index, num_padding_chunks, path_bit_length)
+
+
+def compute_proof(data: bytes, sedes: ListSedes) -> Proof:
+    """
+    Compute the full proof, including the mixed-in length value.
+    """
+    chunks = compute_chunks(data)
+
+    chunk_count = sedes.chunk_count
+    path_bit_length = chunk_count.bit_length()
+
+    data_elements = compute_proof_elements(chunks, chunk_count)
+    length_element = ProofElement(
+        path=(True,), value=Hash32(len(data).to_bytes(CHUNK_SIZE, "little")),
+    )
+    all_elements = data_elements + (length_element,)
+    tree_data = tuple((el.path, el.value) for el in all_elements)
+
+    root_node = construct_node_tree(tree_data, (), path_bit_length)
+    tree = ProofTree(root_node)
+    hash_tree_root = tree.get_hash_tree_root()
+
+    return Proof(hash_tree_root, all_elements, sedes, tree=tree)
+
+
+@to_tuple
+def get_padding_elements(
+    start_index: int, num_padding_chunks: int, path_bit_length: int
+) -> Iterable[ProofElement]:
+    """
+    Get the padding elements for a proof.
+    By decomposing the number of chunks needed into the powers of two which
+    make up the number we can construct the minimal right hand sub-tree(s)
+    needed to pad the hash tree.
+    """
+    for power_of_two in decompose_into_powers_of_two(num_padding_chunks):
+        depth = power_of_two.bit_length() - 1
+        left_index = start_index + power_of_two
+        left_path = chunk_index_to_path(left_index, path_bit_length)
+        padding_hash_tree_root = ZERO_HASHES[depth]
+        yield ProofElement(left_path[: path_bit_length - depth], padding_hash_tree_root)

--- a/ddht/v5_1/alexandria/partials/tree.py
+++ b/ddht/v5_1/alexandria/partials/tree.py
@@ -1,0 +1,406 @@
+import enum
+from typing import Collection, Iterable, List, Optional, Tuple
+
+from eth_typing import Hash32
+from eth_utils import ValidationError, to_tuple
+from eth_utils.toolz import sliding_window
+from ssz.constants import ZERO_HASHES
+from ssz.hash import hash_eth2
+
+from ddht.v5_1.alexandria.partials._utils import display_path
+from ddht.v5_1.alexandria.partials.chunking import (
+    chunk_index_to_path,
+    group_by_subtree,
+    path_to_left_chunk_index,
+)
+from ddht.v5_1.alexandria.partials.typing import TreePath
+
+
+class NodePosition(enum.IntEnum):
+    left = 0
+    right = 1
+    root = 2
+
+
+def construct_node_tree(
+    tree_data: Collection[Tuple[TreePath, Hash32]],
+    current_path: TreePath,
+    path_bit_length: int,
+) -> "Node":
+    """
+    Construct the tree of nodes for a ProofTree.
+
+    TODO: How can we do this non-recursively....
+    """
+    #
+    # TERMINAL NODE
+    #
+    # - First we check to see if the tree terminates at this path.  If so there
+    # should only be a single node.
+    terminal_data = tuple(
+        (path, value) for (path, value) in tree_data if path == current_path
+    )
+
+    if terminal_data:
+        if len(terminal_data) > 1:
+            raise ValidationError(f"Multiple terminal nodes: {terminal_data}")
+        elif not current_path:
+            raise ValidationError(
+                f"Invalid tree termination at root path: {terminal_data}"
+            )
+
+        _, terminal_value = terminal_data[0]
+        return Node(
+            path=current_path,
+            value=terminal_value,
+            left=None,
+            right=None,
+            position=NodePosition(current_path[-1]),
+            path_bit_length=path_bit_length,
+        )
+
+    depth = len(current_path)
+
+    # If the tree does not terminate then it always branches in both
+    # directions.  Split the data into their left/right sides and construct
+    # the subtrees, and then the node at this level.
+    left_data = tuple(
+        (path, value) for (path, value) in tree_data if path[depth] is False
+    )
+    right_data = tuple(
+        (path, value) for (path, value) in tree_data if path[depth] is True
+    )
+
+    left_node: Optional[Node]
+    right_node: Optional[Node]
+
+    if left_data:
+        left_node = construct_node_tree(
+            left_data,
+            current_path=current_path + (False,),
+            path_bit_length=path_bit_length,
+        )
+    else:
+        left_node = None
+
+    if right_data:
+        right_node = construct_node_tree(
+            right_data,
+            current_path=current_path + (True,),
+            path_bit_length=path_bit_length,
+        )
+    else:
+        right_node = None
+
+    if current_path:
+        position = NodePosition(current_path[-1])
+    else:
+        position = NodePosition.root
+
+    return Node(
+        path=current_path,
+        value=None,
+        left=left_node,
+        right=right_node,
+        position=position,
+        path_bit_length=path_bit_length,
+    )
+
+
+class BrokenTree(Exception):
+    """
+    Exception signaling that there are missing nodes in a `ProofTree` which are
+    required for the proof to be valid.
+    """
+
+    ...
+
+
+class TerminalPathError(Exception):
+    """
+    Exception signaling an attempt to navigate too deep into a tree.
+
+    Can occur at either a leaf node, or a padding node.
+    """
+
+    ...
+
+
+class Node:
+    """
+    Representation of a single node within a proof tree.
+    """
+
+    _computed_value: Optional[Hash32] = None
+
+    def __init__(
+        self,
+        path: TreePath,
+        value: Optional[Hash32],
+        left: Optional["Node"],
+        right: Optional["Node"],
+        position: NodePosition,
+        path_bit_length: int,
+    ) -> None:
+        self.path = path
+        self._value = value
+        self._left = left
+        self._right = right
+        self.position = position
+        self._path_bit_length = path_bit_length
+
+    def __str__(self) -> str:
+        if self._left is not None:
+            left = "L"
+        else:
+            left = "?" if self.is_terminal else "X"
+
+        if self._right is not None:
+            right = "R"
+        else:
+            right = "?" if self.is_terminal else "X"
+        return f"Node[path={display_path(self.path)} children=({left}^{right})]"
+
+    def get_value(self) -> Hash32:
+        """
+        The value at this node.  For intermediate nodes, this is a hash.  For
+        leaf nodes this is the actual data.  Intermediate nodes that were not
+        part of the proof are lazily computed.
+        """
+        if self._value is not None:
+            return self._value
+        elif self._computed_value is None:
+            if self._left is None or self._right is None:
+                raise BrokenTree(f"Tree path breaks below: {display_path(self.path)}")
+            self._computed_value = hash_eth2(
+                self._left.get_value() + self._right.get_value()
+            )
+        return self._computed_value
+
+    @property
+    def left(self) -> "Node":
+        """
+        The left child of this node.
+        """
+        if self._left is None:
+            if self.is_terminal:
+                raise TerminalPathError(
+                    f"Tree path terminates: {display_path(self.path)}"
+                )
+            else:
+                raise BrokenTree(f"Tree path breaks left of: {display_path(self.path)}")
+        return self._left
+
+    @property
+    def right(self) -> "Node":
+        """
+        The right child of this node.
+        """
+        if self._right is None:
+            if self.is_terminal:
+                raise TerminalPathError(
+                    f"Tree path terminates: {display_path(self.path)}"
+                )
+            else:
+                raise BrokenTree(
+                    f"Tree path breaks right of: {display_path(self.path)}"
+                )
+        return self._right
+
+    @property
+    def depth(self) -> int:
+        """
+        The number of layers below the merkle root that this node is located.
+        """
+        return len(self.path)
+
+    @property
+    def is_computed(self) -> bool:
+        """
+        Boolean whether this node was computed or part of the original proof.
+        """
+        return not self._value
+
+    @property
+    def is_intermediate(self) -> bool:
+        """
+        Boolean whether this node is an intermediate tree node or part of the actual data.
+        """
+        return not self.is_leaf
+
+    @property
+    def is_leaf(self) -> bool:
+        """
+        Boolean whether this node is part of the actual data.
+        """
+        return len(self.path) == self._path_bit_length or self.path == (True,)
+
+    @property
+    def is_terminal(self) -> bool:
+        """
+        Boolean whether it is possible to navigate below this node in the tree.
+        """
+        return self._left is None and self._right is None and self._value is not None
+
+    @property
+    def is_padding(self) -> bool:
+        """
+        Boolean whether this node *looks* like padding.  Will return true for
+        content trees in which the data is empty bytes.
+
+        TODO: Fix the false-positive cases for this helper.
+        """
+        return self._value == ZERO_HASHES[self._path_bit_length - self.depth]  # type: ignore
+
+
+class Visitor:
+    """
+    Thin helper for navigating around a ProofTree.
+    """
+
+    tree: "ProofTree"
+    node: Node
+
+    def __init__(self, tree: "ProofTree", node: Node) -> None:
+        self.tree = tree
+        self.node = node
+
+    def visit_left(self) -> "Visitor":
+        return Visitor(self.tree, self.node.left)
+
+    def visit_right(self) -> "Visitor":
+        return Visitor(self.tree, self.node.right)
+
+
+class ProofTree:
+    """
+    Tree representation of a Proof
+    """
+
+    root_node: Node
+
+    _hash_tree_root: Optional[Hash32] = None
+
+    def __init__(self, root_node: Node) -> None:
+        self.root_node = root_node
+
+    def get_hash_tree_root(self) -> Hash32:
+        return self.root_node.get_value()
+
+    def get_data_length(self) -> int:
+        length_node = self.get_node((True,))
+        if not length_node.is_leaf:
+            raise Exception("Bad Proof")
+        return int.from_bytes(length_node.get_value(), "little")
+
+    def get_node(self, path: TreePath) -> Node:
+        return self.get_nodes_on_path(path)[-1]
+
+    @to_tuple
+    def get_nodes_on_path(self, path: TreePath) -> Iterable[Node]:
+        node = self.root_node
+        yield node
+        for el in path:
+            if el is False:
+                node = node.left
+            elif el is True:
+                node = node.right
+            else:
+                raise Exception("Invariant")
+            yield node
+
+    def get_deepest_node_on_path(self, path: TreePath) -> Node:
+        node = self.root_node
+        for el in path:
+            if el is False:
+                node = node.left
+            elif el is True:
+                node = node.right
+            else:
+                raise Exception("Invariant")
+            if node.is_terminal:
+                break
+
+        return node
+
+    def visit(self, path: TreePath) -> Visitor:
+        node = self.get_node(path)
+        return Visitor(self, node)
+
+    def visit_left(self) -> Visitor:
+        return self.visit((False,))
+
+    def visit_right(self) -> Visitor:
+        return self.visit((True,))
+
+    def walk(
+        self, start_at: Optional[TreePath] = None, end_at: Optional[TreePath] = None
+    ) -> Iterable[Node]:
+        if end_at is not None and start_at is not None and end_at < start_at:
+            raise Exception("Invariant")
+
+        nodes_on_path: Tuple[Node, ...]
+        if start_at is None:
+            nodes_on_path = (self.root_node,)
+        else:
+            nodes_on_path = self.get_nodes_on_path(start_at)
+
+        stack: List[Node] = []
+        for parent, child in sliding_window(2, nodes_on_path):
+            if child.position is NodePosition.left:
+                stack.append(parent.right)
+
+        stack.append(nodes_on_path[-1])
+
+        while stack:
+            node = stack.pop()
+            if end_at is not None and node.path > end_at:
+                break
+
+            yield node
+            if not node.is_terminal:
+                stack.append(node.right)
+                stack.append(node.left)
+
+    @to_tuple
+    def get_subtree_proof_nodes(
+        self, start_at: TreePath, end_at: TreePath
+    ) -> Iterable[Node]:
+        """
+        Return the minimal set of tree nodes needed to prove the designated
+        section of the tree.  Nodes which belong to the same subtree are
+        collapsed into the parent intermediate node.
+
+        The `group_by_subtree` utility function implements the core logic for
+        this functionality and documents how nodes are grouped.
+        """
+        if len(start_at) != len(end_at):
+            raise Exception("Paths must be at the same depth")
+        path_bit_length = len(start_at)
+        first_chunk_index = path_to_left_chunk_index(start_at, path_bit_length)
+        last_chunk_index = path_to_left_chunk_index(end_at, path_bit_length)
+
+        if last_chunk_index < first_chunk_index:
+            raise Exception("end path is before starting path")
+
+        num_chunks = last_chunk_index - first_chunk_index + 1
+        chunk_index_groups = group_by_subtree(first_chunk_index, num_chunks)
+        groups_with_bit_lengths = tuple(
+            # Each group will contain an even "power-of-two" number of
+            # elements.  This tells us how many tailing bits each element has
+            # which need to be truncated to get the group's common prefix.
+            (group[0], (len(group) - 1).bit_length())
+            for group in chunk_index_groups
+        )
+        subtree_node_paths = tuple(
+            # We take a candidate element from each group and shift it to
+            # remove the bits that are not common to other group members, then
+            # we convert it to a tree path that all elements from this group
+            # have in common.
+            chunk_index_to_path(
+                chunk_index >> bits_to_truncate, path_bit_length - bits_to_truncate,
+            )
+            for chunk_index, bits_to_truncate in groups_with_bit_lengths
+        )
+        for path in subtree_node_paths:
+            yield self.get_node(path)

--- a/tests/core/v5_1/alexandria/test_proof_tree.py
+++ b/tests/core/v5_1/alexandria/test_proof_tree.py
@@ -1,0 +1,503 @@
+from hypothesis import given
+from hypothesis import strategies as st
+import pytest
+from ssz.constants import ZERO_HASHES
+
+from ddht.v5_1.alexandria.partials.proof import compute_proof
+from ddht.v5_1.alexandria.partials.tree import (
+    BrokenTree,
+    ProofTree,
+    TerminalPathError,
+    construct_node_tree,
+)
+from ddht.v5_1.alexandria.sedes import ByteList
+
+short_content_sedes = ByteList(max_length=32 * 16)
+
+
+@pytest.fixture
+def short_proof():
+    data = b"\x01" * 32 + b"\x02" * 32 + b"\x03" * 32 + b"\x04" * 32 + b"\x05" * 32
+    proof = compute_proof(data, sedes=short_content_sedes)
+    return proof
+
+
+#
+# Tree Walking
+#
+# The following diagram visualizes the expected walk order of the tree wich
+# each node labeled with the letters A-Q.  Nodes labeled with a `?` are
+# expected to not be reached during a tree walk.
+r"""
+0:                               A
+                                / \
+                              /     \
+1:                           B       Q
+                            / \   (length)
+                          /     \
+                        /         \
+                      /             \
+                    /                 \
+                  /                     \
+                /                         \
+2:             C                           P
+             /   \                       /   \
+           /       \                   /       \
+         /           \               /           \
+3:      D             K             ?             ?
+       / \           / \           / \           / \
+      /   \         /   \         /   \         /   \
+4:   E     H       L     O       ?     ?       ?     ?
+    / \   / \     / \   / \     / \   / \     / \   / \
+5: F   G I   J   M   N ?   ?   ?   ? ?   ?   ?   ? ?   ?
+
+  |<-----DATA---->| |<-----------PADDING-------------->|
+"""
+
+
+def p(*crumbs):
+    return tuple(bool(crumb) for crumb in crumbs)
+
+
+# These are the paths that we expect to encounter on a full walk of the tree.
+EXPECTED_WALK_ORDER = (
+    p(),  # A
+    p(0,),  # B
+    p(0, 0),  # C
+    p(0, 0, 0),  # D
+    p(0, 0, 0, 0),  # E
+    p(0, 0, 0, 0, 0),  # F
+    p(0, 0, 0, 0, 1),  # G
+    p(0, 0, 0, 1),  # H
+    p(0, 0, 0, 1, 0),  # I
+    p(0, 0, 0, 1, 1),  # J
+    p(0, 0, 1),  # K
+    p(0, 0, 1, 0),  # L
+    p(0, 0, 1, 0, 0),  # M
+    p(0, 0, 1, 0, 1),  # N
+    p(0, 0, 1, 1),  # O
+    p(0, 1),  # P
+    p(1,),  # Q
+)
+
+
+def test_proof_tree_full_traversal(short_proof):
+    tree = short_proof.get_tree()
+
+    nodes_in_walk_order = tuple(tree.walk())
+    assert len(nodes_in_walk_order) == len(EXPECTED_WALK_ORDER)
+    for idx, (node, expected_path) in enumerate(
+        zip(nodes_in_walk_order, EXPECTED_WALK_ORDER)
+    ):
+        assert node.path == expected_path
+
+
+@given(
+    start_at_index=st.integers(min_value=0, max_value=len(EXPECTED_WALK_ORDER) - 1),
+    num_nodes_to_walk=st.one_of(
+        st.none(), st.integers(min_value=1, max_value=len(EXPECTED_WALK_ORDER) - 1),
+    ),
+)
+def test_proof_tree_partial_traversal(short_proof, start_at_index, num_nodes_to_walk):
+    start_at = EXPECTED_WALK_ORDER[start_at_index]
+    if num_nodes_to_walk is None:
+        end_at_index = len(EXPECTED_WALK_ORDER)
+        end_at = None
+    else:
+        end_at_index = min(len(EXPECTED_WALK_ORDER), start_at_index + num_nodes_to_walk)
+        end_at = EXPECTED_WALK_ORDER[end_at_index - 1]
+
+    expected_paths = EXPECTED_WALK_ORDER[start_at_index:end_at_index]
+
+    tree = short_proof.get_tree()
+    nodes_in_walk_order = tuple(tree.walk(start_at, end_at))
+    assert len(nodes_in_walk_order) == len(expected_paths)
+    for idx, (node, expected_path) in enumerate(
+        zip(nodes_in_walk_order, expected_paths)
+    ):
+        assert node.path == expected_path
+
+
+def test_proof_tree_visitor_api(short_proof):
+    r"""
+    0:                               X
+                                    / \
+                                  /     \
+    1:                           0       1
+                                / \   (length)
+                              /     \
+                            /         \
+                          /             \
+                        /                 \
+                      /                     \
+                    /                         \
+    2:             0                           P
+                 /   \                       /   \
+               /       \                   /       \
+             /           \               /           \
+    3:      0             1             0             1
+           / \           / \           / \           / \
+          /   \         /   \         /   \         /   \
+    4:   0     1       0     P       0     1       0     1
+        / \   / \     / \   / \     / \   / \     / \   / \
+    5: 0   1 0   1   0   P 0   1   0   1 0   1   0   1 0   1
+
+      |<-----DATA---->| |<-----------PADDING-------------->|
+    """
+    tree = short_proof.get_tree()
+
+    assert tree.get_hash_tree_root() == short_proof.hash_tree_root
+
+    walked_nodes = tuple(tree.walk())
+    walked_paths = tuple(sorted(node.path for node in walked_nodes if node.is_terminal))
+
+    expected_paths = tuple(sorted(el.path for el in short_proof.elements))
+
+    assert walked_paths == expected_paths
+
+    #
+    # Check finding deepest node on a path which would otherwise extend past a
+    # terminal node.
+    #
+    node_011 = tree.get_deepest_node_on_path((False, False, True, True))
+    assert node_011.path == ((False, False, True, True))
+    assert tree.get_deepest_node_on_path((False, False, True, True, False)) == node_011
+    assert tree.get_deepest_node_on_path((False, False, True, True, True)) == node_011
+
+    #
+    # Now we walk to every node in the tree and verify it looks as expected.
+    #
+
+    #    X
+    #   /
+    #  0
+    #   \
+    #    1
+    #
+    visitor_01 = tree.visit_left().visit_right()
+
+    assert not visitor_01.node.is_computed
+    assert visitor_01.node.is_intermediate
+    assert visitor_01.node.is_terminal
+    assert visitor_01.node.get_value() == ZERO_HASHES[3]
+    assert visitor_01.node.is_padding
+    assert not visitor_01.node.is_leaf
+    assert visitor_01.node.depth == 2
+
+    with pytest.raises(TerminalPathError):
+        visitor_01.visit_left()
+    with pytest.raises(TerminalPathError):
+        visitor_01.visit_right()
+
+    #      X
+    #     /
+    #    0
+    #   /
+    #  0
+    #
+    visitor_00 = tree.visit_left().visit_left()
+
+    assert visitor_00.node.is_computed
+    assert visitor_00.node.is_intermediate
+    assert not visitor_00.node.is_terminal
+    assert not visitor_00.node.is_padding
+    assert not visitor_00.node.is_leaf
+    assert visitor_00.node.depth == 2
+
+    #        X
+    #       /
+    #      0
+    #     /
+    #    0
+    #   /
+    #  0
+    #
+    visitor_000 = visitor_00.visit_left()
+
+    assert visitor_000.node.is_computed
+    assert visitor_000.node.is_intermediate
+    assert not visitor_000.node.is_terminal
+    assert not visitor_000.node.is_padding
+    assert not visitor_000.node.is_leaf
+    assert visitor_000.node.depth == 3
+
+    #      X
+    #     /
+    #    0
+    #   /
+    #  0
+    #   \
+    #    1
+    #
+    visitor_001 = visitor_00.visit_right()
+
+    assert visitor_001.node.is_computed
+    assert visitor_001.node.is_intermediate
+    assert not visitor_001.node.is_terminal
+    assert not visitor_001.node.is_padding
+    assert not visitor_001.node.is_leaf
+    assert visitor_001.node.depth == 3
+
+    #      X
+    #     /
+    #    0
+    #   /
+    #  0
+    #   \
+    #    1
+    #     \
+    #      1
+    #
+    visitor_0011 = visitor_001.visit_right()
+
+    assert not visitor_0011.node.is_computed
+    assert visitor_0011.node.is_intermediate
+    assert visitor_0011.node.is_terminal
+    assert visitor_0011.node.is_padding
+    assert visitor_0011.node.get_value() == ZERO_HASHES[1]
+    assert not visitor_0011.node.is_leaf
+    assert visitor_0011.node.depth == 4
+
+    with pytest.raises(TerminalPathError):
+        visitor_0011.visit_right()
+    with pytest.raises(TerminalPathError):
+        visitor_0011.visit_left()
+
+    #      X
+    #     /
+    #    0
+    #   /
+    #  0
+    #   \
+    #    1
+    #   /
+    #  0
+    #
+    visitor_0010 = visitor_001.visit_left()
+
+    assert visitor_0010.node.is_computed
+    assert visitor_0010.node.is_intermediate
+    assert not visitor_0010.node.is_terminal
+    assert not visitor_0010.node.is_padding
+    assert not visitor_0010.node.is_leaf
+    assert visitor_0010.node.depth == 4
+
+    #      X
+    #     /
+    #    0
+    #   /
+    #  0
+    #   \
+    #    1
+    #   /
+    #  0
+    #   \
+    #    1
+    #
+    visitor_00101 = visitor_0010.visit_right()
+
+    assert not visitor_00101.node.is_computed
+    assert not visitor_00101.node.is_intermediate
+    assert visitor_00101.node.is_terminal
+    assert visitor_00101.node.is_padding
+    assert visitor_00101.node.get_value() == ZERO_HASHES[0]
+    assert visitor_00101.node.is_leaf
+    assert visitor_00101.node.depth == 5
+
+    with pytest.raises(TerminalPathError):
+        visitor_00101.visit_right()
+    with pytest.raises(TerminalPathError):
+        visitor_00101.visit_left()
+
+    #        X
+    #       /
+    #      0
+    #     /
+    #    0
+    #     \
+    #      1
+    #     /
+    #    0
+    #   /
+    #  0
+    #
+    visitor_00100 = visitor_0010.visit_left()
+
+    assert not visitor_00100.node.is_computed
+    assert not visitor_00100.node.is_intermediate
+    assert visitor_00100.node.is_terminal
+    assert not visitor_00100.node.is_padding
+    assert visitor_00100.node.is_leaf
+    assert visitor_00100.node.depth == 5
+    assert visitor_00100.node.get_value() == b"\x05" * 32
+
+    with pytest.raises(TerminalPathError):
+        visitor_00100.visit_right()
+    with pytest.raises(TerminalPathError):
+        visitor_00100.visit_left()
+
+    #          X
+    #         /
+    #        0
+    #       /
+    #      0
+    #     /
+    #    0
+    #   / \
+    #  0   1
+    #
+    visitor_0000 = visitor_000.visit_left()
+    visitor_0001 = visitor_000.visit_right()
+
+    for visitor in (visitor_0000, visitor_0001):
+        assert visitor.node.is_computed
+        assert visitor.node.is_intermediate
+        assert not visitor.node.is_terminal
+        assert not visitor.node.is_padding
+        assert not visitor.node.is_leaf
+        assert visitor.node.depth == 4
+
+    visitor_00000 = visitor_0000.visit_left()
+    visitor_00001 = visitor_0000.visit_right()
+    visitor_00010 = visitor_0001.visit_left()
+    visitor_00011 = visitor_0001.visit_right()
+
+    #             X
+    #            /
+    #           0
+    #          /
+    #         0
+    #        /
+    #       0
+    #      / \
+    #     /   \
+    #    0     1
+    #   / \   / \
+    #  0   1 0   1
+    #
+    for visitor in (visitor_00000, visitor_00001, visitor_00010, visitor_00011):
+        assert not visitor.node.is_computed
+        assert not visitor.node.is_intermediate
+        assert visitor.node.is_terminal
+        assert not visitor.node.is_padding
+        assert visitor.node.is_leaf
+        assert visitor.node.depth == 5
+
+        with pytest.raises(TerminalPathError):
+            visitor.visit_right()
+        with pytest.raises(TerminalPathError):
+            visitor.visit_left()
+
+    assert visitor_00000.node.get_value() == b"\x01" * 32
+    assert visitor_00001.node.get_value() == b"\x02" * 32
+    assert visitor_00010.node.get_value() == b"\x03" * 32
+    assert visitor_00011.node.get_value() == b"\x04" * 32
+
+
+def test_tree_proof_with_empty_data():
+    proof = compute_proof(b"", sedes=short_content_sedes)
+    tree = proof.get_tree()
+
+    node = tree.get_node((False, False, False, False, False))
+
+    assert not node.is_computed
+    assert not node.is_intermediate
+    assert node.is_terminal
+    # TODO: false positive that needs to be addressed
+    # assert not node.is_padding
+    assert node.is_leaf
+    assert node.depth == 5
+
+    walked_nodes = tuple(node for node in tree.walk() if node.is_leaf)
+    # (padded-data-node, padding-node, length-node)
+    assert len(walked_nodes) == 3
+
+
+def test_tree_proof_with_missing_leaf_node(short_proof):
+    all_proof_elements = short_proof.elements
+
+    assert all_proof_elements[3].value == b"\x04" * 32
+
+    # Remove the element that would have been @ 0011
+    proof_elements = all_proof_elements[:3] + all_proof_elements[4:]
+    tree_data = tuple((el.path, el.value) for el in proof_elements)
+    tree = ProofTree(
+        construct_node_tree(tree_data, (), short_proof.sedes.chunk_count.bit_length())
+    )
+
+    with pytest.raises(BrokenTree):
+        # TODO: property access with side-effects is surprising
+        tree.get_hash_tree_root()
+
+    with pytest.raises(BrokenTree):
+        tuple(tree.walk())
+
+    # we should still be able to visit the nodes around the missing one.
+    tree.visit((False, False, False, True))  # the parent of the node
+    tree.visit((False, False, False, True, False))  # the sibling node to the left
+
+    with pytest.raises(BrokenTree):
+        tree.visit((False, False, False, True, True))
+
+
+def test_tree_proof_with_missing_intermediate_node(short_proof):
+    all_proof_elements = short_proof.elements
+
+    assert all_proof_elements[6].value == ZERO_HASHES[1]
+
+    # Remove the element that would have been @ 011
+    proof_elements = all_proof_elements[:6] + all_proof_elements[7:]
+    tree_data = tuple((el.path, el.value) for el in proof_elements)
+    tree = ProofTree(
+        construct_node_tree(tree_data, (), short_proof.sedes.chunk_count.bit_length())
+    )
+
+    with pytest.raises(BrokenTree):
+        # TODO: property access with side-effects is surprising
+        tree.get_hash_tree_root()
+
+    with pytest.raises(BrokenTree):
+        tuple(tree.walk())
+
+    # we should still be able to visit the nodes around the missing one.
+    tree.visit((False, False, True))  # the parent of the missing node
+    tree.visit((False, False, True, False))  # the sibling node to the left
+
+    with pytest.raises(BrokenTree):
+        tree.visit((False, False, True, True))
+
+
+def test_proof_tree_subtree_proof(short_proof):
+    r"""
+    0:                               X
+                                    / \
+                                  /     \
+    1:                           0       1
+                                / \   (length)
+                              /     \
+                            /         \
+                          /             \
+                        /                 \
+                      /                     \
+                    /                         \
+    2:             0                           P
+                 /   \                       /   \
+               /       \                   /       \
+             /           \               /           \
+    3:      0             1             0             1
+           / \           / \           / \           / \
+          /   \         /   \         /   \         /   \
+    4:   0     1       0     P       0     1       0     1
+        / \   / \     / \   / \     / \   / \     / \   / \
+    5: 0   1 0   1   0   P 0   1   0   1 0   1   0   1 0   1
+
+      |<-----DATA---->| |<-----------PADDING-------------->|
+    """
+    tree = short_proof.get_tree()
+
+    # two sibling nodes should return the single parent node for those siblings
+    subtree_proof = tree.get_subtree_proof_nodes(
+        (False, False, False, False, False), (False, False, False, False, True),
+    )
+    assert len(subtree_proof) == 1
+    assert subtree_proof[0].path == (False, False, False, False)


### PR DESCRIPTION
Builds from #142 .  Only the latest commit is relevant when viewing the diff.  Will rebase once #142 is merged.

## What was wrong?

We need to construct partial proofs, which means we need to perform some high level operations on the merkle tree structure.

## How was it fixed?

Implemented the `ddht.v5_1.alexandria.partials.tree.ProofTree`.  This PR also introduces a minimal version of `ddht.v5_1.alexandria.partials.proof.Proof` which is necessary for construction of the tree.  The full API for the `Proof` object will come in the next PR (along with corresponding tests).

#### Cute Animal Picture


![f0a097668bd2f1886c2fe711f384b67d](https://user-images.githubusercontent.com/824194/97740659-3bcbba80-1aa7-11eb-93e5-983a12782910.jpg)
