### PR TITLE
Add ResourceQueue

### DIFF
--- a/ddht/v5_1/alexandria/resource_queue.py
+++ b/ddht/v5_1/alexandria/resource_queue.py
@@ -1,0 +1,56 @@
+from typing import Any, AsyncIterator, Collection, Container, Hashable, Set, TypeVar
+
+from async_generator import asynccontextmanager
+import trio
+
+TResource = TypeVar("TResource", bound=Hashable)
+
+
+class RemoveResource(Exception):
+    pass
+
+
+class ResourceQueue(Container[TResource]):
+    resources: Set[TResource]
+
+    def __init__(
+        self, resources: Collection[TResource], max_resource_count: int = 256
+    ) -> None:
+        if len(resources) > max_resource_count:
+            raise ValueError(
+                f"Number of resources exceeds maximum: {len(resources)} > {max_resource_count}"
+            )
+        self.resources = set(resources)
+        self._max_resource_count = max_resource_count
+        self._send, self._receive = trio.open_memory_channel[TResource](
+            max_resource_count
+        )
+        for resource in resources:
+            self._send.send_nowait(resource)
+
+    async def add(self, resource: TResource) -> None:
+        if resource in self:
+            raise ValueError("Resource already tracked")
+        self.resources.add(resource)
+        await self._send.send(resource)
+
+    def __contains__(self, value: Any) -> bool:
+        return value in self.resources
+
+    def remove(self, resource: TResource) -> None:
+        self.resources.remove(resource)
+
+    @asynccontextmanager
+    async def reserve(self) -> AsyncIterator[TResource]:
+        while True:
+            resource = await self._receive.receive()
+            if resource in self:
+                break
+            else:
+                continue
+
+        try:
+            yield resource
+        finally:
+            if resource in self:
+                await self._send.send(resource)

--- a/tests/core/v5_1/alexandria/test_resource_queue.py
+++ b/tests/core/v5_1/alexandria/test_resource_queue.py
@@ -1,0 +1,77 @@
+import random
+
+import pytest
+import trio
+
+from ddht.v5_1.alexandria.resource_queue import ResourceQueue
+
+
+async def _yield(num: int = 10, base: int = 0):
+    for _ in range(random.randint(0, num) + base):
+        await trio.lowlevel.checkpoint()
+
+
+@pytest.mark.trio
+async def test_resource_queue():
+    known_resources = {"a", "b", "c", "d"}
+    queue = ResourceQueue(known_resources)
+
+    resources_in_use = set()
+    seen_resources = set()
+
+    async def worker(seen):
+        """
+        Worker process intended to try and hit as many edge cases as possible
+        about what could happen within the context block of
+        `ResourceQueue.reserve` by yielding to trio at as many stages as
+        possible.
+        """
+        while True:
+            async with queue.reserve() as resource:
+                seen.add(resource)
+                assert resource in queue
+
+                await _yield()
+
+                assert resource not in resources_in_use
+                resources_in_use.add(resource)
+
+                await _yield()
+
+                resources_in_use.remove(resource)
+
+                await _yield()
+
+                assert resource not in resources_in_use
+
+    async with trio.open_nursery() as nursery:
+        for _ in range(10):
+            nursery.start_soon(worker, seen_resources)
+
+        await _yield(1, 200)
+
+        assert seen_resources == queue.resources
+
+        assert "e" not in queue
+        assert "f" not in queue
+
+        # Now add two more resources.  They should get picked up by the new
+        # workers.
+        await queue.add("e")
+        await queue.add("f")
+
+        assert "e" in queue
+        assert "f" in queue
+
+        await _yield(1, 200)
+
+        seen_resources_after_add = set()
+
+        for _ in range(10):
+            nursery.start_soon(worker, seen_resources_after_add)
+
+        await _yield(1, 200)
+
+        assert seen_resources_after_add == queue.resources
+
+        nursery.cancel_scope.cancel()


### PR DESCRIPTION
## What was wrong?

When retrieving content from the Alexandria network, we'll have the following two sets of things that need special handling.

- A list of nodes that have the content.
- A list of "chunks" that we still need.

For both of these we need a way to manage ensuring that we aren't hitting the same node with multiple requests for content as well as making sure we aren't requesting the same chunk from multiple peers.

## How was it fixed?

This implements a convenience layer over what *could* be done more verbosely with raw trio Channels.

```python
# with raw channels
resources = (...,)
send, receive = trio.open_memory_channel(...)
for resource in resources:
    send.send_nowait(resource)

def worker(...):
    resource = await receive.receive()
    try:
        ...  # do something with it
    except:
        await send.send(resource)  # put it back in the queue if there's an error
    else:
        if not done_with_resource:
            await send.send(resource)

# With the Resource Queue
resources = (...,)
queue = ResourceQueue(resources)

def worker(...):
    async with queue.reserve() as resource:
        ...  # do something with it
        if done_with_resource:
            queue.remove(resource)
```

This pattern cleans the code up a lot, especially in the case where we have two sets of resources that are being concurrently managed.

#### Cute Animal Picture

![20-Absolutely-Amazing-Dog-Halloween-Costumes-1](https://user-images.githubusercontent.com/824194/98580328-07ad8200-227d-11eb-94af-88c23ff4d112.jpg)

