### PR TITLE
Add NewType for ContentID

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -3,7 +3,7 @@ from typing import Any, AsyncContextManager, Collection, Optional, Sequence, Tup
 
 from async_service import ServiceAPI
 from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
-from eth_typing import Hash32, NodeID
+from eth_typing import NodeID
 import trio
 
 from ddht.abc import RequestTrackerAPI, RoutingTableAPI, SubscriptionManagerAPI
@@ -18,6 +18,7 @@ from ddht.v5_1.alexandria.messages import (
     TAlexandriaMessage,
 )
 from ddht.v5_1.alexandria.payloads import PongPayload
+from ddht.v5_1.alexandria.typing import ContentID
 
 
 class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
@@ -87,9 +88,9 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: Hash32,
+        content_id: ContentID,
         start_chunk_index: int,
-        num_chunks: int,
+        max_chunks: int,
         request_id: Optional[bytes] = None,
     ) -> bytes:
         ...
@@ -130,9 +131,9 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: Hash32,
+        content_id: ContentID,
         start_chunk_index: int,
-        num_chunks: int,
+        max_chunks: int,
         request_id: Optional[bytes] = None,
     ) -> ContentMessage:
         ...

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -17,7 +17,7 @@ from async_generator import asynccontextmanager
 from async_service import Service
 from eth_enr import ENRAPI
 from eth_keys import keys
-from eth_typing import Hash32, NodeID
+from eth_typing import NodeID
 from eth_utils import ValidationError
 import trio
 
@@ -50,6 +50,7 @@ from ddht.v5_1.alexandria.payloads import (
     PingPayload,
     PongPayload,
 )
+from ddht.v5_1.alexandria.typing import ContentID
 from ddht.v5_1.constants import REQUEST_RESPONSE_TIMEOUT
 from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
 
@@ -329,13 +330,13 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: Hash32,
+        content_id: ContentID,
         start_chunk_index: int,
-        num_chunks: int,
+        max_chunks: int,
         request_id: Optional[bytes] = None,
     ) -> bytes:
         message = GetContentMessage(
-            GetContentPayload(content_id, start_chunk_index, num_chunks)
+            GetContentPayload(content_id, start_chunk_index, max_chunks)
         )
         return await self._send_request(
             node_id, endpoint, message, request_id=request_id
@@ -417,15 +418,17 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: Hash32,
+        content_id: ContentID,
         start_chunk_index: int,
-        num_chunks: int,
+        max_chunks: int,
         request_id: Optional[bytes] = None,
     ) -> ContentMessage:
         request = GetContentMessage(
-            GetContentPayload(content_id, start_chunk_index, num_chunks)
+            GetContentPayload(content_id, start_chunk_index, max_chunks)
         )
-        response = await self._request(node_id, endpoint, request, ContentMessage)
+        response = await self._request(
+            node_id, endpoint, request, ContentMessage, request_id
+        )
         return response
 
     #

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -123,6 +123,7 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         endpoint: Endpoint,
         request: AlexandriaMessage[Any],
         response_class: Type[TAlexandriaMessage],
+        request_id: Optional[bytes] = None,
     ) -> TAlexandriaMessage:
         #
         # Request ID Shenanigans
@@ -146,7 +147,10 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         # then feed this into our local tracker, which allows us to query it
         # upon receiving an incoming TALKRESPONSE to see if the response is to
         # a message from this protocol.
-        request_id = self.network.client.request_tracker.get_free_request_id(node_id)
+        if request_id is None:
+            request_id = self.network.client.request_tracker.get_free_request_id(
+                node_id
+            )
         request_data = request.to_wire_bytes()
         with self.request_tracker.reserve_request_id(node_id, request_id):
             response_data = await self.network.talk(

--- a/ddht/v5_1/alexandria/content.py
+++ b/ddht/v5_1/alexandria/content.py
@@ -1,0 +1,15 @@
+import hashlib
+
+from eth_typing import NodeID
+
+from .typing import ContentID
+
+
+def content_key_to_content_id(key: bytes) -> ContentID:
+    return ContentID(hashlib.sha256(key).digest())
+
+
+def compute_content_distance(node_id: NodeID, content_id: ContentID) -> int:
+    node_id_int = int.from_bytes(node_id, "big")
+    content_id_int = int.from_bytes(content_id, "big")
+    return node_id_int ^ content_id_int

--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -1,8 +1,9 @@
 from typing import NamedTuple, Sequence, Tuple
 
 from eth_enr import ENR, ENRAPI
-from eth_typing import Hash32
 import rlp
+
+from ddht.v5_1.alexandria.typing import ContentID
 
 
 class PingPayload(NamedTuple):
@@ -34,9 +35,9 @@ class FoundNodesPayload(NamedTuple):
 
 
 class GetContentPayload(NamedTuple):
-    content_id: Hash32
+    content_id: ContentID
     start_chunk_index: int
-    num_chunks: int
+    max_chunks: int
 
 
 class ContentPayload(NamedTuple):

--- a/ddht/v5_1/alexandria/typing.py
+++ b/ddht/v5_1/alexandria/typing.py
@@ -1,0 +1,3 @@
+from typing import NewType
+
+ContentID = NewType("ContentID", bytes)

--- a/tests/core/v5_1/alexandria/test_alexandria_client.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_client.py
@@ -241,7 +241,7 @@ async def test_alexandria_client_send_get_content(
 ):
     content_id = b"unicornsrainbowsuniconrsrainbows"
     start_chunk_index = 5
-    num_chunks = 16
+    max_chunks = 16
 
     async with bob_network.dispatcher.subscribe(TalkRequestMessage) as subscription:
         await alice_alexandria_client.send_get_content(
@@ -249,7 +249,7 @@ async def test_alexandria_client_send_get_content(
             bob.endpoint,
             content_id=content_id,
             start_chunk_index=start_chunk_index,
-            num_chunks=num_chunks,
+            max_chunks=max_chunks,
         )
         with trio.fail_after(1):
             talk_response = await subscription.receive()
@@ -257,7 +257,7 @@ async def test_alexandria_client_send_get_content(
         assert isinstance(message, GetContentMessage)
         assert message.payload.content_id == content_id
         assert message.payload.start_chunk_index == start_chunk_index
-        assert message.payload.num_chunks == num_chunks
+        assert message.payload.max_chunks == max_chunks
 
 
 @pytest.mark.trio
@@ -308,7 +308,7 @@ async def test_alexandria_client_get_content(
                     bob.endpoint,
                     content_id=content_id,
                     start_chunk_index=0,
-                    num_chunks=1,
+                    max_chunks=1,
                 )
 
                 assert isinstance(content_message, ContentMessage)


### PR DESCRIPTION
Builds on #187 

## What was wrong?

We don't want to mix and match `content_id` values and `node_id` values, nor do we want to overload `Hash32` nor do we want to incidentally pass in a `bytes` type of the wrong type as a `content_id`

## How was it fixed?

Add a `NewType("ContentID")` that we can use for the type hint for `content_id` values.

#### Cute Animal Picture

![racoon-bird-feeder-1](https://user-images.githubusercontent.com/824194/99462473-fc97c900-28f0-11eb-9cf0-c07e00848b16.jpg)

