### PR TITLE
Add support for discv5_updateNodeInfo endpoint

### DIFF
--- a/ddht/rpc_handlers.py
+++ b/ddht/rpc_handlers.py
@@ -1,11 +1,14 @@
-from typing import Iterator, Mapping, Tuple, TypedDict
+from typing import Any, Iterable, Iterator, Mapping, Optional, Tuple, TypedDict, Union
 
 from eth_enr import ENRAPI
+from eth_enr.abc import ENRManagerAPI
+from eth_enr.typing import ENR_KV
 from eth_typing import HexStr
-from eth_utils import encode_hex, to_dict
+from eth_utils import encode_hex, is_integer, is_text, to_bytes, to_dict, to_tuple
 
 from ddht.abc import RoutingTableAPI, RPCHandlerAPI, RPCRequest
 from ddht.rpc import RPCError, RPCHandler
+from ddht.v5_1.rpc_handlers import extract_params
 
 
 class BucketInfo(TypedDict):
@@ -84,9 +87,59 @@ class NodeInfoHandler(RPCHandler[None, NodeInfoResponse]):
         )
 
 
+@to_tuple
+def normalize_and_validate_kv_pairs(
+    params: Any,
+) -> Iterable[Tuple[bytes, Optional[bytes]]]:
+    if not params:
+        raise RPCError("Missing parameters.")
+
+    for kv_pair in params:
+        if len(kv_pair) != 2:
+            raise RPCError(f"Invalid kv_pair length: {len(kv_pair)}.")
+
+        if not is_text(kv_pair[0]):
+            raise RPCError(
+                f"Key: {kv_pair[0]} is type: {type(kv_pair[0])}. Keys be text."
+            )
+        key = to_bytes(text=kv_pair[0])
+
+        value: Union[bytes, None]
+        if is_text(kv_pair[1]):
+            value = to_bytes(text=kv_pair[1])
+        elif is_integer(kv_pair[1]):
+            value = to_bytes(kv_pair[1])
+        elif kv_pair[1] is None:
+            value = None
+        else:
+            raise RPCError(
+                f"Value: {kv_pair[1]} is type: {type(kv_pair[1])}. "
+                "Values must be text, integer, or None."
+            )
+
+        yield key, value
+
+
+class UpdateNodeInfoHandler(RPCHandler[Tuple[ENR_KV, ...], None]):
+    _node_id_hex: HexStr
+
+    def __init__(self, enr_manager: ENRManagerAPI) -> None:
+        self._enr_manager = enr_manager
+
+    def extract_params(self, request: RPCRequest) -> Tuple[ENR_KV, ...]:
+        raw_params = extract_params(request)
+        kv_pairs = normalize_and_validate_kv_pairs(raw_params)
+        return kv_pairs
+
+    async def do_call(self, params: Tuple[ENR_KV, ...]) -> None:
+        self._enr_manager.update(*params)
+        return None
+
+
 @to_dict
 def get_core_rpc_handlers(
-    enr: ENRAPI, routing_table: RoutingTableAPI
+    enr_manager: ENRManagerAPI, routing_table: RoutingTableAPI
 ) -> Iterator[Tuple[str, RPCHandlerAPI]]:
     yield ("discv5_routingTableInfo", RoutingTableInfoHandler(routing_table))
-    yield ("discv5_nodeInfo", NodeInfoHandler(enr))
+    yield ("discv5_nodeInfo", NodeInfoHandler(enr_manager.enr))
+    yield ("discv5_updateNodeInfo", UpdateNodeInfoHandler(enr_manager))

--- a/ddht/tools/web3.py
+++ b/ddht/tools/web3.py
@@ -20,6 +20,7 @@ except ImportError:
 
 
 from eth_enr import ENR, ENRAPI
+from eth_enr.typing import ENR_KV
 from eth_typing import HexStr, NodeID
 from eth_utils import decode_hex
 from web3.method import Method
@@ -126,6 +127,7 @@ class EmptyPayload(NamedTuple):
 
 class RPC:
     nodeInfo = RPCEndpoint("discv5_nodeInfo")
+    updateNodeInfo = RPCEndpoint("discv5_updateNodeInfo")
     routingTableInfo = RPCEndpoint("discv5_routingTableInfo")
     getENR = RPCEndpoint("discv5_getENR")
     setENR = RPCEndpoint("discv5_setENR")
@@ -171,10 +173,21 @@ def normalize_node_id_identifier(identifier: NodeIDIdentifier) -> str:
         raise ValueError(f"Unrecognized node identifier: {identifier}")
 
 
+#
+# Mungers
+# See: https://github.com/ethereum/web3.py/blob/002151020cecd826a694ded2fdc10cc70e73e636/web3/method.py#L77  # noqa: E501
+#
+
+
+def kv_pair_munger(module: Any, *kv_pairs: ENR_KV) -> Tuple[ENR_KV, ...]:
+    """
+    Normalizes the inputs for `discv5_updateNodeInfo` JSON-RPC endpoints:
+    """
+    return kv_pairs
+
+
 def node_identifier_munger(module: Any, identifier: NodeIDIdentifier,) -> List[str]:
     """
-    See: https://github.com/ethereum/web3.py/blob/002151020cecd826a694ded2fdc10cc70e73e636/web3/method.py#L77  # noqa: E501
-
     Normalizes the inputs for the following JSON-RPC endpoints:
     - `discv5_ping`
     - `discv5_getENR`
@@ -189,8 +202,6 @@ def send_pong_munger(
     module: Any, identifier: NodeIDIdentifier, request_id: HexStr
 ) -> Tuple[str, HexStr]:
     """
-    See: https://github.com/ethereum/web3.py/blob/002151020cecd826a694ded2fdc10cc70e73e636/web3/method.py#L77  # noqa: E501
-
     Normalizes the inputs for the `discv5_sendPong` JSON-RPC endpoints
     """
     return (
@@ -205,8 +216,6 @@ def find_nodes_munger(
     distance_or_distances: Union[int, Sequence[int]],
 ) -> Tuple[str, Union[int, Sequence[int]]]:
     """
-    See: https://github.com/ethereum/web3.py/blob/002151020cecd826a694ded2fdc10cc70e73e636/web3/method.py#L77  # noqa: E501
-
     Normalizes the inputs for the `discv5_findNodes` JSON-RPC endpoint
     """
     return (
@@ -228,6 +237,11 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
 
     get_node_info: Method[Callable[[], NodeInfo]] = Method(
         RPC.nodeInfo, result_formatters=lambda method: NodeInfo.from_rpc_response,
+    )
+    update_node_info: Method[Callable[[], NodeInfo]] = Method(
+        RPC.updateNodeInfo,
+        result_formatters=lambda method: EmptyPayload.from_rpc_response,
+        mungers=[kv_pair_munger],
     )
     get_routing_table_info: Method[Callable[[], TableInfo]] = Method(
         RPC.routingTableInfo,

--- a/ddht/tools/web3.py
+++ b/ddht/tools/web3.py
@@ -115,6 +115,14 @@ class GetENRPayload(NamedTuple):
         return cls(enr=ENR.from_repr(response["enr_repr"]))
 
 
+class UpdateENRPayload(NamedTuple):
+    enr: ENRAPI
+
+    @classmethod
+    def from_rpc_response(cls, response: NodeInfoResponse) -> "UpdateENRPayload":
+        return cls(enr=ENR.from_repr(response["enr"]))
+
+
 class EmptyResponse(TypedDict):
     pass
 
@@ -240,7 +248,7 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
     )
     update_node_info: Method[Callable[[], NodeInfo]] = Method(
         RPC.updateNodeInfo,
-        result_formatters=lambda method: EmptyPayload.from_rpc_response,
+        result_formatters=lambda method: UpdateENRPayload.from_rpc_response,
         mungers=[kv_pair_munger],
     )
     get_routing_table_info: Method[Callable[[], TableInfo]] = Method(

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -110,7 +110,7 @@ class Application(BaseApplication):
 
         if self._boot_info.is_rpc_enabled:
             handlers = merge(
-                get_core_rpc_handlers(enr_manager.enr, self.network.routing_table),
+                get_core_rpc_handlers(enr_manager, self.network.routing_table),
                 get_v51_rpc_handlers(self.network),
             )
             rpc_server = RPCServer(self._boot_info.ipc_path, handlers)

--- a/newsfragments/182.feature.rst
+++ b/newsfragments/182.feature.rst
@@ -1,0 +1,1 @@
+Add support for discv5_updateNodeInfo json rpc endpoint.


### PR DESCRIPTION
## What was wrong?
Add jsonrpc support for `discv5_updateNodeInfo`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/99384935-7a97a800-28d0-11eb-8314-332cd24d6907.png)

