### PR TITLE
Implement partial proofs

### DIFF
--- a/ddht/v5_1/alexandria/partials/proof.py
+++ b/ddht/v5_1/alexandria/partials/proof.py
@@ -1,8 +1,19 @@
 import bisect
 from dataclasses import dataclass
 import functools
+import itertools
 import operator
-from typing import Any, Collection, Iterable, Optional, Sequence, Tuple
+from typing import (
+    Any,
+    Collection,
+    Iterable,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    overload,
+)
 
 from eth_typing import Hash32
 from eth_utils import ValidationError, to_tuple
@@ -16,7 +27,12 @@ from ddht.v5_1.alexandria.partials._utils import (
     display_path,
     get_chunk_count_for_data_length,
 )
-from ddht.v5_1.alexandria.partials.chunking import chunk_index_to_path, compute_chunks
+from ddht.v5_1.alexandria.partials.chunking import (
+    chunk_index_to_path,
+    compute_chunks,
+    group_by_subtree,
+    path_to_left_chunk_index,
+)
 from ddht.v5_1.alexandria.partials.typing import TreePath
 
 
@@ -39,6 +55,83 @@ class ProofElement:
 
     def __str__(self) -> str:
         return f"{display_path(self.path)}: {self.value.hex()}"
+
+
+class DataSegment(NamedTuple):
+    start_index: int
+    data: bytes
+
+    @property
+    def end_index(self) -> int:
+        return self.start_index + len(self.data)
+
+
+class DataPartial:
+    """
+    A wrapper around a partial proof which facilitates easy access to the proven data.
+
+    The `Proof.get_proven_data` API returns an instance of this class, which
+    wraps the various segments of proven data and allows you to treat them as
+    if they were a single byte string with missing sections.  Attempts to
+    access a section of the data that is missing will raise an `IndexError`.
+
+    Data can be accessed by slice or index in the same manner as a normal byte
+    string, with the exception that it does not allow for slices that extend
+    beyond the end of the data, nor does it allow slices that define a `step`
+    value.
+    """
+
+    def __init__(self, length: int, segments: Tuple[DataSegment, ...]) -> None:
+        self._length = length
+        self._segments = segments
+
+    def __len__(self) -> int:
+        return self._length
+
+    @overload
+    def __getitem__(self, index_or_slice: int) -> int:
+        ...
+
+    @overload
+    def __getitem__(self, index_or_slice: slice) -> bytes:
+        ...
+
+    def __getitem__(self, index_or_slice: Union[int, slice]) -> Union[int, bytes]:
+        if isinstance(index_or_slice, slice):
+            if index_or_slice.step is not None:
+                raise Exception("step values not supported")
+            start_at = index_or_slice.start or 0
+            end_at = index_or_slice.stop
+        elif isinstance(index_or_slice, int):
+            start_at = index_or_slice
+            end_at = index_or_slice + 1
+        else:
+            raise TypeError(f"Unsupported type: {type(index_or_slice)}")
+
+        data_length = end_at - start_at
+
+        candidate_index = max(0, bisect.bisect_left(self._segments, (start_at,)) - 1)
+        segment = self._segments[candidate_index]
+        is_within_bounds = (
+            segment.start_index <= start_at <= segment.end_index
+            and data_length <= len(segment.data)
+        )
+        if not is_within_bounds:
+            raise IndexError(
+                f"Requested data is out of bounds: segment=({segment.start_index} - "
+                f"{segment.end_index}) slice=({start_at} - {end_at})"
+            )
+
+        if isinstance(index_or_slice, slice):
+            offset_slice = slice(
+                start_at - segment.start_index, end_at - segment.start_index
+            )
+            return segment.data[offset_slice]
+        elif isinstance(index_or_slice, int):
+            offset_index = index_or_slice - segment.start_index
+            return segment.data[offset_index]
+        else:
+            raise TypeError(f"Unsupported type: {type(index_or_slice)}")
 
 
 class Proof:
@@ -212,10 +305,199 @@ class Proof:
         """
         return self.sedes.chunk_count.bit_length()  # type: ignore
 
+    def to_partial(self, start_at: int, partial_data_length: int) -> "Proof":
+        """
+        Return another proof with the minimal number of tree elements necessary
+        to prove the slice of the underlying bytestring denoted by the
+        `start_at` and `partial_data_length` parameters.
+        """
+        # First retrieve the overall content length from the proof.  The `length`
+        # should always be found on the path `(True,)` which should always be
+        # present in the tree.
+        length = self.get_content_length()
+
+        # Ensure that we aren't requesting data that exceeds the overall length
+        # of the actual content.
+        end_at = start_at + partial_data_length
+        if end_at > length:
+            raise Exception(
+                f"Cannot create partial that exceeds the data length: {end_at} > {length}"
+            )
+
+        # Compute the chunk indices and corresponding paths for the locations
+        # in the tree where the partial data starts and ends.
+        first_partial_chunk_index = start_at // CHUNK_SIZE
+
+        if partial_data_length == 0:
+            last_partial_chunk_index = first_partial_chunk_index
+        else:
+            last_partial_chunk_index = (end_at - 1) // CHUNK_SIZE
+
+        first_partial_chunk_path = chunk_index_to_path(
+            first_partial_chunk_index, self.path_bit_length
+        )
+        last_partial_chunk_path = chunk_index_to_path(
+            last_partial_chunk_index, self.path_bit_length
+        )
+
+        # Get all of the leaf nodes for the section of the tree where the
+        # partial data is located.  Ensure that we have a contiguous section of
+        # leaf nodes for this part of the tree.
+        partial_elements = self.get_elements(
+            left=first_partial_chunk_path,
+            right=last_partial_chunk_path,
+            right_inclusive=True,
+        )
+        expected_partial_chunk_count = (
+            last_partial_chunk_index - first_partial_chunk_index
+        ) + 1
+        if len(partial_elements) != expected_partial_chunk_count:
+            raise Exception(
+                "Proof is missing leaf nodes required for partial construction."
+            )
+
+        minimal_data_elements_left_of_partial: Tuple[ProofElement, ...]
+        if first_partial_chunk_index == 0:
+            minimal_data_elements_left_of_partial = ()
+        else:
+            minimal_data_elements_left_of_partial = self.get_minimal_proof_elements(
+                0, first_partial_chunk_index,
+            )
+
+        last_data_chunk_index = self.get_last_data_chunk_index()
+
+        minimal_data_elements_right_of_partial: Tuple[ProofElement, ...]
+        if last_partial_chunk_index == last_data_chunk_index:
+            minimal_data_elements_right_of_partial = ()
+        else:
+            minimal_data_elements_right_of_partial = self.get_minimal_proof_elements(
+                last_partial_chunk_index + 1,
+                last_data_chunk_index - (last_partial_chunk_index + 1) + 1,
+            )
+
+        padding_elements = self.get_padding_elements()
+
+        length_element = self.get_element((True,))
+
+        # Now re-assembly the sections of the tree for the minimal proof for
+        # the partial data.
+        partial_elements = sum(
+            (
+                minimal_data_elements_left_of_partial,
+                partial_elements,
+                minimal_data_elements_right_of_partial,
+                padding_elements,
+                (length_element,),
+            ),
+            (),
+        )
+
+        return Proof(partial_elements, self.sedes)
+
+    def get_proven_data(self) -> DataPartial:
+        """
+        Returns a view over the proven data which can be accessed similar to a
+        bytestring by either indexing or slicing.
+        """
+        segments = self.get_proven_data_segments()
+        return DataPartial(self.get_content_length(), segments)
+
+    @to_tuple
+    def get_proven_data_segments(self) -> Iterable[DataSegment]:
+        length = self.get_content_length()
+
+        last_data_chunk_data_size = length % CHUNK_SIZE
+
+        next_chunk_index = 0
+        segment_start_index = 0
+        data_segment = b""
+
+        # Walk over the data chunks merging contigious chunks into a single
+        # segment.
+        last_data_chunk_path = self.get_last_data_chunk_path()
+        data_elements = self.get_elements(
+            right=last_data_chunk_path, right_inclusive=True,
+        )
+        for el in data_elements:
+            if el.depth != self.path_bit_length:
+                continue
+
+            if el.path == last_data_chunk_path:
+                if last_data_chunk_data_size:
+                    chunk_data = el.value[:last_data_chunk_data_size]
+                else:
+                    chunk_data = el.value
+            else:
+                chunk_data = el.value
+
+            chunk_index = path_to_left_chunk_index(el.path, self.path_bit_length)
+
+            if chunk_index == next_chunk_index:
+                data_segment += chunk_data
+            else:
+                if data_segment:
+                    yield DataSegment(segment_start_index, data_segment)
+                data_segment = chunk_data
+                segment_start_index = chunk_index * CHUNK_SIZE
+
+            next_chunk_index = chunk_index + 1
+
+        if length:
+            if data_segment:
+                yield DataSegment(segment_start_index, data_segment)
+        if not length:
+            yield DataSegment(0, b"")
+
+    @to_tuple
+    def get_minimal_proof_elements(
+        self, start_chunk_index: int, num_chunks: int,
+    ) -> Iterable[ProofElement]:
+        """
+        Return the minimal set of tree nodes needed to prove the designated
+        section of the tree.  Nodes which belong to the same subtree are
+        collapsed into the parent intermediate node.
+
+        The `group_by_subtree` utility function implements the core logic for
+        this functionality and documents how nodes are grouped.
+        """
+        if num_chunks < 1:
+            raise Exception("Invariant")
+
+        end_chunk_index = start_chunk_index + num_chunks - 1
+
+        num_chunks = end_chunk_index - start_chunk_index + 1
+        chunk_index_groups = group_by_subtree(start_chunk_index, num_chunks)
+        groups_with_bit_lengths = tuple(
+            # Each group will contain an even "power-of-two" number of
+            # elements.  This tells us how many tailing bits each element has
+            # which need to be truncated to get the group's common prefix.
+            (group[0], (len(group) - 1).bit_length())
+            for group in chunk_index_groups
+        )
+        subtree_paths = tuple(
+            # We take a candidate element from each group and shift it to
+            # remove the bits that are not common to other group members, then
+            # we convert it to a tree path that all elements from this group
+            # have in common.
+            chunk_index_to_path(
+                chunk_index >> bits_to_truncate,
+                self.path_bit_length - bits_to_truncate,
+            )
+            for chunk_index, bits_to_truncate in groups_with_bit_lengths
+        )
+        for path in subtree_paths:
+            element_group = self.get_elements_under(path)
+            if len(element_group) == 1:
+                yield element_group[0]
+            else:
+                yield ProofElement(path=path, value=merklize_elements(element_group))
+
 
 def merklize_elements(elements: Sequence[ProofElement]) -> Hash32:
     """
     Given a set of `ProofElement` compute the `hash_tree_root`.
+
+    This also verifies that the proof is both "well-formed" and "minimal".
     """
     elements_by_depth = groupby(operator.attrgetter("depth"), elements)
     max_depth = max(elements_by_depth.keys())
@@ -226,21 +508,32 @@ def merklize_elements(elements: Sequence[ProofElement]) -> Hash32:
         except KeyError:
             continue
 
+        # Verify that all of the paths at this level are unique
+        paths = set(el.path for el in elements_at_depth)
+        if len(paths) != len(elements_at_depth):
+            raise BrokenTree(
+                f"Duplicate paths detected: depth={depth}  elements={elements_at_depth}"
+            )
+
         sibling_pairs = tuple(
             (left, right)
             for left, right in sliding_window(2, elements_at_depth)
             if left.path[:-1] == right.path[:-1]
         )
+
+        # Check to see if any of the elements didn't have a sibling which
+        # indicates either a missing sibling, or a duplicate node.
+        orphans = set(elements_at_depth).difference(itertools.chain(*sibling_pairs))
+        if orphans:
+            raise BrokenTree(f"Orphaned tree elements: dept={depth} orphans={orphans}")
+
         parents = tuple(
             ProofElement(path=left.path[:-1], value=hash_eth2(left.value + right.value))
             for left, right in sibling_pairs
         )
 
-        if not elements_by_depth:
-            if len(parents) == 1:
-                return parents[0].value
-            else:
-                raise BrokenTree("Multiple root nodes")
+        if not elements_by_depth and len(parents) == 1:
+            return parents[0].value
         else:
             elements_by_depth.setdefault(depth - 1, [])
             elements_by_depth[depth - 1].extend(parents)

--- a/tests/core/v5_1/alexandria/test_partial_proofs.py
+++ b/tests/core/v5_1/alexandria/test_partial_proofs.py
@@ -1,11 +1,164 @@
-from hypothesis import given
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 import pytest
+from ssz import get_hash_tree_root
+from ssz.hash import hash_eth2
 
-from ddht.v5_1.alexandria.partials.proof import compute_proof
-from ddht.v5_1.alexandria.sedes import ByteList
+from ddht.v5_1.alexandria.constants import GB
+from ddht.v5_1.alexandria.partials.proof import (
+    Proof,
+    compute_proof,
+    is_proof_valid,
+    validate_proof,
+)
+from ddht.v5_1.alexandria.sedes import ByteList, content_sedes
+
+
+@settings(max_examples=1000)
+@given(data=st.binary(min_size=0, max_size=GB))
+@example(data=b"")
+@example(data=b"\x00" * 31)
+@example(data=b"\x00" * 32)
+@example(data=b"\x00" * 33)
+@example(data=b"\x00" * 63)
+@example(data=b"\x00" * 64)
+@example(data=b"\x00" * 65)
+def test_ssz_full_proofs(data):
+    expected_hash_tree_root = get_hash_tree_root(data, sedes=content_sedes)
+    proof = compute_proof(data, sedes=content_sedes)
+
+    validate_proof(proof)
+    assert is_proof_valid(proof)
+    assert proof.get_hash_tree_root() == expected_hash_tree_root
+
+    proven_data_segments = proof.get_proven_data_segments()
+
+    assert len(proven_data_segments) == 1
+    start_index, proven_data = proven_data_segments[0]
+    assert start_index == 0
+    assert proven_data == data
+
+    proven_data = proof.get_proven_data()
+    assert proven_data[0 : len(data)] == data
+
 
 short_content_sedes = ByteList(max_length=32 * 16)
+
+CONTENT_12345 = b"\x01" * 32 + b"\x02" * 32 + b"\x03" * 32 + b"\x04" * 32 + b"\x05" * 32
+CONTENT_512 = bytes((i % 256 for i in range(512)))
+r"""
+                Tree for CONTENT_12345
+
+0:                               X
+                                / \
+                              /     \
+1:                           0       1
+                            / \   (length)
+                          /     \
+                        /         \
+                      /             \
+                    /                 \
+                  /                     \
+                /                         \
+2:             0                           P
+             /   \                       /   \
+           /       \                   /       \
+         /           \               /           \
+3:      0             1             0             1
+       / \           / \           / \           / \
+      /   \         /   \         /   \         /   \
+4:   0     1       0     P       0     1       0     1
+    / \   / \     / \   / \     / \   / \     / \   / \
+5: 0   1 0   1   0   P 0   1   0   1 0   1   0   1 0   1
+
+  |<-----DATA---->| |<-----------PADDING-------------->|
+"""
+
+
+@pytest.mark.parametrize(
+    "content,data_slice",
+    (
+        # short cases
+        (b"", slice(0, 0)),
+        (b"\x00", slice(0, 0)),
+        (b"\x00", slice(0, 1)),
+        (b"\x01", slice(0, 0)),
+        (b"\x01", slice(0, 1)),
+        (b"\x00" * 32, slice(0, 0)),
+        (b"\x00" * 32, slice(0, 1)),
+        (b"\x00" * 32, slice(0, 32)),
+        (b"\x00" * 33, slice(0, 0)),
+        # longer content
+        (CONTENT_12345, slice(0, 0)),
+        (CONTENT_12345, slice(0, 32)),
+        (CONTENT_12345, slice(0, 31)),
+        (CONTENT_12345, slice(1, 32)),
+        (CONTENT_12345, slice(1, 33)),
+        (CONTENT_12345, slice(0, 64)),
+        (CONTENT_12345, slice(32, 64)),
+        (CONTENT_12345, slice(32, 65)),
+        (CONTENT_12345, slice(31, 64)),
+        (CONTENT_12345, slice(31, 65)),
+        (CONTENT_12345, slice(64, 128)),
+        (CONTENT_12345, slice(64, 129)),
+        (CONTENT_12345, slice(63, 128)),
+        (CONTENT_12345, slice(63, 129)),
+        (CONTENT_12345, slice(0, 160)),
+        (CONTENT_12345, slice(128, 160)),
+        (CONTENT_12345, slice(127, 160)),
+        # full content
+        (CONTENT_512, slice(0, 128)),
+        (CONTENT_512, slice(128, 256)),
+        (CONTENT_512, slice(0, 512)),
+        (CONTENT_512, slice(128, 512)),
+        (CONTENT_512, slice(256, 512)),
+        (CONTENT_512, slice(500, 512)),
+    ),
+)
+def test_ssz_partial_proof_construction(content, data_slice):
+    full_proof = compute_proof(content, sedes=short_content_sedes)
+
+    slice_length = data_slice.stop - data_slice.start
+
+    partial_proof = full_proof.to_partial(
+        start_at=data_slice.start, partial_data_length=slice_length,
+    )
+    assert partial_proof.get_hash_tree_root() == full_proof.get_hash_tree_root()
+
+    validate_proof(partial_proof)
+    assert is_proof_valid(partial_proof)
+
+    partial = partial_proof.get_proven_data()
+    data_from_partial = partial[data_slice]
+    assert data_from_partial == content[data_slice]
+
+
+@settings(max_examples=1000)
+@given(data=st.data())
+def test_ssz_partial_proof_fuzzy(data):
+    content = data.draw(st.binary(min_size=0, max_size=GB))
+
+    slice_start = data.draw(
+        st.integers(min_value=0, max_value=max(0, len(content) - 1))
+    )
+    slice_stop = data.draw(st.integers(min_value=slice_start, max_value=len(content)))
+    data_slice = slice(slice_start, slice_stop)
+
+    full_proof = compute_proof(content, sedes=content_sedes)
+
+    slice_length = max(0, data_slice.stop - data_slice.start - 1)
+
+    partial_proof = full_proof.to_partial(
+        start_at=data_slice.start, partial_data_length=slice_length,
+    )
+    assert partial_proof.get_hash_tree_root() == full_proof.get_hash_tree_root()
+
+    validate_proof(partial_proof)
+    assert is_proof_valid(partial_proof)
+
+    partial = partial_proof.get_proven_data()
+    data_from_partial = partial[data_slice]
+    assert data_from_partial == content[data_slice]
 
 
 def test_proof_get_element_api():
@@ -382,3 +535,179 @@ def test_proof_get_elements_under_api():
 
     under_1 = proof.get_elements_under((True,))
     assert to_paths(under_1) == (path_8,)
+
+
+@pytest.fixture
+def short_proof():
+    data = b"\x01" * 32 + b"\x02" * 32 + b"\x03" * 32 + b"\x04" * 32 + b"\x05" * 32
+    proof = compute_proof(data, sedes=short_content_sedes)
+    return proof
+
+
+def test_proof_get_minimal_proof_elements_all_leaves():
+    r"""
+    0:                                X
+                                     / \
+                                   /     \
+    1:                            0       1
+                                 / \   (length)
+                               /     \
+                             /         \
+                           /             \
+                         /                 \
+                       /                     \
+                     /                         \
+    2:              0                           1
+                  /   \                       /   \
+                /       \                   /       \
+              /           \               /           \
+    3:       0             1             0             1
+            / \           / \           / \           / \
+           /   \         /   \         /   \         /   \
+    4:    0     1       0     1       0     1       0     1
+         / \   / \     / \   / \     / \   / \     / \   / \
+    5:  0   1 0   1   0   1 0   1   0   1 0   1   0   1 0   1
+
+    Tests:
+    A: |-|
+    B:     |-|
+    C:                         |-|
+    D: |<--->|
+    E:               |<--->|
+    F:     |<->|
+    G: |<----->|
+    H:     |<----->|
+    I:     |<----------------------->|
+    """
+    proof = compute_proof(CONTENT_512, sedes=short_content_sedes)
+
+    # Just a single node
+    elements_a = proof.get_minimal_proof_elements(0, 1)
+    assert len(elements_a) == 1
+    assert elements_a[0].path == p(0, 0, 0, 0, 0)
+    assert elements_a[0].value == CONTENT_512[:32]
+
+    elements_b = proof.get_minimal_proof_elements(1, 1)
+    assert len(elements_b) == 1
+    assert elements_b[0].path == p(0, 0, 0, 0, 1)
+    assert elements_b[0].value == CONTENT_512[32:64]
+
+    elements_c = proof.get_minimal_proof_elements(7, 1)
+    assert len(elements_c) == 1
+    assert elements_c[0].path == p(0, 0, 1, 1, 1)
+    assert elements_c[0].value == CONTENT_512[224:256]
+
+    # pair of sibling nodes
+    elements_d = proof.get_minimal_proof_elements(0, 2)
+    assert len(elements_d) == 1
+    assert elements_d[0].path == p(0, 0, 0, 0)
+    assert elements_d[0].value == hash_eth2(CONTENT_512[0:64])
+
+    elements_e = proof.get_minimal_proof_elements(4, 2)
+    assert len(elements_e) == 1
+    assert elements_e[0].path == p(0, 0, 1, 0)
+    assert elements_e[0].value == hash_eth2(CONTENT_512[128:192])
+
+    # pair of non-sibling nodes
+    elements_f = proof.get_minimal_proof_elements(1, 2)
+    assert len(elements_f) == 2
+    assert elements_f[0].path == p(0, 0, 0, 0, 1)
+    assert elements_f[0].value == CONTENT_512[32:64]
+    assert elements_f[1].path == p(0, 0, 0, 1, 0)
+    assert elements_f[1].value == CONTENT_512[64:96]
+
+    # disjoint sets of three
+    elements_g = proof.get_minimal_proof_elements(0, 3)
+    assert len(elements_g) == 2
+    assert elements_g[0].path == p(0, 0, 0, 0)
+    assert elements_g[0].value == hash_eth2(CONTENT_512[0:64])
+    assert elements_g[1].path == p(0, 0, 0, 1, 0)
+    assert elements_g[1].value == CONTENT_512[64:96]
+
+    elements_h = proof.get_minimal_proof_elements(1, 3)
+    assert len(elements_h) == 2
+    assert elements_h[0].path == p(0, 0, 0, 0, 1)
+    assert elements_h[0].value == CONTENT_512[32:64]
+    assert elements_h[1].path == p(0, 0, 0, 1)
+    assert elements_h[1].value == hash_eth2(CONTENT_512[64:128])
+
+    # span of 8
+    elements_i = proof.get_minimal_proof_elements(1, 8)
+    assert len(elements_i) == 4
+    assert elements_i[0].path == p(0, 0, 0, 0, 1)
+    assert elements_i[0].value == CONTENT_512[32:64]
+    assert elements_i[1].path == p(0, 0, 0, 1)
+    assert elements_i[1].value == hash_eth2(CONTENT_512[64:128])
+    assert elements_i[2].path == p(0, 0, 1)
+    assert elements_i[2].value == hash_eth2(
+        hash_eth2(CONTENT_512[128:192]) + hash_eth2(CONTENT_512[192:256])
+    )
+    assert elements_i[3].path == p(0, 1, 0, 0, 0)
+    assert elements_i[3].value == CONTENT_512[256:288]
+
+
+def test_proof_get_minimal_proof_elements_mixed_depths():
+    r"""
+    0:                                X
+                                     / \
+                                   /     \
+    1:                            0       1
+                                 / \   (length)
+                               /     \
+                             /         \
+                           /             \
+                         /                 \
+                       /                     \
+                     /                         \
+    2:              0                           1
+                  /   \                       /   \
+                /       \                   /       \
+              /           \               /           \
+    3:       0             1             0             1
+            / \           / \           / \           / \
+           /   \         /   \         /   \         /   \
+    4:    0     1       0     1       X     X       0     1
+         / \   / \     / \   / \     / \   / \     / \   / \
+    5:  0   1 X   X   0   1 0   1   X   X X   X   0   1 X   X
+
+    Nodes marked with `X` have already been collapsed
+
+    Tests:
+    A: |<--------->|
+    B:                             |<----------------------->|
+    """
+    full_proof = compute_proof(CONTENT_512, sedes=short_content_sedes)
+
+    section_a = full_proof.get_elements_under(p(0, 0, 0, 0))
+    section_b = full_proof.get_minimal_proof_elements(2, 2)
+    section_c = full_proof.get_elements_under(p(0, 0, 1))
+    section_d = full_proof.get_minimal_proof_elements(8, 4)
+    section_e = full_proof.get_elements_under(p(0, 1, 1, 0))
+    section_f = full_proof.get_minimal_proof_elements(14, 2)
+    section_g = (full_proof.get_element((True,)),)
+
+    sparse_elements = sum(
+        (section_a, section_b, section_c, section_d, section_e, section_f, section_g,),
+        (),
+    )
+    sparse_proof = Proof(elements=sparse_elements, sedes=short_content_sedes,)
+    validate_proof(sparse_proof)
+
+    # spans nodes at different levels
+    elements_a = sparse_proof.get_minimal_proof_elements(0, 4)
+    assert len(elements_a) == 1
+    assert elements_a[0].path == p(0, 0, 0)
+    assert elements_a[0].value == hash_eth2(
+        hash_eth2(CONTENT_512[0:64]) + hash_eth2(CONTENT_512[64:128])
+    )
+
+    elements_b = sparse_proof.get_minimal_proof_elements(8, 8)
+    assert len(elements_b) == 1
+    assert elements_b[0].path == p(0, 1)
+    hash_010 = hash_eth2(
+        hash_eth2(CONTENT_512[256:320]) + hash_eth2(CONTENT_512[320:384])
+    )
+    hash_011 = hash_eth2(
+        hash_eth2(CONTENT_512[384:448]) + hash_eth2(CONTENT_512[448:512])
+    )
+    assert elements_b[0].value == hash_eth2(hash_010 + hash_011)


### PR DESCRIPTION
Builds on #175 

## What was wrong?

We need to be able to compute "partial" proofs.

## How was it fixed?

This PR fills out the `Proof.to_partial` object API and adds tests for it.

#### Cute Animal Picture

![dogfox](https://user-images.githubusercontent.com/824194/97745692-ded40280-1aae-11eb-839e-2384cda764e2.jpg)

