### PR TITLE
Allow specifying request_id in alexandria message sending

### DIFF
--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -123,6 +123,7 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         endpoint: Endpoint,
         request: AlexandriaMessage[Any],
         response_class: Type[TAlexandriaMessage],
+        request_id: Optional[bytes] = None,
     ) -> TAlexandriaMessage:
         #
         # Request ID Shenanigans
@@ -146,7 +147,10 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         # then feed this into our local tracker, which allows us to query it
         # upon receiving an incoming TALKRESPONSE to see if the response is to
         # a message from this protocol.
-        request_id = self.network.client.request_tracker.get_free_request_id(node_id)
+        if request_id is None:
+            request_id = self.network.client.request_tracker.get_free_request_id(
+                node_id
+            )
         request_data = request.to_wire_bytes()
         with self.request_tracker.reserve_request_id(node_id, request_id):
             response_data = await self.network.talk(


### PR DESCRIPTION
## What was wrong?

It is useful to be able to specify the `request_id` in most situations.

## How was it fixed?

Added ability to manually supply a request_id

#### Cute Animal Picture

![racoon-bird-feeder](https://user-images.githubusercontent.com/824194/99462193-6499df80-28f0-11eb-8303-317471319891.jpg)
