### PR TITLE
Proof serialization

### DIFF
--- a/ddht/v5_1/alexandria/leb128.py
+++ b/ddht/v5_1/alexandria/leb128.py
@@ -2,7 +2,9 @@ import functools
 import itertools
 import math
 import operator
-from typing import IO, Iterable
+from typing import Iterable, Iterator, Tuple
+
+from eth_utils import to_tuple
 
 from ddht.exceptions import ParseError
 
@@ -27,11 +29,36 @@ def _encode_leb128(value: int) -> Iterable[int]:
             yield byte | HIGH_MASK
 
 
-def parse_leb128(stream: IO[bytes]) -> int:
+def decode_leb128(data: bytes) -> int:
     """
     https://en.wikipedia.org/wiki/LEB128
     """
-    return functools.reduce(operator.or_, _parse_leb128(stream), 0,)
+    value, remainder = parse_leb128(data)
+    if remainder:
+        raise ParseError(f"Dangling bytes: data={data.hex()}  extra={remainder.hex()}")
+    return value
+
+
+def parse_leb128(data: bytes) -> Tuple[int, bytes]:
+    data_iter = iter(data)
+    value = functools.reduce(operator.or_, _parse_leb128(data_iter), 0,)
+    remainder = bytes(data_iter)
+    return value, remainder
+
+
+@to_tuple
+def partition_leb128(data: bytes) -> Iterable[bytes]:
+    if not data:
+        return
+    last_idx = 0
+    for idx, byte in enumerate(data):
+        if not byte & HIGH_MASK:
+            yield data[last_idx : idx + 1]
+            last_idx = idx + 1
+    if last_idx != len(data):
+        raise ParseError(
+            f"Dangling bytes: data={data.hex()}  extra={data[last_idx:].hex()}"
+        )
 
 
 # The maximum shift width for a 64 bit integer.  We shouldn't have to decode
@@ -39,16 +66,14 @@ def parse_leb128(stream: IO[bytes]) -> int:
 SHIFT_64_BIT_MAX = int(math.ceil(64 / 7)) * 7
 
 
-def _parse_leb128(stream: IO[bytes]) -> Iterable[int]:
+def _parse_leb128(data_iter: Iterator[int]) -> Iterable[int]:
     for shift in itertools.count(0, 7):
         if shift > SHIFT_64_BIT_MAX:
             raise ParseError("Decoded integer exceeds maximum decodable size...")
 
-        byte = stream.read(1)
-
         try:
-            value = byte[0]
-        except IndexError:
+            value = next(data_iter)
+        except StopIteration:
             raise ParseError(
                 "Unexpected end of stream while parsing LEB128 encoded integer"
             )

--- a/tests/core/v5_1/alexandria/test_leb128.py
+++ b/tests/core/v5_1/alexandria/test_leb128.py
@@ -1,18 +1,30 @@
-import io
-
 from hypothesis import given
 from hypothesis import strategies as st
 import pytest
 
-from ddht.v5_1.alexandria.leb128 import encode_leb128, parse_leb128
+from ddht.exceptions import ParseError
+from ddht.v5_1.alexandria.leb128 import (
+    decode_leb128,
+    encode_leb128,
+    parse_leb128,
+    partition_leb128,
+)
 
 
 @pytest.mark.parametrize(
     "value,expected", ((b"\x00", 0), (b"\xe5\x8e\x26", 624485),),
 )
-def test_parse_leb128(value, expected):
-    actual = parse_leb128(io.BytesIO(value))
+def test_decode_leb128(value, expected):
+    actual = decode_leb128(value)
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected", ((b"\x00\x00", 0), (b"\xe5\x8e\x26\x00", 624485),),
+)
+def test_decode_leb128_dangling_bytes(value, expected):
+    with pytest.raises(ParseError):
+        decode_leb128(value)
 
 
 @pytest.mark.parametrize(
@@ -26,5 +38,59 @@ def test_encode_leb128(value, expected):
 @given(value=st.integers(min_value=0, max_value=2 ** 32 - 1))
 def test_leb128_encoding_round_trip(value):
     encoded_value = encode_leb128(value)
-    decoded_value = parse_leb128(io.BytesIO(encoded_value))
+    decoded_value = decode_leb128(encoded_value)
     assert decoded_value == value
+
+
+@pytest.mark.parametrize(
+    "encoded_stream,expected",
+    (
+        (b"", ()),
+        (b"\x00", (b"\x00",)),
+        (b"\x00\x00", (b"\x00", b"\x00")),
+        (b"\xe5\x8e\x26", (b"\xe5\x8e\x26",)),
+        (b"\xe5\x8e\x26\x00", (b"\xe5\x8e\x26", b"\x00")),
+        (b"\x00\xe5\x8e\x26\x00", (b"\x00", b"\xe5\x8e\x26", b"\x00")),
+    ),
+)
+def test_partition_leb128(encoded_stream, expected):
+    actual = partition_leb128(encoded_stream)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "data,expected",
+    (
+        (b"\x00", (0, b"")),
+        (b"\x00\x00", (0, b"\x00")),
+        (b"\xe5\x8e\x26\x00", (624485, b"\x00")),
+        (b"\xe5\x8e\x26\xff", (624485, b"\xff")),
+    ),
+)
+def test_parse_leb128(data, expected):
+    actual = parse_leb128(data)
+    assert actual == expected
+
+
+@given(
+    value=st.integers(min_value=0, max_value=2 ** 32 - 1),
+    remainder=st.binary(min_size=0, max_size=16),
+)
+def test_parse_leb128_fuzzy(value, remainder):
+    data = encode_leb128(value) + remainder
+    actual = parse_leb128(data)
+    assert actual == (value, remainder)
+
+
+@given(
+    values=st.lists(
+        st.integers(min_value=0, max_value=2 ** 32 - 1), min_size=0, max_size=50,
+    ).map(tuple),
+)
+def test_partition_leb128_fuzzy(values):
+    encoded = b"".join((encode_leb128(value) for value in values))
+    encoded_values = partition_leb128(encoded)
+    decoded_values = tuple(
+        decode_leb128(encoded_value) for encoded_value in encoded_values
+    )
+    assert decoded_values == values

--- a/tests/core/v5_1/alexandria/test_proof_serialization.py
+++ b/tests/core/v5_1/alexandria/test_proof_serialization.py
@@ -1,0 +1,103 @@
+from hypothesis import given, settings
+from hypothesis import strategies as st
+import pytest
+
+from ddht.v5_1.alexandria.constants import GB
+from ddht.v5_1.alexandria.partials.proof import (
+    Proof,
+    compute_proof,
+    deserialize_path,
+    serialize_path,
+    validate_proof,
+)
+from ddht.v5_1.alexandria.sedes import content_sedes
+
+VALUE = bytes(bytearray((i for i in range(32))))
+
+
+def p(*crumbs):
+    return tuple(bool(crumb) for crumb in crumbs)
+
+
+@pytest.mark.parametrize(
+    "path,previous",
+    (
+        ((), (),),
+        (p(1), (),),
+        (p(0), (),),
+        ((True,) * 25, (),),
+        ((False,) * 25, (),),
+        (p(0, 0, 1, 1, 0, 0), (),),
+        (p(1, 1, 0, 0, 1, 1), (),),
+        # Previous path without any common bits
+        (p(1, 0, 1, 0, 1, 0), p(0, 1)),
+        # Previous path without one common bit
+        (p(1, 0, 1, 0, 1, 0), p(1, 1)),
+        # Previous path without multiple common bits
+        (p(1, 0, 1, 0, 1, 0), p(1, 0, 1, 0, 0),),
+        # Exceed single byte boundaries
+        (p(1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0), p(1, 0),),
+        (p(1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0), p(1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1),),
+    ),
+)
+def test_proof_path_serialization_round_trip(path, previous):
+    serialized = serialize_path(previous, path)
+    result = deserialize_path(previous, serialized)
+    assert result == path
+
+
+@given(data=st.data(),)
+def test_proof_path_serialization_round_trip_fuzzy(data):
+    path = data.draw(st.lists(st.booleans(), min_size=0, max_size=25).map(tuple))
+    previous = data.draw(st.lists(st.booleans(), min_size=0, max_size=25).map(tuple))
+
+    serialized = serialize_path(previous, path)
+    result = deserialize_path(previous, serialized)
+    assert result == path
+
+
+@settings(max_examples=1000)
+@given(content=st.binary(min_size=0, max_size=GB))
+def test_full_proof_serialization_and_deserialization(content):
+    proof = compute_proof(content, sedes=content_sedes)
+
+    serialized = proof.serialize()
+    result = Proof.deserialize(serialized)
+
+    assert result.get_hash_tree_root() == proof.get_hash_tree_root()
+
+    validate_proof(result)
+
+    assert result == proof
+
+
+@settings(max_examples=1000)
+@given(data=st.data())
+def test_partial_proof_serialization_and_deserialization(data):
+    content = data.draw(st.binary(min_size=0, max_size=GB))
+
+    slice_start = data.draw(
+        st.integers(min_value=0, max_value=max(0, len(content) - 1))
+    )
+    slice_stop = data.draw(st.integers(min_value=slice_start, max_value=len(content)))
+    data_slice = slice(slice_start, slice_stop)
+
+    full_proof = compute_proof(content, sedes=content_sedes)
+
+    slice_length = max(0, data_slice.stop - data_slice.start - 1)
+
+    partial_proof = full_proof.to_partial(
+        start_at=data_slice.start, partial_data_length=slice_length,
+    )
+    assert partial_proof.get_hash_tree_root() == full_proof.get_hash_tree_root()
+
+    serialized = partial_proof.serialize()
+    result = Proof.deserialize(serialized)
+
+    validate_proof(result)
+
+    assert result == partial_proof
+
+    partial = result.get_proven_data()
+    data_from_partial = partial[data_slice]
+    assert data_from_partial == content[data_slice]


### PR DESCRIPTION
builds on #145

## What was wrong?

With #145 we get a full API for interacting with partial proofs for content.  This implements serialization (and deserialization) for use at the wire protocol level.

## How was it fixed?

Implement a a compact scheme for serializing proofs.

#### Cute Animal Picture

![Unusual-animal-friendships-03](https://user-images.githubusercontent.com/824194/97747054-f44a2c00-1ab0-11eb-9a38-c750be5ad7b6.jpeg)

