### PR TITLE
Make `recursive_find_nodes` and `get_nodes_near` use a common protocol based implementation.

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -1,6 +1,15 @@
 from abc import ABC, abstractmethod
 import logging
-from typing import Any, AsyncContextManager, Collection, Optional, Sequence, Tuple, Type
+from typing import (
+    Any,
+    AsyncContextManager,
+    Collection,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    Type,
+)
 import uuid
 
 from async_service import ServiceAPI
@@ -410,6 +419,34 @@ class ClientAPI(ServiceAPI):
 
 class TalkProtocolAPI(ABC):
     protocol_id: bytes
+
+
+class NetworkProtocol(Protocol):
+    logger: logging.Logger
+    routing_table: RoutingTableAPI
+
+    @property
+    def local_node_id(self) -> NodeID:
+        ...
+
+    @property
+    def enr_db(self) -> ENRDatabaseAPI:
+        ...
+
+    async def find_nodes(
+        self,
+        node_id: NodeID,
+        *distances: int,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
+    ) -> Tuple[ENRAPI, ...]:
+        ...
+
+    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
+        ...
+
+    async def get_nodes_near(self, target: NodeID) -> Tuple[NodeID, ...]:
+        ...
 
 
 class NetworkAPI(ServiceAPI):

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -191,3 +191,9 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     @abstractmethod
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         ...
+
+    @abstractmethod
+    async def get_nodes_near(
+        self, target: NodeID, max_nodes: int = 32
+    ) -> Tuple[NodeID, ...]:
+        ...


### PR DESCRIPTION
## What was wrong?

We need the `get_nodes_near` API in Alexandria.  However, previously, copy/paste approach is problematic as these APIs evolve.

## How was it fixed?

Created a `NetworkProtocol` type and extracted the logic for both `recursive_find_nodes` and `get_nodes_near` to use the same logic.


#### Cute Animal Picture

![raccoon_feeder](https://user-images.githubusercontent.com/824194/99462837-bdb64300-28f1-11eb-97c3-ce7081ffa69f.jpg)

