### PR TITLE
Move RPC handler validation utilities to validation module

### DIFF
--- a/ddht/v5_1/rpc_handlers.py
+++ b/ddht/v5_1/rpc_handlers.py
@@ -1,23 +1,18 @@
-import ipaddress
 from socket import inet_ntoa
 from typing import Any, Iterable, List, Optional, Tuple, TypedDict
 
-from eth_enr import ENR
 from eth_typing import HexStr, NodeID
-from eth_utils import (
-    decode_hex,
-    encode_hex,
-    is_hex,
-    is_integer,
-    is_list_like,
-    remove_0x_prefix,
-    to_dict,
-)
+from eth_utils import encode_hex, is_list_like, to_dict
 
 from ddht.abc import RPCHandlerAPI
 from ddht.endpoint import Endpoint
 from ddht.rpc import RPCError, RPCHandler, RPCRequest
 from ddht.v5_1.abc import NetworkAPI
+from ddht.validation import (
+    validate_and_extract_destination,
+    validate_and_normalize_distances,
+    validate_params_length,
+)
 
 
 class PongResponse(TypedDict):
@@ -42,76 +37,6 @@ def extract_params(request: RPCRequest) -> List[Any]:
         )
 
     return params
-
-
-def validate_params_length(params: List[Any], length: int) -> None:
-    if len(params) != length:
-        raise RPCError(
-            f"Endpoint expects {length} params: length={len(params)} "
-            f"params={params}"
-        )
-
-
-def is_hex_node_id(value: Any) -> bool:
-    return (
-        isinstance(value, str)
-        and is_hex(value)
-        and len(remove_0x_prefix(HexStr(value))) == 64
-    )
-
-
-def validate_hex_node_id(value: Any) -> None:
-    if not is_hex_node_id(value):
-        raise RPCError(f"Invalid NodeID: {value}")
-
-
-def is_endpoint(value: Any) -> bool:
-    if not isinstance(value, str):
-        return False
-    ip_address, _, port = value.rpartition(":")
-    try:
-        ipaddress.ip_address(ip_address)
-    except ValueError:
-        return False
-
-    if not port.isdigit():
-        return False
-
-    return True
-
-
-def validate_endpoint(value: Any) -> None:
-    if not is_endpoint(value):
-        raise RPCError(f"Invalid Endpoint: {value}")
-
-
-def validate_and_extract_destination(value: Any) -> Tuple[NodeID, Optional[Endpoint]]:
-    node_id: NodeID
-    endpoint: Optional[Endpoint]
-
-    if is_hex_node_id(value):
-        node_id = NodeID(decode_hex(value))
-        endpoint = None
-    elif value.startswith("enode://"):
-        raw_node_id, _, raw_endpoint = value[8:].partition("@")
-
-        validate_hex_node_id(raw_node_id)
-        validate_endpoint(raw_endpoint)
-
-        node_id = NodeID(decode_hex(raw_node_id))
-
-        raw_ip_address, _, raw_port = raw_endpoint.partition(":")
-        ip_address = ipaddress.ip_address(raw_ip_address)
-        port = int(raw_port)
-        endpoint = Endpoint(ip_address.packed, port)
-    elif value.startswith("enr:"):
-        enr = ENR.from_repr(value)
-        node_id = enr.node_id
-        endpoint = Endpoint.from_enr(enr)
-    else:
-        raise RPCError(f"Unrecognized node identifier: {value}")
-
-    return node_id, endpoint
 
 
 class PingHandler(RPCHandler[Tuple[NodeID, Optional[Endpoint]], PongResponse]):
@@ -159,26 +84,6 @@ class SendPingHandler(RPCHandler[Tuple[NodeID, Optional[Endpoint]], SendPingResp
             endpoint = Endpoint.from_enr(enr)
         request_id = await self._network.client.send_ping(node_id, endpoint)
         return SendPingResponse(request_id=encode_hex(request_id))
-
-
-def _is_valid_distance(value: Any) -> bool:
-    return is_integer(value) and 0 <= value <= 256
-
-
-def validate_and_normalize_distances(value: Any) -> Tuple[int, ...]:
-    if _is_valid_distance(value):
-        return (value,)
-    elif (
-        is_list_like(value)
-        and value
-        and all(_is_valid_distance(element) for element in value)
-    ):
-        return tuple(value)
-    else:
-        raise RPCError(
-            f"Distances must be either a single integer distance or a non-empty list of "
-            f"distances: {value}"
-        )
 
 
 FindNodesRPCParams = Tuple[NodeID, Optional[Endpoint], Tuple[int, ...]]

--- a/ddht/validation.py
+++ b/ddht/validation.py
@@ -1,6 +1,19 @@
-from typing import Any, Collection
+import ipaddress
+from typing import Any, Collection, List, Optional, Tuple
 
-from eth_utils import ValidationError
+from eth_enr import ENR
+from eth_typing import HexStr, NodeID
+from eth_utils import (
+    ValidationError,
+    decode_hex,
+    is_hex,
+    is_integer,
+    is_list_like,
+    remove_0x_prefix,
+)
+
+from ddht.endpoint import Endpoint
+from ddht.rpc import RPCError
 
 
 def validate_length(value: Collection[Any], length: int, title: str = "Value") -> None:
@@ -22,3 +35,93 @@ def validate_length_lte(
                 maximum_length, value, len(value), title=title,
             )
         )
+
+
+def validate_params_length(params: List[Any], length: int) -> None:
+    if len(params) != length:
+        raise RPCError(
+            f"Endpoint expects {length} params: length={len(params)} "
+            f"params={params}"
+        )
+
+
+def is_hex_node_id(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and is_hex(value)
+        and len(remove_0x_prefix(HexStr(value))) == 64
+    )
+
+
+def validate_hex_node_id(value: Any) -> None:
+    if not is_hex_node_id(value):
+        raise RPCError(f"Invalid NodeID: {value}")
+
+
+def is_endpoint(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    ip_address, _, port = value.rpartition(":")
+    try:
+        ipaddress.ip_address(ip_address)
+    except ValueError:
+        return False
+
+    if not port.isdigit():
+        return False
+
+    return True
+
+
+def validate_endpoint(value: Any) -> None:
+    if not is_endpoint(value):
+        raise RPCError(f"Invalid Endpoint: {value}")
+
+
+def _is_valid_distance(value: Any) -> bool:
+    return is_integer(value) and 0 <= value <= 256
+
+
+def validate_and_normalize_distances(value: Any) -> Tuple[int, ...]:
+    if _is_valid_distance(value):
+        return (value,)
+    elif (
+        is_list_like(value)
+        and value
+        and all(_is_valid_distance(element) for element in value)
+    ):
+        return tuple(value)
+    else:
+        raise RPCError(
+            f"Distances must be either a single integer distance or a non-empty list of "
+            f"distances: {value}"
+        )
+
+
+def validate_and_extract_destination(value: Any) -> Tuple[NodeID, Optional[Endpoint]]:
+    node_id: NodeID
+    endpoint: Optional[Endpoint]
+
+    if is_hex_node_id(value):
+        node_id = NodeID(decode_hex(value))
+        endpoint = None
+    elif value.startswith("enode://"):
+        raw_node_id, _, raw_endpoint = value[8:].partition("@")
+
+        validate_hex_node_id(raw_node_id)
+        validate_endpoint(raw_endpoint)
+
+        node_id = NodeID(decode_hex(raw_node_id))
+
+        raw_ip_address, _, raw_port = raw_endpoint.partition(":")
+        ip_address = ipaddress.ip_address(raw_ip_address)
+        port = int(raw_port)
+        endpoint = Endpoint(ip_address.packed, port)
+    elif value.startswith("enr:"):
+        enr = ENR.from_repr(value)
+        node_id = enr.node_id
+        endpoint = Endpoint.from_enr(enr)
+    else:
+        raise RPCError(f"Unrecognized node identifier: {value}")
+
+    return node_id, endpoint

--- a/newsfragments/174.misc.rst
+++ b/newsfragments/174.misc.rst
@@ -1,0 +1,1 @@
+Relocate rpc handler validation utils to validation module.


### PR DESCRIPTION
## What was wrong?
`ddht.v5_1.rpc_handlers` contains some validation utilities and as more rpc handlers are added, the file will probably become more and more clunky. 

## How was it fixed?
I moved the validation utils to the validation module.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/98812947-b7bcef80-2423-11eb-9812-45377968296e.png)

