### PR TITLE
Add support for discv5_sendPong jsonrpc endpoint

### DIFF
--- a/newsfragments/177.feature.rst
+++ b/newsfragments/177.feature.rst
@@ -1,0 +1,1 @@
+Add support for discv5_sendPong json rpc endpoint.


### PR DESCRIPTION
## What was wrong?
Added support for `discv5_sendPong` json rpc endpoint

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/99049675-6a618f00-2597-11eb-8250-d9e963951e0d.png)

