### PR TITLE
Update Alexandria message API for custom payload encoding

### DIFF
--- a/ddht/v5_1/alexandria/messages.py
+++ b/ddht/v5_1/alexandria/messages.py
@@ -47,9 +47,12 @@ class AlexandriaMessage(Generic[TPayload]):
         return b"".join(
             (
                 UINT8_TO_BYTES[self.message_id],
-                ssz.encode(self.payload, sedes=self.sedes),
+                ssz.encode(self.get_payload_for_encoding(), sedes=self.sedes),
             )
         )
+
+    def get_payload_for_encoding(self) -> Any:
+        return self.payload
 
     @classmethod
     def from_payload_args(


### PR DESCRIPTION
## What was wrong?

We need the ability to customize how message payloads are encoded to support the message format of the Advertise message that is being introduced in #186 

## How was it fixed?

These is now a `get_payload_for_encoding()` API on the `AlexandriaMessage` class which allows for custom handling of payload encoding.

#### Cute Animal Picture

![istockphoto-598177190-612x612](https://user-images.githubusercontent.com/824194/99464123-9c0a8b00-28f4-11eb-8c11-42651a571e13.jpg)

