### PR TITLE
Faster bootstrapping process

### DIFF
--- a/ddht/kademlia.py
+++ b/ddht/kademlia.py
@@ -5,6 +5,7 @@ import itertools
 import logging
 import math
 import random
+import secrets
 import struct
 from typing import (
     Any,
@@ -106,6 +107,21 @@ def compute_log_distance(left_node_id: NodeID, right_node_id: NodeID) -> int:
         raise ValueError("Cannot compute log distance between identical nodes")
     distance = compute_distance(left_node_id, right_node_id)
     return distance.bit_length()
+
+
+def at_log_distance(target: NodeID, distance: int) -> NodeID:
+    node_as_int = int.from_bytes(target, "big")
+    bits_in_common = 256 - (distance - 1)
+
+    # This is the common prefix
+    high_mask = (2 ** bits_in_common - 1) << distance
+    # We flip the bit at the appropriate distance
+    differential_bit = ~node_as_int & (2 ** (distance - 1))
+    # We randomize all of the low bits.
+    low_mask = secrets.randbelow(2 ** (distance - 1))
+
+    node_at_distance = (node_as_int & high_mask) | differential_bit | low_mask
+    return NodeID(node_at_distance.to_bytes(32, "big"))
 
 
 class KademliaRoutingTable(RoutingTableAPI):

--- a/ddht/token_bucket.py
+++ b/ddht/token_bucket.py
@@ -1,0 +1,96 @@
+import time
+from typing import AsyncGenerator, Union
+
+import trio
+
+
+class NotEnoughTokens(Exception):
+    """
+    Raised if the token bucket is empty when trying to take a token in blocking
+    mode.
+    """
+
+    pass
+
+
+class TokenBucket:
+    def __init__(self, rate: Union[int, float], capacity: Union[int, float]) -> None:
+        self._rate = rate
+        self._capacity = capacity
+        self._num_tokens = self._capacity
+        self._last_refill = time.perf_counter()
+        self._seconds_per_token = 1 / self._rate
+        self._take_lock = trio.Lock()
+
+    async def __aiter__(self) -> AsyncGenerator[None, None]:
+        """
+        Can be used as an async iterator to limit the rate at which a loop can
+        run.
+        """
+        while True:
+            await self.take()
+            yield
+
+    def get_num_tokens(self) -> float:
+        """
+        Return the number of tokens current in the bucket.
+        """
+        return max(0, self._get_num_tokens(time.perf_counter()))
+
+    def _get_num_tokens(self, when: float) -> float:
+        # Note that the implementation of the `take` method requires that this
+        # function to allow negative results..
+        return min(
+            self._capacity,
+            self._num_tokens + (self._rate * (when - self._last_refill)),
+        )
+
+    def _take(self, num: Union[int, float] = 1) -> None:
+        now = time.perf_counter()
+        if num < 0:
+            raise ValueError("Cannot take negative token quantity")
+
+        # refill the bucket
+        self._num_tokens = self._get_num_tokens(now)
+        self._last_refill = now
+
+        # deduct the requested tokens.  this operation is allowed to result in
+        # a negative internal representation of the number of tokens in the
+        # bucket.
+        self._num_tokens -= num
+
+    async def take(self, num: Union[int, float] = 1) -> None:
+        """
+        Take `num` tokens out of the bucket.  If the bucket does not have
+        enough tokens, blocks until the bucket will be full enough to fulfill
+        the request.
+        """
+        # the lock ensures that we don't have two processes take from the
+        # bucket at the same time while the inner sleep is happening
+        async with self._take_lock:
+            self._take(num)
+
+        # if the bucket balance is negative, wait an amount of seconds
+        # adequatet to fill it.  Note that this requires that `_get_num_tokens`
+        # be able to return a negative value.
+        if self._num_tokens < 0:
+            sleep_for = abs(self._num_tokens) * self._seconds_per_token
+            await trio.sleep(sleep_for)
+
+    def take_nowait(self, num: Union[int, float] = 1) -> None:
+        # we calculate this value locally to ensure that in the case of not
+        # having enough tokens the error message is accurate due to race
+        # condition between calculating capacity and raising the error message.
+        num_tokens = self.get_num_tokens()
+        if num_tokens >= num:
+            self._take(num)
+        else:
+            raise NotEnoughTokens(
+                f"Insufficient capacity.  Needed {num:.2f} but only has {num_tokens:.2f}"
+            )
+
+    def can_take(self, num: Union[int, float] = 1) -> bool:
+        """
+        Return boolean whether the bucket has enough tokens to take `num` tokens.
+        """
+        return num <= self.get_num_tokens()

--- a/ddht/tools/factories/node_id.py
+++ b/ddht/tools/factories/node_id.py
@@ -1,12 +1,9 @@
-import random
 from typing import Tuple
 
 from eth_typing import NodeID
 from eth_utils import big_endian_to_int, int_to_big_endian
 from eth_utils.toolz import reduce
 import factory
-
-from ddht.kademlia import compute_log_distance
 
 
 def bytes_to_bits(input_bytes: bytes) -> Tuple[bool, ...]:
@@ -36,32 +33,6 @@ class NodeIDFactory(factory.Factory):  # type: ignore
 
     @classmethod
     def at_log_distance(cls, reference: NodeID, log_distance: int) -> NodeID:
-        num_bits = len(reference) * 8
+        from ddht.kademlia import at_log_distance as _at_log_distance
 
-        if log_distance > num_bits:
-            raise ValueError(
-                "Log distance must not be greater than number of bits in the node id"
-            )
-        elif log_distance < 0:
-            raise ValueError("Log distance cannot be negative")
-
-        num_common_bits = num_bits - log_distance
-        flipped_bit_index = num_common_bits
-        num_random_bits = num_bits - num_common_bits - 1
-
-        reference_bits = bytes_to_bits(reference)
-
-        shared_bits = reference_bits[:num_common_bits]
-        flipped_bit = not reference_bits[flipped_bit_index]
-        random_bits = [
-            bool(random.randint(0, 1))
-            for _ in range(
-                flipped_bit_index + 1, flipped_bit_index + 1 + num_random_bits
-            )
-        ]
-
-        result_bits = tuple(list(shared_bits) + [flipped_bit] + random_bits)
-        result = NodeID(bits_to_bytes(result_bits))
-
-        assert compute_log_distance(result, reference) == log_distance
-        return result
+        return _at_log_distance(reference, log_distance)

--- a/tests/core/test_node_at_distance.py
+++ b/tests/core/test_node_at_distance.py
@@ -1,0 +1,13 @@
+import random
+
+from ddht.kademlia import at_log_distance, compute_log_distance
+from ddht.tools.factories.node_id import NodeIDFactory
+
+
+def test_at_log_distance():
+    for i in range(10000):
+        node = NodeIDFactory()
+        distance = random.randint(1, 256)
+        other = at_log_distance(node, distance)
+        actual = compute_log_distance(node, other)
+        assert actual == distance

--- a/tests/core/test_weighted_choice_util.py
+++ b/tests/core/test_weighted_choice_util.py
@@ -1,0 +1,20 @@
+import collections
+
+from ddht._utils import weighted_choice
+
+
+def test_weighted_choice():
+    for _ in range(100):
+        options = ("a", "b", "c")
+        results = tuple(weighted_choice(options) for _ in range(10000))
+        counts = collections.Counter(results)
+        count_a = counts["a"]
+        count_b = counts["b"]
+        count_c = counts["c"]
+
+        assert count_a < count_b < count_c
+
+        # `c` should be piced 3x as often as `a`
+        # `b` should be piced 2x as often as `a`
+        assert abs(3 - count_c / count_a) < 1.50
+        assert abs(2 - count_b / count_a) < 1.50

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -262,7 +262,7 @@ async def test_network_recursive_find_nodes(tester, alice, bob):
             bootnodes.append(node.enr)
 
         # give the the network some time to interconnect.
-        with trio.fail_after(5):
+        with trio.fail_after(20):
             for _ in range(1000):
                 await trio.lowlevel.checkpoint()
 
@@ -271,7 +271,7 @@ async def test_network_recursive_find_nodes(tester, alice, bob):
         )
 
         # give alice a little time to connect to the network as well
-        with trio.fail_after(5):
+        with trio.fail_after(20):
             for _ in range(1000):
                 await trio.lowlevel.checkpoint()
 
@@ -284,7 +284,7 @@ async def test_network_recursive_find_nodes(tester, alice, bob):
         )
         best_node_ids_by_distance = set(node_ids_by_distance[:3])
 
-        with trio.fail_after(10):
+        with trio.fail_after(60):
             found_enrs = await alice_network.recursive_find_nodes(target_node_id)
         found_node_ids = tuple(enr.node_id for enr in found_enrs)
 


### PR DESCRIPTION
## What was wrong?

The bootstrapping process was simple, leaving plenty of room for optimizations.

## How was it fixed?

First, small change to the initial bootstrapping logic to avoid an ineffective hang condition where bonding might happen after the `move_on_after` which would result in going back through the loop one more un-necessary time before moving on.

Second, I pulled the `TokenBucket` implementation from trinity so that we can burst our initial lookups, and then scale back to the periodic lookup when we are initially exploring the network.

Third, the actual lookup logic has been improved.  We still perform a random lookup, but we also perform a targeted lookup on one of our outermost non-full routing table buckets.  A randomly generated node-id has a 50% chance of landing in bucket 256.  This means that if we only perform random lookups, 50% of those will be for our outermost bucket.  Since the outermost bucket is typically always full, these lookups are not very effective.  By specifically targeted our non-full buckets we more effectively explore the unexplored parts of the network.

#### Cute Animal Picture

![racoons-3-trash](https://user-images.githubusercontent.com/824194/99850729-19bfd800-2b3b-11eb-9f1a-e9e6610a5e8d.jpg)

