### PR TITLE
Raise custom exception when fields missing from ENR

### DIFF
--- a/ddht/endpoint.py
+++ b/ddht/endpoint.py
@@ -4,7 +4,7 @@ from typing import NamedTuple
 from eth_enr import ENRAPI
 from eth_enr.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
 
-from ddht.exceptions import MissingEndpoint
+from ddht.exceptions import MissingEndpointFields
 
 
 class Endpoint(NamedTuple):
@@ -19,7 +19,7 @@ class Endpoint(NamedTuple):
         try:
             ip_address = enr[IP_V4_ADDRESS_ENR_KEY]
             port = enr[UDP_PORT_ENR_KEY]
-        except KeyError:
-            raise MissingEndpoint("Missing endpoint address information: ")
+        except KeyError as err:
+            raise MissingEndpointFields(f"Missing endpoint address information: {err}")
 
         return Endpoint(ip_address, port)

--- a/ddht/exceptions.py
+++ b/ddht/exceptions.py
@@ -62,10 +62,10 @@ class EmptyFindNodesResponse(BaseDDHTError):
     pass
 
 
-class MissingEndpoint(BaseDDHTError):
+class MissingEndpointFields(BaseDDHTError):
     """
-    Raised when trying to extract an ``ddht.endpoint.Endpoint`` from an ENR
-    record that is missing the necessary fields
+    Raised when trying to extract and `Endpoint` from an ENR record when the
+    ENR record is missing the necessary fields
     """
 
     pass


### PR DESCRIPTION
## What was wrong?

Wanted a more precise name for this exception class

## How was it fixed?

Renamed it

#### Cute Animal Picture

![dog-riders-pet-costumes-3](https://user-images.githubusercontent.com/824194/98561389-15a3d880-2266-11eb-9f8b-549f1c555f94.jpg)

