### PR TITLE
Implement ssz proof merging

### DIFF
--- a/ddht/v5_1/alexandria/partials/_utils.py
+++ b/ddht/v5_1/alexandria/partials/_utils.py
@@ -1,6 +1,7 @@
 from typing import Iterable
 
 from eth_utils import to_tuple
+from eth_utils.toolz import sliding_window
 from ssz.constants import CHUNK_SIZE
 
 from ddht.v5_1.alexandria.constants import POWERS_OF_TWO
@@ -47,3 +48,22 @@ def get_chunk_count_for_data_length(length: int) -> int:
     if length == 0:
         return 0
     return (length + CHUNK_SIZE - 1) // CHUNK_SIZE  # type: ignore
+
+
+@to_tuple
+def filter_overlapping_paths(*paths: TreePath) -> Iterable[TreePath]:
+    """
+    Filter out any paths that are a prefix of another path.
+    """
+    if not paths:
+        return
+    sorted_paths = sorted(paths)
+    for left, right in sliding_window(2, sorted_paths):
+        if right[: len(left)] == left:
+            continue
+        else:
+            yield left
+
+    # Because of the use of `sliding_window` we need to manually yield the last
+    # path
+    yield sorted_paths[-1]

--- a/tests/core/v5_1/alexandria/test_partial_utils.py
+++ b/tests/core/v5_1/alexandria/test_partial_utils.py
@@ -3,6 +3,7 @@ import pytest
 from ddht.v5_1.alexandria.partials._utils import (
     decompose_into_powers_of_two,
     display_path,
+    filter_overlapping_paths,
     get_chunk_count_for_data_length,
     get_longest_common_path,
 )
@@ -74,4 +75,16 @@ def test_get_chunk_count_for_data_length(length, expected):
 )
 def test_display_path(path, expected):
     actual = display_path(path)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "paths,expected",
+    (
+        ((p(0, 0, 1), p(0, 0, 0), p(0, 0)), (p(0, 0, 0), p(0, 0, 1)),),
+        ((p(0, 0, 1), p(0,), p(0, 0, 0), p(0, 0)), (p(0, 0, 0), p(0, 0, 1)),),
+    ),
+)
+def test_filter_overlapping_paths(paths, expected):
+    actual = filter_overlapping_paths(*paths)
     assert actual == expected


### PR DESCRIPTION
Builds on #145 

## What was wrong?

When we request content in the Alexandria network, we get it in pieces.  We need a way to merge these pieces into a single unit.

## How was it fixed?

Quick and dirty implementation of `Proof.merge` which combines the two proofs into a single new proof, dropping any elements from the proof that are duplicated or no longer necessary (such as intermediate tree nodes for which we have all of the underlying leaves.


#### Cute Animal Picture

![20-Absolutely-Amazing-Dog-Halloween-Costumes-4](https://user-images.githubusercontent.com/824194/98487537-c5cefe00-21e0-11eb-83bb-a8735e7781e5.jpg)
