### PR TITLE
Expose local private key from ClientAPI

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -221,6 +221,7 @@ class DispatcherAPI(ServiceAPI):
 
 
 class ClientAPI(ServiceAPI):
+    local_private_key: keys.PrivateKey
     enr_manager: ENRManagerAPI
     events: EventsAPI
     dispatcher: DispatcherAPI

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -16,6 +16,7 @@ from typing import (
 from async_generator import asynccontextmanager
 from async_service import Service
 from eth_enr import ENRAPI
+from eth_keys import keys
 from eth_typing import Hash32, NodeID
 from eth_utils import ValidationError
 import trio
@@ -68,6 +69,10 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         network.add_talk_protocol(self)
 
         self._active_request_ids = set()
+
+    @property
+    def local_private_key(self) -> keys.PrivateKey:
+        return self.network.client.local_private_key
 
     #
     # Service API

--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -56,7 +56,7 @@ class Client(Service, ClientAPI):
         events: EventsAPI = None,
         message_type_registry: MessageTypeRegistry = v51_registry,
     ) -> None:
-        self._local_private_key = local_private_key
+        self.local_private_key = local_private_key
 
         self.listen_on = listen_on
         self._listening = trio.Event()
@@ -102,7 +102,7 @@ class Client(Service, ClientAPI):
         self.events = events
 
         self.pool = Pool(
-            local_private_key=self._local_private_key,
+            local_private_key=self.local_private_key,
             local_node_id=self.enr_manager.enr.node_id,
             enr_db=self.enr_db,
             outbound_envelope_send_channel=self._outbound_envelope_send_channel,


### PR DESCRIPTION
## What was wrong?

The Alexandria network needs access to the private key in order to sign advertisements.

## How was it fixed?

Expose it as a public property.

#### Cute Animal Picture

![dogs-carrying-piano-pet-costume](https://user-images.githubusercontent.com/824194/98560007-8813b900-2264-11eb-848a-624bd6db1598.jpg)

