### PR TITLE
Add discv5_sendPing json rpc endpoint

### DIFF
--- a/ddht/tools/web3.py
+++ b/ddht/tools/web3.py
@@ -89,7 +89,7 @@ class PongPayload(NamedTuple):
 
 
 class SendPingPayload(NamedTuple):
-    request_id: int
+    request_id: HexStr
 
     @classmethod
     def from_rpc_response(cls, response: SendPingResponse) -> "SendPingPayload":

--- a/ddht/v5_1/rpc_handlers.py
+++ b/ddht/v5_1/rpc_handlers.py
@@ -6,12 +6,12 @@ from eth_enr import ENR
 from eth_typing import HexStr, NodeID
 from eth_utils import (
     decode_hex,
+    encode_hex,
     is_hex,
     is_integer,
     is_list_like,
     remove_0x_prefix,
     to_dict,
-    to_int,
 )
 
 from ddht.abc import RPCHandlerAPI
@@ -27,7 +27,7 @@ class PongResponse(TypedDict):
 
 
 class SendPingResponse(TypedDict):
-    request_id: int
+    request_id: HexStr
 
 
 def extract_params(request: RPCRequest) -> List[Any]:
@@ -158,7 +158,7 @@ class SendPingHandler(RPCHandler[Tuple[NodeID, Optional[Endpoint]], SendPingResp
             enr = await self._network.lookup_enr(node_id)
             endpoint = Endpoint.from_enr(enr)
         request_id = await self._network.client.send_ping(node_id, endpoint)
-        return SendPingResponse(request_id=to_int(request_id))
+        return SendPingResponse(request_id=encode_hex(request_id))
 
 
 def _is_valid_distance(value: Any) -> bool:

--- a/ddht/v5_1/rpc_handlers.py
+++ b/ddht/v5_1/rpc_handlers.py
@@ -11,6 +11,7 @@ from eth_utils import (
     is_list_like,
     remove_0x_prefix,
     to_dict,
+    to_int,
 )
 
 from ddht.abc import RPCHandlerAPI
@@ -23,6 +24,10 @@ class PongResponse(TypedDict):
     enr_seq: int
     packet_ip: str
     packet_port: int
+
+
+class SendPingResponse(TypedDict):
+    request_id: int
 
 
 def extract_params(request: RPCRequest) -> List[Any]:
@@ -134,6 +139,28 @@ class PingHandler(RPCHandler[Tuple[NodeID, Optional[Endpoint]], PongResponse]):
         )
 
 
+class SendPingHandler(RPCHandler[Tuple[NodeID, Optional[Endpoint]], SendPingResponse]):
+    def __init__(self, network: NetworkAPI) -> None:
+        self._network = network
+
+    def extract_params(self, request: RPCRequest) -> Tuple[NodeID, Optional[Endpoint]]:
+        raw_params = extract_params(request)
+        validate_params_length(raw_params, 1)
+        raw_destination = raw_params[0]
+        node_id, endpoint = validate_and_extract_destination(raw_destination)
+        return node_id, endpoint
+
+    async def do_call(
+        self, params: Tuple[NodeID, Optional[Endpoint]]
+    ) -> SendPingResponse:
+        node_id, endpoint = params
+        if endpoint is None:
+            enr = await self._network.lookup_enr(node_id)
+            endpoint = Endpoint.from_enr(enr)
+        request_id = await self._network.client.send_ping(node_id, endpoint)
+        return SendPingResponse(request_id=to_int(request_id))
+
+
 def _is_valid_distance(value: Any) -> bool:
     return is_integer(value) and 0 <= value <= 256
 
@@ -187,3 +214,4 @@ class FindNodesHandler(RPCHandler[FindNodesRPCParams, Tuple[str, ...]]):
 def get_v51_rpc_handlers(network: NetworkAPI) -> Iterable[Tuple[str, RPCHandlerAPI]]:
     yield ("discv5_ping", PingHandler(network))
     yield ("discv5_findNodes", FindNodesHandler(network))
+    yield ("discv5_sendPing", SendPingHandler(network))

--- a/newsfragments/173.feature.rst
+++ b/newsfragments/173.feature.rst
@@ -1,0 +1,1 @@
+Add support for discv5_sendPing json rpc endpoint.

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -114,7 +114,7 @@ async def test_v51_rpc_ping(make_request, bob_node_id_param, alice, bob):
 
 
 @pytest.mark.trio
-async def test_v51_rpc_ping_invalid_node_id(make_request, invalid_node_id, alice, bob):
+async def test_v51_rpc_ping_invalid_node_id(make_request, invalid_node_id):
     with pytest.raises(Exception, match="'error':"):
         await make_request("discv5_ping", [invalid_node_id])
     with pytest.raises(Exception, match="'error':"):
@@ -127,6 +127,28 @@ async def test_v51_rpc_ping_web3(make_request, bob_node_id_param_w3, alice, bob,
     assert pong.enr_seq == bob.enr.sequence_number
     assert pong.packet_ip == ipaddress.ip_address(alice.endpoint.ip_address)
     assert pong.packet_port == alice.endpoint.port
+
+
+@pytest.mark.trio
+async def test_v51_rpc_send_ping(make_request, bob_node_id_param):
+    response = await make_request("discv5_sendPing", [bob_node_id_param])
+    assert response["request_id"] > 0
+
+
+@pytest.mark.trio
+async def test_v51_rpc_send_ping_invalid_node_id(make_request, invalid_node_id):
+    with pytest.raises(Exception, match="'error':"):
+        await make_request("discv5_sendPing", [invalid_node_id])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request("discv5_sendPing", [])
+
+
+@pytest.mark.trio
+async def test_v51_rpc_send_ping_web3(
+    make_request, bob_node_id_param_w3, alice, bob, w3
+):
+    response = await trio.to_thread.run_sync(w3.discv5.send_ping, bob_node_id_param_w3)
+    assert response.request_id > 0
 
 
 @pytest.mark.trio


### PR DESCRIPTION
## What was wrong?
Support the `discv5_sendPing` jsonrpc endpoint.

## How was it fixed?
Add a jsonrpc endpoint for `discv5_sendPing` that will send a ping to the given node id, but won't wait for a pong in response like `discv5_ping` and will simply return the request id.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/98658049-e020ed00-2342-11eb-8854-423d2d4ec541.png)
