### PR TITLE
Missing tests for FindNodes and FoundNodes alexandria messages

### DIFF
--- a/ddht/v5_1/alexandria/messages.py
+++ b/ddht/v5_1/alexandria/messages.py
@@ -120,6 +120,17 @@ class FoundNodesMessage(AlexandriaMessage[FoundNodesPayload]):
 
     payload: FoundNodesPayload
 
+    @classmethod
+    def from_payload_args(
+        cls: Type[TAlexandriaMessage], payload_args: Any
+    ) -> TAlexandriaMessage:
+        # py-ssz uses an internal type for decoded `ssz.sedes.List` types that
+        # we don't need or want so we force it to a normal tuple type here.
+        total, ssz_wrapped_enrs = payload_args
+        enrs = tuple(ssz_wrapped_enrs)
+        payload = cls.payload_type(total, enrs)
+        return cls(payload)
+
 
 @register
 class GetContentMessage(AlexandriaMessage[GetContentPayload]):

--- a/tests/core/v5_1/alexandria/test_message_encoding.py
+++ b/tests/core/v5_1/alexandria/test_message_encoding.py
@@ -1,8 +1,21 @@
+from eth_enr.tools.factories import ENRFactory
 from hypothesis import given
 from hypothesis import strategies as st
+import rlp
 
-from ddht.v5_1.alexandria.messages import PingMessage, PongMessage, decode_message
-from ddht.v5_1.alexandria.payloads import PingPayload, PongPayload
+from ddht.v5_1.alexandria.messages import (
+    FindNodesMessage,
+    FoundNodesMessage,
+    PingMessage,
+    PongMessage,
+    decode_message,
+)
+from ddht.v5_1.alexandria.payloads import (
+    FindNodesPayload,
+    FoundNodesPayload,
+    PingPayload,
+    PongPayload,
+)
 
 
 @given(enr_seq=st.integers(min_value=0, max_value=2 ** 32 - 1))
@@ -21,3 +34,27 @@ def test_pong_message_encoding_round_trip(enr_seq):
     encoded = message.to_wire_bytes()
     result = decode_message(encoded)
     assert result == message
+
+
+@given(
+    distances=st.lists(
+        st.integers(min_value=0, max_value=256), min_size=1, max_size=32, unique=True,
+    ).map(tuple)
+)
+def test_find_nodes_message_encoding_round_trip(distances):
+    payload = FindNodesPayload(distances)
+    message = FindNodesMessage(payload)
+    encoded = message.to_wire_bytes()
+    result = decode_message(encoded)
+    assert result == message
+
+
+@given(num_enr_records=st.integers(min_value=0, max_value=5))
+def test_found_nodes_message_encoding_round_trip(num_enr_records):
+    enrs = tuple(ENRFactory() for _ in range(num_enr_records))
+    encoded_enrs = tuple(rlp.encode(enr) for enr in enrs)
+    payload = FoundNodesPayload(num_enr_records, encoded_enrs)
+    message = FoundNodesMessage(payload)
+    encoded = message.to_wire_bytes()
+    result = decode_message(encoded)
+    assert result.payload == message.payload


### PR DESCRIPTION
## What was wrong?

Missing encoding/decoding tests for FIND/FOUND nodes messages.

## How was it fixed?

Added tests.

#### Cute Animal Picture

![red_panda_5](https://user-images.githubusercontent.com/824194/99114916-d7ccea00-25ae-11eb-9eee-c0e6240ef733.JPG)
