### PR TITLE
Use 'content' as variable name for proofs

### DIFF
--- a/ddht/v5_1/alexandria/partials/chunking.py
+++ b/ddht/v5_1/alexandria/partials/chunking.py
@@ -12,7 +12,7 @@ from ddht.v5_1.alexandria.partials.typing import TreePath
 
 
 @to_tuple
-def compute_chunks(data: bytes) -> Iterable[Hash32]:
+def compute_chunks(content: bytes) -> Iterable[Hash32]:
     """
     An optimized version of SSZ chunking specifically for byte
     strings.
@@ -20,23 +20,23 @@ def compute_chunks(data: bytes) -> Iterable[Hash32]:
     Takes the data and splits it into chunks of length 32.  The last chunk is
     padded out to 32 bytes with null bytes `0x00` if it is not full.
     """
-    if not data:
+    if not content:
         yield ZERO_BYTES32
         return
-    elif len(data) > GB:
+    elif len(content) > GB:
         raise Exception("too big")
-    data_length = len(data)
-    if data_length % CHUNK_SIZE == 0:
-        padded_data = data
+    content_length = len(content)
+    if content_length % CHUNK_SIZE == 0:
+        padded_content = content
     else:
-        padding_byte_count = CHUNK_SIZE - data_length % CHUNK_SIZE
-        padded_data = data + b"\x00" * padding_byte_count
+        padding_byte_count = CHUNK_SIZE - content_length % CHUNK_SIZE
+        padded_content = content + b"\x00" * padding_byte_count
 
-    padded_length = len(padded_data)
+    padded_length = len(padded_content)
     for left_boundary, right_boundary in sliding_window(
         2, range(0, padded_length + 1, CHUNK_SIZE)
     ):
-        yield Hash32(padded_data[left_boundary:right_boundary])
+        yield Hash32(padded_content[left_boundary:right_boundary])
 
 
 @to_tuple

--- a/ddht/v5_1/alexandria/partials/proof.py
+++ b/ddht/v5_1/alexandria/partials/proof.py
@@ -939,17 +939,17 @@ def compute_proof_elements(
     yield from get_padding_elements(start_index, num_padding_chunks, path_bit_length)
 
 
-def compute_proof(data: bytes, sedes: ListSedes) -> Proof:
+def compute_proof(content: bytes, sedes: ListSedes) -> Proof:
     """
     Compute the full proof, including the mixed-in length value.
     """
-    chunks = compute_chunks(data)
+    chunks = compute_chunks(content)
 
     chunk_count = sedes.chunk_count
 
     proof_elements = compute_proof_elements(chunks, chunk_count)
     length_element = ProofElement(
-        path=(True,), value=Hash32(len(data).to_bytes(CHUNK_SIZE, "little")),
+        path=(True,), value=Hash32(len(content).to_bytes(CHUNK_SIZE, "little")),
     )
     all_elements = proof_elements + (length_element,)
 

--- a/tests/core/v5_1/alexandria/test_partial_proofs.py
+++ b/tests/core/v5_1/alexandria/test_partial_proofs.py
@@ -16,17 +16,17 @@ from ddht.v5_1.alexandria.sedes import ByteList, content_sedes
 
 
 @settings(max_examples=1000)
-@given(data=st.binary(min_size=0, max_size=GB))
-@example(data=b"")
-@example(data=b"\x00" * 31)
-@example(data=b"\x00" * 32)
-@example(data=b"\x00" * 33)
-@example(data=b"\x00" * 63)
-@example(data=b"\x00" * 64)
-@example(data=b"\x00" * 65)
-def test_ssz_full_proofs(data):
-    expected_hash_tree_root = get_hash_tree_root(data, sedes=content_sedes)
-    proof = compute_proof(data, sedes=content_sedes)
+@given(content=st.binary(min_size=0, max_size=GB))
+@example(content=b"")
+@example(content=b"\x00" * 31)
+@example(content=b"\x00" * 32)
+@example(content=b"\x00" * 33)
+@example(content=b"\x00" * 63)
+@example(content=b"\x00" * 64)
+@example(content=b"\x00" * 65)
+def test_ssz_full_proofs(content):
+    expected_hash_tree_root = get_hash_tree_root(content, sedes=content_sedes)
+    proof = compute_proof(content, sedes=content_sedes)
 
     validate_proof(proof)
     assert is_proof_valid(proof)
@@ -37,10 +37,10 @@ def test_ssz_full_proofs(data):
     assert len(proven_data_segments) == 1
     start_index, proven_data = proven_data_segments[0]
     assert start_index == 0
-    assert proven_data == data
+    assert proven_data == content
 
     proven_data = proof.get_proven_data()
-    assert proven_data[0 : len(data)] == data
+    assert proven_data[0 : len(content)] == content
 
 
 short_content_sedes = ByteList(max_length=32 * 16)


### PR DESCRIPTION
## What was wrong?

The code was inconsistently using either `data` or `content` to refer to the raw content of network data.

## How was it fixed?

Unified to use `content` in all places.

#### Cute Animal Picture

![01_57](https://user-images.githubusercontent.com/824194/99460236-be000f80-28ec-11eb-9e99-17cd67ee1403.jpg)

