### PR TITLE
Implement content transmission messages for AlexandriaClient

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -3,7 +3,7 @@ from typing import Any, AsyncContextManager, Collection, Optional, Sequence, Tup
 
 from async_service import ServiceAPI
 from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
-from eth_typing import NodeID
+from eth_typing import Hash32, NodeID
 import trio
 
 from ddht.abc import RequestTrackerAPI, RoutingTableAPI, SubscriptionManagerAPI
@@ -12,6 +12,7 @@ from ddht.endpoint import Endpoint
 from ddht.v5_1.abc import NetworkAPI, TalkProtocolAPI
 from ddht.v5_1.alexandria.messages import (
     AlexandriaMessage,
+    ContentMessage,
     FoundNodesMessage,
     PongMessage,
     TAlexandriaMessage,
@@ -80,6 +81,31 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     ) -> int:
         ...
 
+    @abstractmethod
+    async def send_get_content(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        content_id: Hash32,
+        start_chunk_index: int,
+        num_chunks: int,
+        request_id: Optional[bytes] = None,
+    ) -> bytes:
+        ...
+
+    @abstractmethod
+    async def send_content(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        is_proof: bool,
+        payload: bytes,
+        request_id: bytes,
+    ) -> None:
+        ...
+
     #
     # High Level Request/Response
     #
@@ -96,6 +122,19 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         *,
         request_id: Optional[bytes] = None,
     ) -> Tuple[InboundMessage[FoundNodesMessage], ...]:
+        ...
+
+    @abstractmethod
+    async def get_content(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        content_id: Hash32,
+        start_chunk_index: int,
+        num_chunks: int,
+        request_id: Optional[bytes] = None,
+    ) -> ContentMessage:
         ...
 
 

--- a/ddht/v5_1/alexandria/messages.py
+++ b/ddht/v5_1/alexandria/messages.py
@@ -6,14 +6,18 @@ from ssz import BaseSedes
 from ddht.constants import UINT8_TO_BYTES
 from ddht.exceptions import DecodingError
 from ddht.v5_1.alexandria.payloads import (
+    ContentPayload,
     FindNodesPayload,
     FoundNodesPayload,
+    GetContentPayload,
     PingPayload,
     PongPayload,
 )
 from ddht.v5_1.alexandria.sedes import (
+    ContentSedes,
     FindNodesSedes,
     FoundNodesSedes,
+    GetContentSedes,
     PingSedes,
     PongSedes,
 )
@@ -115,6 +119,24 @@ class FoundNodesMessage(AlexandriaMessage[FoundNodesPayload]):
     payload_type = FoundNodesPayload
 
     payload: FoundNodesPayload
+
+
+@register
+class GetContentMessage(AlexandriaMessage[GetContentPayload]):
+    message_id = 5
+    sedes = GetContentSedes
+    payload_type = GetContentPayload
+
+    payload: GetContentPayload
+
+
+@register
+class ContentMessage(AlexandriaMessage[ContentPayload]):
+    message_id = 6
+    sedes = ContentSedes
+    payload_type = ContentPayload
+
+    payload: ContentPayload
 
 
 def decode_message(data: bytes) -> AlexandriaMessage[Any]:

--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -1,6 +1,7 @@
 from typing import NamedTuple, Sequence, Tuple
 
 from eth_enr import ENR, ENRAPI
+from eth_typing import Hash32
 import rlp
 
 
@@ -30,3 +31,14 @@ class FoundNodesPayload(NamedTuple):
     def from_enrs(cls, total: int, enrs: Sequence[ENRAPI]) -> "FoundNodesPayload":
         encoded_enrs = tuple(rlp.encode(enr) for enr in enrs)
         return cls(total, encoded_enrs)
+
+
+class GetContentPayload(NamedTuple):
+    content_id: Hash32
+    start_chunk_index: int
+    num_chunks: int
+
+
+class ContentPayload(NamedTuple):
+    is_proof: bool
+    payload: bytes

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -1,4 +1,4 @@
-from ssz.sedes import Container, List, uint8, uint16, uint32
+from ssz.sedes import Container, List, boolean, bytes32, uint8, uint16, uint32
 
 
 class ByteList(List):  # type: ignore
@@ -19,3 +19,5 @@ PingSedes = Container(field_sedes=(uint32,))
 PongSedes = Container(field_sedes=(uint32,))
 FindNodesSedes = Container(field_sedes=(List(uint16, max_length=256),))
 FoundNodesSedes = Container(field_sedes=(uint8, List(byte_list, max_length=32)))
+GetContentSedes = Container(field_sedes=(bytes32, uint32, uint16))
+ContentSedes = Container(field_sedes=(boolean, byte_list,))


### PR DESCRIPTION
## What was wrong?

We need a message pair for transmitting content over the Alexandria network

## How was it fixed?

Implemented the `GetContentMessage` and `ContentMessage` pair, as well as the base APIs in the `AlexandriaClientAPI` for sending these messages.

#### Cute Animal Picture


![zorro_plush_1400x840_LgHGf](https://user-images.githubusercontent.com/824194/97757749-fd43f900-1ac2-11eb-860a-ed157ed6aee0.jpg)
