### PR TITLE
Include advertisement_radius in Ping and Pong messages

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -17,6 +17,7 @@ from ddht.v5_1.abc import (
     SessionAPI,
 )
 from ddht.v5_1.alexandria.abc import (
+    AdvertisementDatabaseAPI,
     AlexandriaClientAPI,
     AlexandriaNetworkAPI,
     ContentStorageAPI,
@@ -28,6 +29,7 @@ from ddht.v5_1.packets import AnyPacket
 
 class AlexandriaNodeAPI(ABC):
     content_storage: ContentStorageAPI
+    advertisement_db: AdvertisementDatabaseAPI
 
     @abstractmethod
     def client(

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -285,10 +285,12 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     client: AlexandriaClientAPI
     routing_table: RoutingTableAPI
 
-    advertisement_db: AdvertisementDatabaseAPI
+    max_advertisement_count: int
 
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI
+
+    advertisement_db: AdvertisementDatabaseAPI
 
     @property
     @abstractmethod
@@ -308,6 +310,14 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     @property
     @abstractmethod
     def enr_db(self) -> QueryableENRDatabaseAPI:
+        ...
+
+    #
+    # Local properties
+    #
+    @property
+    @abstractmethod
+    def local_advertisement_radius(self) -> int:
         ...
 
     #

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -160,13 +160,20 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         endpoint: Endpoint,
         *,
         enr_seq: int,
+        advertisement_radius: int,
         request_id: Optional[bytes] = None,
     ) -> bytes:
         ...
 
     @abstractmethod
     async def send_pong(
-        self, node_id: NodeID, endpoint: Endpoint, *, enr_seq: int, request_id: bytes,
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        enr_seq: int,
+        advertisement_radius: int,
+        request_id: bytes,
     ) -> None:
         ...
 
@@ -243,7 +250,14 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     # High Level Request/Response
     #
     @abstractmethod
-    async def ping(self, node_id: NodeID, endpoint: Endpoint) -> PongMessage:
+    async def ping(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        enr_seq: int,
+        advertisement_radius: int,
+        request_id: Optional[bytes] = None,
+    ) -> PongMessage:
         ...
 
     @abstractmethod
@@ -331,7 +345,13 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
 
     @abstractmethod
     async def ping(
-        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
+        self,
+        node_id: NodeID,
+        *,
+        enr_seq: Optional[int] = None,
+        advertisement_radius: Optional[int] = None,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
     ) -> PongPayload:
         ...
 

--- a/ddht/v5_1/alexandria/app.py
+++ b/ddht/v5_1/alexandria/app.py
@@ -1,8 +1,10 @@
 import argparse
+import sqlite3
 
 from ddht.app import BaseApplication
 from ddht.boot_info import BootInfo
-from ddht.v5_1.alexandria.abc import ContentStorageAPI
+from ddht.v5_1.alexandria.abc import AdvertisementDatabaseAPI, ContentStorageAPI
+from ddht.v5_1.alexandria.advertisement_db import AdvertisementDatabase
 from ddht.v5_1.alexandria.boot_info import AlexandriaBootInfo
 from ddht.v5_1.alexandria.content_storage import MemoryContentStorage
 from ddht.v5_1.alexandria.network import AlexandriaNetwork
@@ -24,10 +26,16 @@ class AlexandriaApplication(BaseApplication):
 
         content_storage: ContentStorageAPI = MemoryContentStorage()
 
+        # Temporarily we just use an in memory database for advertisements.
+        advertisement_db: AdvertisementDatabaseAPI = AdvertisementDatabase(
+            sqlite3.connect(":memory:"),
+        )
+
         alexandria_network = AlexandriaNetwork(
             network=self.base_protocol_app.network,
             bootnodes=self._alexandria_boot_info.bootnodes,
             content_storage=content_storage,
+            advertisement_db=advertisement_db,
         )
 
         self.manager.run_daemon_child_service(alexandria_network)

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -286,17 +286,24 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         endpoint: Endpoint,
         *,
         enr_seq: int,
+        advertisement_radius: int,
         request_id: Optional[bytes] = None,
     ) -> bytes:
-        message = PingMessage(PingPayload(enr_seq))
+        message = PingMessage(PingPayload(enr_seq, advertisement_radius))
         return await self._send_request(
             node_id, endpoint, message, request_id=request_id
         )
 
     async def send_pong(
-        self, node_id: NodeID, endpoint: Endpoint, *, enr_seq: int, request_id: bytes,
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        enr_seq: int,
+        advertisement_radius: int,
+        request_id: bytes,
     ) -> None:
-        message = PongMessage(PongPayload(enr_seq))
+        message = PongMessage(PongPayload(enr_seq, advertisement_radius))
         await self._send_response(node_id, endpoint, message, request_id=request_id)
 
     async def send_find_nodes(
@@ -389,9 +396,18 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
     #
     # High Level Request/Response
     #
-    async def ping(self, node_id: NodeID, endpoint: Endpoint) -> PongMessage:
-        request = PingMessage(PingPayload(self.network.enr_manager.enr.sequence_number))
-        response = await self._request(node_id, endpoint, request, PongMessage)
+    async def ping(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        enr_seq: int,
+        advertisement_radius: int,
+        request_id: Optional[bytes] = None,
+    ) -> PongMessage:
+        request = PingMessage(PingPayload(enr_seq, advertisement_radius))
+        response = await self._request(
+            node_id, endpoint, request, PongMessage, request_id
+        )
         return response
 
     async def find_nodes(

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -171,12 +171,28 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         await self.bond(node_id, endpoint=endpoint)
 
     async def ping(
-        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
+        self,
+        node_id: NodeID,
+        *,
+        enr_seq: Optional[int] = None,
+        advertisement_radius: Optional[int] = None,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
     ) -> PongPayload:
         if endpoint is None:
             endpoint = await self.network.endpoint_for_node_id(node_id)
+        if enr_seq is None:
+            enr_seq = self.network.enr_manager.enr.sequence_number
+        if advertisement_radius is None:
+            advertisement_radius = self.local_advertisement_radius
 
-        response = await self.client.ping(node_id, endpoint=endpoint,)
+        response = await self.client.ping(
+            node_id,
+            enr_seq=enr_seq,
+            advertisement_radius=advertisement_radius,
+            endpoint=endpoint,
+            request_id=request_id,
+        )
         return response.payload
 
     async def find_nodes(
@@ -478,6 +494,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                     request.sender_node_id,
                     request.sender_endpoint,
                     enr_seq=self.enr_manager.enr.sequence_number,
+                    advertisement_radius=self.local_advertisement_radius,
                     request_id=request.request_id,
                 )
                 enr = await self.network.lookup_enr(

--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -9,10 +9,12 @@ from ddht.v5_1.alexandria.typing import ContentKey
 
 class PingPayload(NamedTuple):
     enr_seq: int
+    advertisement_radius: int
 
 
 class PongPayload(NamedTuple):
     enr_seq: int
+    advertisement_radius: int
 
 
 class FindNodesPayload(NamedTuple):

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -28,8 +28,8 @@ byte_list = ByteList(max_length=2048)
 uint40 = UInt(40)
 
 
-PingSedes = Container(field_sedes=(uint32,))
-PongSedes = Container(field_sedes=(uint32,))
+PingSedes = Container(field_sedes=(uint32, uint256))
+PongSedes = Container(field_sedes=(uint32, uint256))
 
 FindNodesSedes = Container(field_sedes=(List(uint16, max_length=256),))
 FoundNodesSedes = Container(field_sedes=(uint8, List(byte_list, max_length=32)))

--- a/tests/core/v5_1/alexandria/test_alexandria_network.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_network.py
@@ -32,10 +32,14 @@ async def test_alexandria_network_responds_to_pings(
 ):
     with trio.fail_after(2):
         pong_message = await alice_alexandria_network.client.ping(
-            bob.node_id, bob.endpoint
+            bob.node_id, bob.endpoint, enr_seq=0, advertisement_radius=1,
         )
 
     assert pong_message.payload.enr_seq == bob.enr.sequence_number
+    assert (
+        pong_message.payload.advertisement_radius
+        == bob_alexandria_network.local_advertisement_radius
+    )
 
 
 @pytest.mark.trio

--- a/tests/core/v5_1/alexandria/test_message_encoding.py
+++ b/tests/core/v5_1/alexandria/test_message_encoding.py
@@ -23,18 +23,24 @@ from ddht.v5_1.alexandria.payloads import (
 )
 
 
-@given(enr_seq=st.integers(min_value=0, max_value=2 ** 32 - 1))
-def test_ping_message_encoding_round_trip(enr_seq):
-    payload = PingPayload(enr_seq=enr_seq)
+@given(
+    enr_seq=st.integers(min_value=0, max_value=2 ** 32 - 1),
+    advertisement_radius=st.integers(min_value=0, max_value=2 ** 256 - 1),
+)
+def test_ping_message_encoding_round_trip(enr_seq, advertisement_radius):
+    payload = PingPayload(enr_seq=enr_seq, advertisement_radius=advertisement_radius)
     message = PingMessage(payload)
     encoded = message.to_wire_bytes()
     result = decode_message(encoded)
     assert result == message
 
 
-@given(enr_seq=st.integers(min_value=0, max_value=2 ** 32 - 1))
-def test_pong_message_encoding_round_trip(enr_seq):
-    payload = PongPayload(enr_seq=enr_seq)
+@given(
+    enr_seq=st.integers(min_value=0, max_value=2 ** 32 - 1),
+    advertisement_radius=st.integers(min_value=0, max_value=2 ** 256 - 1),
+)
+def test_pong_message_encoding_round_trip(enr_seq, advertisement_radius):
+    payload = PongPayload(enr_seq=enr_seq, advertisement_radius=advertisement_radius)
     message = PongMessage(payload)
     encoded = message.to_wire_bytes()
     result = decode_message(encoded)

--- a/tests/core/v5_1/alexandria/test_subscriptions.py
+++ b/tests/core/v5_1/alexandria/test_subscriptions.py
@@ -11,7 +11,10 @@ async def test_alexandria_client_subscription_via_talk_request(
 ):
     async with bob_alexandria_client.subscribe(PingMessage) as subscription:
         await alice_alexandria_client.send_ping(
-            bob.node_id, bob.endpoint, enr_seq=alice.enr.sequence_number,
+            bob.node_id,
+            bob.endpoint,
+            enr_seq=alice.enr.sequence_number,
+            advertisement_radius=1234,
         )
 
         with trio.fail_after(1):
@@ -19,6 +22,7 @@ async def test_alexandria_client_subscription_via_talk_request(
 
         assert isinstance(message.message, PingMessage)
         assert message.message.payload.enr_seq == alice.enr.sequence_number
+        assert message.message.payload.advertisement_radius == 1234
 
 
 @pytest.mark.trio
@@ -34,6 +38,7 @@ async def test_alexandria_client_subscription_via_talk_response(
                     bob.node_id,
                     bob.endpoint,
                     enr_seq=alice.enr.sequence_number,
+                    advertisement_radius=1234,
                     request_id=b"\x01\x02",
                 )
 
@@ -41,6 +46,7 @@ async def test_alexandria_client_subscription_via_talk_response(
 
             assert isinstance(message.message, PongMessage)
             assert message.message.payload.enr_seq == alice.enr.sequence_number
+            assert message.message.payload.advertisement_radius == 1234
 
 
 @pytest.mark.trio
@@ -48,7 +54,7 @@ async def test_alexandria_client_subscription_via_talk_request_protocol_mismatch
     alice_network, alice, bob, bob_alexandria_client, autojump_clock
 ):
     async with bob_alexandria_client.subscribe(PingMessage) as subscription:
-        message = PingMessage(PingPayload(alice.enr.sequence_number))
+        message = PingMessage(PingPayload(alice.enr.sequence_number, 1234))
         data_payload = message.to_wire_bytes()
         await alice_network.client.send_talk_request(
             bob.node_id,
@@ -66,7 +72,7 @@ async def test_alexandria_client_subscription_via_talk_response_unknown_request_
     alice_network, alice, bob, bob_alexandria_client, autojump_clock
 ):
     async with bob_alexandria_client.subscribe(PongMessage) as subscription:
-        message = PongMessage(PongPayload(alice.enr.sequence_number))
+        message = PongMessage(PongPayload(alice.enr.sequence_number, 1234))
         data_payload = message.to_wire_bytes()
         await alice_network.client.send_talk_response(
             bob.node_id,


### PR DESCRIPTION
depends on #200 #239 #190 #198 

## What was wrong?

Nodes need to be regularly updating others on their advertisement radius.

## How was it fixed?

Include advertisement radius in the Ping and Pong messages.

#### Cute Animal Picture

![RaccoonMingoWildlifeRefuge-1](https://user-images.githubusercontent.com/824194/99460903-f81de100-28ed-11eb-9d27-5a3b79b9d2cf.jpg)

