### PR TITLE
More precice upper bounds on alexandria payloads

### DIFF
--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -29,7 +29,7 @@ from ddht.request_tracker import RequestTracker
 from ddht.subscription_manager import SubscriptionManager
 from ddht.v5_1.abc import NetworkAPI
 from ddht.v5_1.alexandria.abc import AlexandriaClientAPI
-from ddht.v5_1.alexandria.constants import ALEXANDRIA_PROTOCOL_ID
+from ddht.v5_1.alexandria.constants import ALEXANDRIA_PROTOCOL_ID, MAX_PAYLOAD_SIZE
 from ddht.v5_1.alexandria.messages import (
     AlexandriaMessage,
     ContentMessage,
@@ -49,7 +49,7 @@ from ddht.v5_1.alexandria.payloads import (
     PingPayload,
     PongPayload,
 )
-from ddht.v5_1.constants import FOUND_NODES_MAX_PAYLOAD_SIZE, REQUEST_RESPONSE_TIMEOUT
+from ddht.v5_1.constants import REQUEST_RESPONSE_TIMEOUT
 from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
 
 
@@ -307,9 +307,7 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         request_id: bytes,
     ) -> int:
 
-        enr_batches = partition_enrs(
-            enrs, max_payload_size=FOUND_NODES_MAX_PAYLOAD_SIZE
-        )
+        enr_batches = partition_enrs(enrs, max_payload_size=MAX_PAYLOAD_SIZE,)
         num_batches = len(enr_batches)
         for batch in enr_batches:
             message = FoundNodesMessage(FoundNodesPayload.from_enrs(num_batches, batch))

--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -1,5 +1,7 @@
 from typing import Tuple
 
+from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
+
 ALEXANDRIA_PROTOCOL_ID = b"alexandria"
 
 DEFAULT_BOOTNODES: Tuple[str, ...] = ()
@@ -10,3 +12,14 @@ GB = 1024 * 1024 * 1024  # 2**30
 
 # All of the powers of two
 POWERS_OF_TWO = tuple(2 ** n for n in range(256))
+
+# Safe upper bound for the raw payload of an alexandria packet.  We expect the following overhead:
+#
+# - 23 bytes for the packet header
+# - up-to 34 bytes of packet overhead.
+# - up-to 4 bytes for request_id
+# - 10 bytes for the `protocol_id`
+# - 1 byte for the alexandria message type
+# - up-to 10 bytes for RLP encoding overhead.
+#
+MAX_PAYLOAD_SIZE = DISCOVERY_MAX_PACKET_SIZE - 90


### PR DESCRIPTION
## What was wrong?

We should make sure we every byte we can in our UDP packets.

## How was it fixed?

A more precise calculation of the upper bound we can expect for packets.

#### Cute Animal Picture

![Insta-Barney-mixedbreed-TheBilionaire-scasserly1](https://user-images.githubusercontent.com/824194/98560641-3586cc80-2265-11eb-962d-bb560629eb35.png)

