### PR TITLE
Implement Advertise/Ack message sending

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -19,14 +19,16 @@ from ddht.abc import RequestTrackerAPI, RoutingTableAPI, SubscriptionManagerAPI
 from ddht.base_message import InboundMessage
 from ddht.endpoint import Endpoint
 from ddht.v5_1.abc import NetworkAPI, TalkProtocolAPI
+from ddht.v5_1.alexandria.advertisements import Advertisement
 from ddht.v5_1.alexandria.messages import (
+    AckMessage,
     AlexandriaMessage,
     ContentMessage,
     FoundNodesMessage,
     PongMessage,
     TAlexandriaMessage,
 )
-from ddht.v5_1.alexandria.payloads import PongPayload
+from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
 from ddht.v5_1.alexandria.typing import ContentKey
 
 
@@ -142,6 +144,28 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     ) -> None:
         ...
 
+    @abstractmethod
+    async def send_advertisements(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        advertisements: Sequence[Advertisement],
+        request_id: Optional[bytes] = None,
+    ) -> bytes:
+        ...
+
+    @abstractmethod
+    async def send_ack(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        advertisement_radius: int,
+        request_id: bytes,
+    ) -> None:
+        ...
+
     #
     # High Level Request/Response
     #
@@ -171,6 +195,16 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         max_chunks: int,
         request_id: Optional[bytes] = None,
     ) -> ContentMessage:
+        ...
+
+    @abstractmethod
+    async def advertise(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        advertisements: Collection[Advertisement],
+    ) -> Tuple[AckMessage, ...]:
         ...
 
 
@@ -221,6 +255,16 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         endpoint: Optional[Endpoint] = None,
         request_id: Optional[bytes] = None,
     ) -> Tuple[ENRAPI, ...]:
+        ...
+
+    @abstractmethod
+    async def advertise(
+        self,
+        node_id: NodeID,
+        *,
+        advertisements: Collection[Advertisement],
+        endpoint: Optional[Endpoint] = None,
+    ) -> Tuple[AckPayload, ...]:
         ...
 
     @abstractmethod

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -16,9 +16,10 @@ from ddht.endpoint import Endpoint
 from ddht.kademlia import KademliaRoutingTable
 from ddht.v5_1.abc import NetworkAPI
 from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI
+from ddht.v5_1.alexandria.advertisements import Advertisement
 from ddht.v5_1.alexandria.client import AlexandriaClient
 from ddht.v5_1.alexandria.messages import FindNodesMessage, PingMessage, PongMessage
-from ddht.v5_1.alexandria.payloads import PongPayload
+from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
 from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE
 from ddht.v5_1.network import common_recursive_find_nodes
 
@@ -151,6 +152,20 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
 
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         return await common_recursive_find_nodes(self, target)
+
+    async def advertise(
+        self,
+        node_id: NodeID,
+        *,
+        advertisements: Collection[Advertisement],
+        endpoint: Optional[Endpoint] = None,
+    ) -> Tuple[AckPayload, ...]:
+        if endpoint is None:
+            endpoint = await self.network.endpoint_for_node_id(node_id)
+        responses = await self.client.advertise(
+            node_id, advertisements=advertisements, endpoint=endpoint,
+        )
+        return tuple(response.payload for response in responses)
 
     #
     # Long Running Processes

--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -3,6 +3,7 @@ from typing import NamedTuple, Sequence, Tuple
 from eth_enr import ENR, ENRAPI
 import rlp
 
+from ddht.v5_1.alexandria.advertisements import Advertisement
 from ddht.v5_1.alexandria.typing import ContentKey
 
 
@@ -43,3 +44,10 @@ class GetContentPayload(NamedTuple):
 class ContentPayload(NamedTuple):
     is_proof: bool
     payload: bytes
+
+
+AdvertisePayload = Tuple[Advertisement, ...]
+
+
+class AckPayload(NamedTuple):
+    advertisement_radius: int

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -41,6 +41,7 @@ AdvertisementSedes = Container(
     field_sedes=(byte_list, bytes32, uint40, uint8, uint256, uint256)
 )
 AdvertiseSedes = List(AdvertisementSedes, max_length=32)
+AckSedes = Container(field_sedes=(uint256,))
 
 # sedes used for encoding alexandria content
 content_sedes = ByteList(max_length=GB)


### PR DESCRIPTION
Based on #196 

## What was wrong?

We need to be able to send advertisements around the network.

## How was it fixed?

Implement advertisement message sending APIs on network and client models.

#### Cute Animal Picture

![1070548876](https://user-images.githubusercontent.com/824194/99461934-f35a2c80-28ef-11eb-94a0-974a5a38eccd.png)

