### PR TITLE
Benchmarking for content proofs.

### DIFF
--- a/ddht/tools/benchmark/partials.py
+++ b/ddht/tools/benchmark/partials.py
@@ -1,0 +1,155 @@
+import hashlib
+import logging
+import sys
+import time
+from typing import List, Tuple
+
+from ddht.v5_1.alexandria.partials.proof import compute_proof
+from ddht.v5_1.alexandria.sedes import content_sedes
+
+try:
+    import texttable
+except ImportError as err:
+    raise ImportError(
+        "The `texttable` python library is required to use the benchmarking "
+        "suite.  Installable usin `pip install ddht[benchmark]`"
+    ) from err
+
+
+MB = 1024 * 1024
+
+
+logger = logging.getLogger("ddht.benchmarks")
+
+
+SEGMENTS = (
+    ("32b-first", (0, 32)),
+    ("32b-offset-1c", (32, 32)),
+    ("32b-offset-4c", (128, 32)),
+    ("64b-first", (0, 64)),
+    ("64b-offset-1c", (32, 64)),
+    ("64b-offset-4c", (128, 64)),
+    ("128b-first", (0, 128)),
+    ("128b-offset-1c", (32, 128)),
+    ("128b-offset-4c", (128, 128)),
+    ("256b-first", (0, 256)),
+    ("256b-offset-1c", (32, 256)),
+    ("256b-offset-4c", (128, 256)),
+    ("512b-first", (0, 512)),
+    ("512b-offset-1c", (32, 512)),
+    ("512b-offset-4c", (128, 512)),
+    ("768b-first", (0, 768)),
+    ("768b-offset-1c", (32, 768)),
+    ("768b-offset-4c", (128, 768)),
+    ("1kb-first", (0, 1024)),
+    ("1kb-offset-1c", (32, 1024)),
+    ("1kb-offset-4c", (128, 1024)),
+)
+
+
+def benchmark_serialization(
+    benchmark_name: str,
+    content: bytes,
+    segments: Tuple[Tuple[str, Tuple[int, int]], ...],
+) -> None:
+    full_proof = compute_proof(content, sedes=content_sedes)
+
+    proofs = tuple(
+        full_proof.to_partial(
+            start_at=start_at, partial_data_length=partial_data_length
+        )
+        for (name, (start_at, partial_data_length)) in segments
+    )
+    serialized_proofs = tuple(proof.serialize() for proof in proofs)
+
+    sizes = tuple(len(serialized_proof) for serialized_proof in serialized_proofs)
+
+    table_header = ("name", "start", "end", "length", "size")
+    table_rows = tuple(
+        (name, start_at, start_at + partial_data_length, partial_data_length, size)
+        for ((name, (start_at, partial_data_length)), size) in zip(segments, sizes)
+    )
+
+    table = texttable.Texttable()
+    table.set_cols_align(("l", "r", "r", "r", "r"))
+    table.header(table_header)
+    table.add_rows(table_rows, header=False)
+
+    logger.info("\n##########################")
+    logger.info(f"benchmark: {benchmark_name}")
+    logger.info("##########################\n")
+    logger.info(table.draw())
+
+
+CONTENT_SIZES = (
+    ("0b", 0, 1000),
+    ("128b", 128, 1000),
+    ("256b", 256, 1000),
+    ("512b", 512, 1000),
+    ("1kb", 1024, 500),
+    ("2kb", 2048, 300),
+    ("4kb", 4096, 200),
+    ("10kb", 10240, 100),
+    ("20kb", 20480, 70),
+    ("100kb", 102400, 20),
+)
+
+
+def benchmark_full_construction(sizes: Tuple[Tuple[str, int, int], ...],) -> None:
+    base_content_length = max(size for name, size, iteration_count in sizes)
+    base_content = b"".join(
+        (
+            hashlib.sha256(i.to_bytes(32, "big")).digest()
+            for i in range((base_content_length + 31) // 32)
+        )
+    )
+
+    proof_performances: List[Tuple[float, int]] = []
+    for name, size, iteration_count in sizes:
+        content = base_content[:size]
+        start_at = time.monotonic()
+        for _ in range(iteration_count):
+            compute_proof(content, sedes=content_sedes)
+        end_at = time.monotonic()
+        proof_performances.append((end_at - start_at, iteration_count))
+
+    proofs_per_second = tuple(
+        iteration_count / elapsed for (elapsed, iteration_count) in proof_performances
+    )
+
+    table_header = ("name", "size", "elapsed", "proofs/sec", "iterations")
+    table_rows = tuple(
+        (name, size, elapsed, rate, iteration_count)
+        for ((name, size, iteration_count), (elapsed, _), rate) in zip(
+            sizes, proof_performances, proofs_per_second
+        )
+    )
+
+    table = texttable.Texttable()
+    table.set_cols_align(("l", "r", "r", "r", "r"))
+    table.header(table_header)
+    table.add_rows(table_rows, header=False)
+
+    logger.info("\n######################################")
+    logger.info("benchmark: Proof Generation Speed")
+    logger.info("######################################\n")
+    logger.info(table.draw())
+
+
+def do_benchmarks() -> None:
+    content_1mb = b"".join(
+        (hashlib.sha256(i.to_bytes(32, "big")).digest() for i in range(MB // 32))
+    )
+    benchmark_serialization("1MB", content_1mb, SEGMENTS)
+
+    benchmark_full_construction(CONTENT_SIZES)
+
+
+if __name__ == "__main__":
+    handler_stream = logging.StreamHandler(sys.stderr)
+    handler_stream.setLevel(logging.INFO)
+
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler_stream)
+
+    do_benchmarks()

--- a/ddht/v5_1/alexandria/leb128.py
+++ b/ddht/v5_1/alexandria/leb128.py
@@ -40,6 +40,11 @@ def decode_leb128(data: bytes) -> int:
 
 
 def parse_leb128(data: bytes) -> Tuple[int, bytes]:
+    """
+    Decode a LEB128 encoded integer off of the head of some data, returning the
+    decoded integer and the remaining data that was not part of the encoded
+    value.
+    """
     data_iter = iter(data)
     value = functools.reduce(operator.or_, _parse_leb128(data_iter), 0,)
     remainder = bytes(data_iter)
@@ -48,6 +53,10 @@ def parse_leb128(data: bytes) -> Tuple[int, bytes]:
 
 @to_tuple
 def partition_leb128(data: bytes) -> Iterable[bytes]:
+    """
+    Given a set of LEB128 encoded values that have been concatenated together,
+    split them up into their individual encoded values.
+    """
     if not data:
         return
     last_idx = 0

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ extras_require = {
     "alexandria": [
         "ssz>=0.2.4,<0.3",
     ],
+    "benchmark": [
+        "texttable==1.6.3",
+    ],
 }
 
 extras_require["dev"] = (

--- a/tests/core/v5_1/alexandria/test_partial_bencharks.py
+++ b/tests/core/v5_1/alexandria/test_partial_bencharks.py
@@ -1,0 +1,5 @@
+from ddht.tools.benchmark.partials import do_benchmarks
+
+
+def test_partial_benchmarks():
+    do_benchmarks()

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ extras=
     test
     web3
     alexandria
+    benchmark
     docs: doc
 whitelist_externals=make
 


### PR DESCRIPTION
Builds on #146 

## What was wrong?

#146 finishes the proof API needed to do partial content proofs.  The proof code is going to be one of the performance critical components so we need to be able to measure performance to be able to know how changes effect it.

## How was it fixed?

Added two benchmarking suites:

- size of serialized proofs
- rate that we can generate proofs for content

Output looks like this

```
$ python ddht/tools/benchmark/partials.py

##########################
benchmark: 1MB
##########################

+----------------+-------+------+--------+------+
|      name      | start | end  | length | size |
+================+=======+======+========+======+
| 32b-first      |     0 |   32 |     32 |  546 |
+----------------+-------+------+--------+------+
| 32b-offset-1c  |    32 |   64 |     32 |  546 |
+----------------+-------+------+--------+------+
| 32b-offset-4c  |   128 |  160 |     32 |  546 |
+----------------+-------+------+--------+------+
| 64b-first      |     0 |   64 |     64 |  546 |
+----------------+-------+------+--------+------+
| 64b-offset-1c  |    32 |   96 |     64 |  580 |
+----------------+-------+------+--------+------+
| 64b-offset-4c  |   128 |  192 |     64 |  546 |
+----------------+-------+------+--------+------+
| 128b-first     |     0 |  128 |    128 |  580 |
+----------------+-------+------+--------+------+
| 128b-offset-1c |    32 |  160 |    128 |  648 |
+----------------+-------+------+--------+------+
| 128b-offset-4c |   128 |  256 |    128 |  580 |
+----------------+-------+------+--------+------+
| 256b-first     |     0 |  256 |    256 |  682 |
+----------------+-------+------+--------+------+
| 256b-offset-1c |    32 |  288 |    256 |  784 |
+----------------+-------+------+--------+------+
| 256b-offset-4c |   128 |  384 |    256 |  716 |
+----------------+-------+------+--------+------+
| 512b-first     |     0 |  512 |    512 |  920 |
+----------------+-------+------+--------+------+
| 512b-offset-1c |    32 |  544 |    512 | 1057 |
+----------------+-------+------+--------+------+
| 512b-offset-4c |   128 |  640 |    512 |  989 |
+----------------+-------+------+--------+------+
| 768b-first     |     0 |  768 |    768 | 1193 |
+----------------+-------+------+--------+------+
| 768b-offset-1c |    32 |  800 |    768 | 1295 |
+----------------+-------+------+--------+------+
| 768b-offset-4c |   128 |  896 |    768 | 1227 |
+----------------+-------+------+--------+------+
| 1kb-first      |     0 | 1024 |   1024 | 1431 |
+----------------+-------+------+--------+------+
| 1kb-offset-1c  |    32 | 1056 |   1024 | 1602 |
+----------------+-------+------+--------+------+
| 1kb-offset-4c  |   128 | 1152 |   1024 | 1534 |
+----------------+-------+------+--------+------+

######################################
benchmark: Proof Generation Speed
######################################

+-------+--------+---------+------------+------------+
| name  |  size  | elapsed | proofs/sec | iterations |
+=======+========+=========+============+============+
| 0b    |      0 |   0.303 |   3305.073 |       1000 |
+-------+--------+---------+------------+------------+
| 128b  |    128 |   0.321 |   3119.925 |       1000 |
+-------+--------+---------+------------+------------+
| 256b  |    256 |   0.359 |   2783.899 |       1000 |
+-------+--------+---------+------------+------------+
| 512b  |    512 |   0.458 |   2183.154 |       1000 |
+-------+--------+---------+------------+------------+
| 1kb   |   1024 |   0.329 |   1520.218 |        500 |
+-------+--------+---------+------------+------------+
| 2kb   |   2048 |   0.321 |    933.607 |        300 |
+-------+--------+---------+------------+------------+
| 4kb   |   4096 |   0.445 |    449.122 |        200 |
+-------+--------+---------+------------+------------+
| 10kb  |  10240 |   0.549 |    182.092 |        100 |
+-------+--------+---------+------------+------------+
| 20kb  |  20480 |   0.795 |     88.026 |         70 |
+-------+--------+---------+------------+------------+
| 100kb | 102400 |   1.134 |     17.644 |         20 |
+-------+--------+---------+------------+------------+
```

#### Cute Animal Picture

![Unlikely-Animal-Friends-11](https://user-images.githubusercontent.com/824194/97749707-25c4f680-1ab5-11eb-9ffd-55d97730aca1.jpg)

