### PR TITLE
Implement BroadcastLogAPI

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -20,6 +20,7 @@ from ddht.base_message import InboundMessage
 from ddht.endpoint import Endpoint
 from ddht.v5_1.abc import NetworkAPI, TalkProtocolAPI
 from ddht.v5_1.alexandria.advertisements import Advertisement
+from ddht.v5_1.alexandria.constants import ONE_HOUR
 from ddht.v5_1.alexandria.messages import (
     AckMessage,
     AlexandriaMessage,
@@ -55,6 +56,18 @@ class ContentStorageAPI(ABC):
         start_key: Optional[ContentKey] = None,
         end_key: Optional[ContentKey] = None,
     ) -> Iterable[ContentKey]:
+        ...
+
+
+class BroadcastLogAPI(ABC):
+    @abstractmethod
+    def log(self, node_id: NodeID, advertisement: Advertisement) -> None:
+        ...
+
+    @abstractmethod
+    def was_logged(
+        self, node_id: NodeID, advertisement: Advertisement, max_age: int = ONE_HOUR
+    ) -> bool:
         ...
 
 

--- a/ddht/v5_1/alexandria/broadcast_log.py
+++ b/ddht/v5_1/alexandria/broadcast_log.py
@@ -1,0 +1,37 @@
+import hashlib
+import time
+from typing import Dict
+
+from eth_typing import Hash32, NodeID
+from lru import LRU
+
+from ddht.v5_1.alexandria.advertisements import Advertisement
+from ddht.v5_1.alexandria.constants import ONE_HOUR
+
+
+class BroadcastLog:
+    """
+    Tracks the last time each advertisement was broadcast to each peer.
+    """
+
+    def __init__(self, max_records: int = 8192):
+        self._log: Dict[Hash32, int] = LRU(max_records)
+
+    def log(self, node_id: NodeID, advertisement: Advertisement) -> None:
+        key = Hash32(
+            hashlib.sha256(node_id + advertisement.signature.to_bytes()).digest()
+        )
+        self._log[key] = int(time.monotonic())
+
+    def was_logged(
+        self, node_id: NodeID, advertisement: Advertisement, max_age: int = ONE_HOUR
+    ) -> bool:
+        key = Hash32(
+            hashlib.sha256(node_id + advertisement.signature.to_bytes()).digest()
+        )
+        try:
+            last_logged_at = self._log[key]
+        except KeyError:
+            return False
+        else:
+            return time.monotonic() - last_logged_at < max_age

--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -23,3 +23,7 @@ POWERS_OF_TWO = tuple(2 ** n for n in range(256))
 # - up-to 10 bytes for RLP encoding overhead.
 #
 MAX_PAYLOAD_SIZE = DISCOVERY_MAX_PACKET_SIZE - 90
+
+
+# One hour in seconds
+ONE_HOUR = 60 * 60

--- a/tests/core/v5_1/alexandria/test_broadcast_log.py
+++ b/tests/core/v5_1/alexandria/test_broadcast_log.py
@@ -1,0 +1,34 @@
+import pytest
+
+from ddht.tools.factories.alexandria import AdvertisementFactory
+from ddht.v5_1.alexandria.broadcast_log import BroadcastLog
+
+
+@pytest.mark.trio
+async def test_broadcast_log(alice, bob):
+    ad_a = AdvertisementFactory(private_key=alice.private_key)
+    ad_b = AdvertisementFactory(private_key=alice.private_key)
+    ad_c = AdvertisementFactory(private_key=alice.private_key)
+    ad_d = AdvertisementFactory(private_key=bob.private_key)
+    ad_e = AdvertisementFactory(private_key=bob.private_key)
+
+    all_ads = (ad_a, ad_b, ad_c, ad_d, ad_e)
+
+    broadcast_log = BroadcastLog(max_records=8)
+
+    # not logged when empty
+    for ad in all_ads:
+        assert not broadcast_log.was_logged(alice.node_id, ad)
+        assert not broadcast_log.was_logged(bob.node_id, ad)
+
+    broadcast_log.log(alice.node_id, ad_a)
+
+    assert broadcast_log.was_logged(alice.node_id, ad_a)
+    assert not broadcast_log.was_logged(bob.node_id, ad_a)
+
+    # we insert 8 more, which should evict alice's entries for `ad_a`
+    for ad in all_ads[1:]:
+        broadcast_log.log(alice.node_id, ad)
+        broadcast_log.log(bob.node_id, ad)
+
+    assert not broadcast_log.was_logged(alice.node_id, ad_a)


### PR DESCRIPTION
Builds on #196 

## What was wrong?

One of the gossip rules for advertisements is that we should only send an advertisement to a peer if we have not "recently" sent it to them.

## How was it fixed?

Implements the `BroadcastLogAPI` and `BroadcastLog` which exposes an API for tracking the last time we sent an advertisement to a given node and for querying this data.

#### Cute Animal Picture

![raccoon-herd](https://user-images.githubusercontent.com/824194/99549179-9d7c9780-2976-11eb-8114-40d696dada6e.jpg)

