### PR TITLE
Add jsonrpc support for discv5_sendFindNodes and discv5_sendFoundNodes

### DIFF
--- a/newsfragments/195.feature.rst
+++ b/newsfragments/195.feature.rst
@@ -1,0 +1,1 @@
+Add support for discv5_sendFindNodes and discv5_sendFoundNodes json rpc endpoints.


### PR DESCRIPTION
## What was wrong?
Added support for `discv5_sendFindNodes` and `discv5_sendFoundNodes` jsonrpc endpoints.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/99545758-02a3ad80-29b6-11eb-9110-51106a4c072e.png)
