### PR TITLE
Alexandria: Add nodes to routing table which ping us

### DIFF
--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -236,6 +236,13 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                     enr_seq=self.enr_manager.enr.sequence_number,
                     request_id=request.request_id,
                 )
+                enr = await self.network.lookup_enr(
+                    request.sender_node_id,
+                    enr_seq=request.message.payload.enr_seq,
+                    endpoint=request.sender_endpoint,
+                )
+                self.routing_table.update(enr.node_id)
+                self._routing_table_ready.set()
 
     async def _serve_find_nodes(self) -> None:
         async with self.client.subscribe(FindNodesMessage) as subscription:


### PR DESCRIPTION
## What was wrong?

When a node pings us, they should be a candidate for the routing table

## How was it fixed?

Now when a node pings us, we add them to the routing table.

#### Cute Animal Picture

![page-raccoons](https://user-images.githubusercontent.com/824194/99464295-058a9980-28f5-11eb-8686-264dc15e49cb.jpg)

