### PR TITLE
Refactor lazy endpoint retrieval for nodes

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -505,3 +505,11 @@ class NetworkAPI(ServiceAPI):
     @abstractmethod
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         ...
+
+    @abstractmethod
+    async def get_nodes_near(self, target: NodeID) -> Tuple[NodeID, ...]:
+        ...
+
+    @abstractmethod
+    async def endpoint_for_node_id(self, node_id: NodeID) -> Endpoint:
+        ...

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -188,11 +188,5 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         ...
 
     @abstractmethod
-    async def lookup_enr(
-        self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
-    ) -> ENRAPI:
-        ...
-
-    @abstractmethod
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         ...

--- a/tests/core/v5_1/test_client.py
+++ b/tests/core/v5_1/test_client.py
@@ -299,7 +299,9 @@ async def test_client_talk_request_response_timeout(alice, bob_client, autojump_
 
 @given(datagram_bytes=st.binary(max_size=1024))
 @pytest.mark.trio
-async def test_client_handles_malformed_datagrams(tester, datagram_bytes):
+async def test_client_handles_malformed_datagrams(
+    tester, datagram_bytes, autojump_clock
+):
     bob = tester.node()
     async with bob.client() as bob_client:
         alice = tester.node()


### PR DESCRIPTION
Fixes https://github.com/ethereum/ddht/issues/161

## What was wrong?

Up until now, the only way for us to learn about another node was via `FINDNODES/FOUNDNODES`.  This had the implicit guarantee that we would have an ENR record for that node.

With the upcoming introduction of Advertisements in Alexandria, we gain a new way to find a `node_id` without having encountered the node's ENR record yet.  This makes things like performing the liveliness check difficult.


## How was it fixed?

First, I removed some of the duplicated `AlexandriaNetworkAPI` methods.  Specifically, it now delegates to `NetworkAPI.lookup_enr` and `NetworkAPI.endpoint_for_node_id`.

Second, the `NetworkAPI.lookup_enr` now falls back to trying to find the node via a `NetworkAPI.recursive_find_nodes` when the endpoint is not known.


This also implements a new API, `NetworkAPI.get_nodes_near` which exposes a combined API between `NetworkAPI.recursive_find_nodes` and `RoutingTableAPI.iter_nodes_around` allowing for a more robust way to reliably find the closest nodes we can to a certain area of the network.

#### Cute Animal Picture


![redpanda](https://user-images.githubusercontent.com/824194/98583608-df745200-2281-11eb-9dbc-588fbdfdf020.jpg)
