### PR TITLE
Add support for discv5_lookupENR jsonrpc endpoint

### DIFF
--- a/ddht/tools/web3.py
+++ b/ddht/tools/web3.py
@@ -28,7 +28,6 @@ from web3.method import Method
 from web3.module import ModuleV2
 from web3.types import RPCEndpoint
 
-from ddht.endpoint import Endpoint
 from ddht.rpc_handlers import BucketInfo as BucketInfoDict
 from ddht.rpc_handlers import NodeInfoResponse, TableInfoResponse
 from ddht.typing import AnyIPAddress
@@ -209,18 +208,16 @@ def node_identifier_munger(module: Any, identifier: NodeIDIdentifier,) -> List[s
     return [normalize_node_id_identifier(identifier)]
 
 
-def node_identifier_and_endpoint_munger(
-    module: Any, identifier: NodeIDIdentifier, endpoint: Optional[Endpoint] = None
-) -> Tuple[str, Optional[Endpoint]]:
+def node_identifier_and_sequence_munger(
+    module: Any, identifier: NodeIDIdentifier, sequence_number: Optional[int] = 0
+) -> Tuple[str, Optional[int]]:
     """
-    See: https://github.com/ethereum/web3.py/blob/002151020cecd826a694ded2fdc10cc70e73e636/web3/method.py#L77  # noqa: E501
-
     Normalizes the inputs for the following JSON-RPC endpoints:
     - `discv5_lookupENR`
     """
     return (
         normalize_node_id_identifier(identifier),
-        endpoint,
+        sequence_number,
     )
 
 
@@ -291,7 +288,7 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
     lookup_enr: Method[Callable[[NodeIDIdentifier], GetENRPayload]] = Method(
         RPC.lookupENR,
         result_formatters=lambda method: GetENRPayload.from_rpc_response,
-        mungers=[node_identifier_and_endpoint_munger],
+        mungers=[node_identifier_and_sequence_munger],
     )
     ping: Method[Callable[[NodeIDIdentifier], PongPayload]] = Method(
         RPC.ping,

--- a/newsfragments/183.feature.rst
+++ b/newsfragments/183.feature.rst
@@ -1,0 +1,1 @@
+Add support for discv5_lookupENR json rpc endpoint.

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -282,15 +282,17 @@ async def test_v51_rpc_lookup_enr_web3_with_sequence_number(
 
 
 @pytest.mark.trio
-async def test_v51_rpc_lookup_enr_with_unseen_node_id(make_request, new_enr):
-    with pytest.raises(Exception, match="'error':"):
-        await make_request("discv5_lookupENR", [repr(new_enr)])
+async def test_v51_rpc_lookup_enr_with_unseen_node_id(make_request, bob):
+    await make_request("discv5_deleteENR", [repr(bob.enr)])
+    with pytest.raises(Exception):
+        await make_request("discv5_lookupENR", [repr(bob.enr)])
 
 
 @pytest.mark.trio
-async def test_v51_rpc_lookup_enr_web3_unseen_node_id(make_request, new_enr, w3):
+async def test_v51_rpc_lookup_enr_web3_unseen_node_id(make_request, bob, w3):
+    await trio.to_thread.run_sync(w3.discv5.delete_enr, repr(bob.enr))
     with pytest.raises(Exception, match="Unexpected Error"):
-        await trio.to_thread.run_sync(w3.discv5.lookup_enr, repr(new_enr))
+        await trio.to_thread.run_sync(w3.discv5.lookup_enr, repr(bob.enr))
 
 
 @pytest.mark.trio

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -121,7 +121,14 @@ async def test_v51_rpc_ping(make_request, bob_node_id_param, alice, bob):
 
 
 @pytest.mark.parametrize(
-    "endpoint", ("discv5_deleteENR", "discv5_getENR", "discv5_ping", "discv5_sendPing",)
+    "endpoint",
+    (
+        "discv5_deleteENR",
+        "discv5_getENR",
+        "discv5_lookupENR",
+        "discv5_ping",
+        "discv5_sendPing",
+    ),
 )
 @pytest.mark.trio
 async def test_v51_rpc_invalid_node_id(make_request, invalid_node_id, endpoint):
@@ -134,6 +141,7 @@ async def test_v51_rpc_invalid_node_id(make_request, invalid_node_id, endpoint):
     (
         "discv5_deleteENR",
         "discv5_getENR",
+        "discv5_lookupENR",
         "discv5_ping",
         "discv5_setENR",
         "discv5_sendPing",
@@ -241,6 +249,48 @@ async def test_v51_rpc_delete_enr_web3(make_request, w3, bob, bob_node_id_param_
 
     with pytest.raises(Exception):
         await trio.to_thread.run_sync(w3.discv5.get_enr, bob_node_id_param_w3)
+
+
+@pytest.mark.trio
+async def test_v51_rpc_lookup_enr(make_request, bob, bob_node_id_param):
+    bob_response = await make_request("discv5_lookupENR", [bob_node_id_param])
+    assert bob_response["enr_repr"] == repr(bob.enr)
+
+
+@pytest.mark.trio
+async def test_v51_rpc_lookup_enr_with_sequence_number(
+    make_request, bob, bob_node_id_param
+):
+    bob_response = await make_request("discv5_lookupENR", [bob_node_id_param, 101])
+    assert bob_response["enr_repr"] == repr(bob.enr)
+
+
+@pytest.mark.trio
+async def test_v51_rpc_lookup_enr_web3(make_request, bob, bob_node_id_param_w3, w3):
+    response = await trio.to_thread.run_sync(w3.discv5.lookup_enr, bob_node_id_param_w3)
+    assert response.enr == bob.enr
+
+
+@pytest.mark.trio
+async def test_v51_rpc_lookup_enr_web3_with_sequence_number(
+    make_request, bob, bob_node_id_param_w3, w3
+):
+    response = await trio.to_thread.run_sync(
+        w3.discv5.lookup_enr, bob_node_id_param_w3, 101
+    )
+    assert response.enr == bob.enr
+
+
+@pytest.mark.trio
+async def test_v51_rpc_lookup_enr_with_unseen_node_id(make_request, new_enr):
+    with pytest.raises(Exception, match="'error':"):
+        await make_request("discv5_lookupENR", [repr(new_enr)])
+
+
+@pytest.mark.trio
+async def test_v51_rpc_lookup_enr_web3_unseen_node_id(make_request, new_enr, w3):
+    with pytest.raises(Exception, match="Unexpected Error"):
+        await trio.to_thread.run_sync(w3.discv5.lookup_enr, repr(new_enr))
 
 
 @pytest.mark.trio


### PR DESCRIPTION
## What was wrong?
Add support for `discv5_lookupENR` endpoint.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/99404438-ea675c00-28eb-11eb-8c70-41ba3f459ced.png)

