### PR TITLE
Implement content transmission on AlexandriaNetworkAPI

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -12,7 +12,7 @@ from typing import (
 
 from async_service import ServiceAPI
 from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
-from eth_typing import NodeID
+from eth_typing import Hash32, NodeID
 import trio
 
 from ddht.abc import RequestTrackerAPI, RoutingTableAPI, SubscriptionManagerAPI
@@ -29,6 +29,7 @@ from ddht.v5_1.alexandria.messages import (
     PongMessage,
     TAlexandriaMessage,
 )
+from ddht.v5_1.alexandria.partials.proof import Proof
 from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
 from ddht.v5_1.alexandria.typing import ContentKey
 
@@ -268,6 +269,30 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         endpoint: Optional[Endpoint] = None,
         request_id: Optional[bytes] = None,
     ) -> Tuple[ENRAPI, ...]:
+        ...
+
+    async def get_content_proof(
+        self,
+        node_id: NodeID,
+        *,
+        hash_tree_root: Hash32,
+        content_key: ContentKey,
+        start_chunk_index: int,
+        max_chunks: int,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
+    ) -> Proof:
+        ...
+
+    @abstractmethod
+    async def get_content_from_nodes(
+        self,
+        nodes: Collection[Tuple[NodeID, Optional[Endpoint]]],
+        *,
+        hash_tree_root: Hash32,
+        content_key: ContentKey,
+        concurrency: int = 4,
+    ) -> Proof:
         ...
 
     @abstractmethod

--- a/tests/core/v5_1/alexandria/test_alexandria_network.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_network.py
@@ -4,9 +4,16 @@ import trio
 
 from ddht.constants import ROUTING_TABLE_BUCKET_SIZE
 from ddht.kademlia import KademliaRoutingTable, compute_log_distance
+from ddht.tools.factories.content import ContentFactory
 from ddht.v5_1.alexandria.advertisements import Advertisement
-from ddht.v5_1.alexandria.messages import AdvertiseMessage, FindNodesMessage
+from ddht.v5_1.alexandria.messages import (
+    AdvertiseMessage,
+    FindNodesMessage,
+    GetContentMessage,
+)
+from ddht.v5_1.alexandria.partials.proof import compute_proof, validate_proof
 from ddht.v5_1.alexandria.payloads import AckPayload
+from ddht.v5_1.alexandria.sedes import content_sedes
 
 
 @pytest.mark.trio
@@ -142,3 +149,126 @@ async def test_alexandria_network_advertise(
 
                 assert isinstance(ack_payload, AckPayload)
                 assert ack_payload.advertisement_radius == 12345
+
+
+@pytest.mark.trio
+async def test_alexandria_network_get_content_proof_api(
+    alice, bob, alice_alexandria_network, bob_alexandria_client,
+):
+    content = ContentFactory(length=16 * 32 * 4)
+    proof = compute_proof(content, sedes=content_sedes)
+
+    async with bob_alexandria_client.subscribe(GetContentMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+
+            async def _serve():
+                request = await subscription.receive()
+                partial = proof.to_partial(
+                    request.message.payload.start_chunk_index * 32,
+                    request.message.payload.max_chunks * 32,
+                )
+                payload = partial.serialize()
+                await bob_alexandria_client.send_content(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    is_proof=True,
+                    payload=payload,
+                    request_id=request.request_id,
+                )
+
+            nursery.start_soon(_serve)
+
+            with trio.fail_after(2):
+                partial = await alice_alexandria_network.get_content_proof(
+                    bob.node_id,
+                    hash_tree_root=proof.get_hash_tree_root(),
+                    content_key=b"test-content-key",
+                    start_chunk_index=0,
+                    max_chunks=16,
+                )
+                validate_proof(partial)
+                partial_data = partial.get_proven_data()
+                assert partial_data[0 : 16 * 32] == content[0 : 16 * 32]
+
+
+@pytest.mark.trio
+async def test_alexandria_network_get_content_from_nodes_api_single_peer(
+    alice, bob, alice_alexandria_network, bob_alexandria_client,
+):
+    content = ContentFactory(length=1024 * 10)
+    proof = compute_proof(content, sedes=content_sedes)
+
+    async with bob_alexandria_client.subscribe(GetContentMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+
+            async def _serve():
+                async for request in subscription:
+                    start_at = request.message.payload.start_chunk_index * 32
+                    end_at = min(
+                        len(content), start_at + request.message.payload.max_chunks * 32
+                    )
+                    partial = proof.to_partial(start_at, end_at - start_at)
+                    payload = partial.serialize()
+                    await bob_alexandria_client.send_content(
+                        request.sender_node_id,
+                        request.sender_endpoint,
+                        is_proof=True,
+                        payload=payload,
+                        request_id=request.request_id,
+                    )
+
+            nursery.start_soon(_serve)
+
+            with trio.fail_after(2):
+                result = await alice_alexandria_network.get_content_from_nodes(
+                    nodes=((bob.node_id, bob.endpoint),),
+                    hash_tree_root=proof.get_hash_tree_root(),
+                    content_key=b"test-content-key",
+                    concurrency=1,
+                )
+                validate_proof(result)
+                result_data = result.get_proven_data()
+                assert result_data[0 : len(content)] == content
+
+            nursery.cancel_scope.cancel()
+
+
+@pytest.mark.trio
+async def test_alexandria_network_get_content_from_nodes_api_impartial_chunks(
+    alice, bob, alice_alexandria_network, bob_alexandria_client,
+):
+    content = ContentFactory(length=1024 * 10)
+    proof = compute_proof(content, sedes=content_sedes)
+
+    async with bob_alexandria_client.subscribe(GetContentMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+
+            async def _serve():
+                async for request in subscription:
+                    start_at = request.message.payload.start_chunk_index * 32
+                    # We only every return a proof for 1 chunk of data
+                    end_at = min(len(content), start_at + 32)
+                    partial = proof.to_partial(start_at, end_at - start_at)
+                    payload = partial.serialize()
+                    await bob_alexandria_client.send_content(
+                        request.sender_node_id,
+                        request.sender_endpoint,
+                        is_proof=True,
+                        payload=payload,
+                        request_id=request.request_id,
+                    )
+
+            nursery.start_soon(_serve)
+
+            with trio.fail_after(4):
+                result = await alice_alexandria_network.get_content_from_nodes(
+                    nodes=((bob.node_id, bob.endpoint),),
+                    hash_tree_root=proof.get_hash_tree_root(),
+                    content_key=b"test-content-key",
+                    concurrency=1,
+                )
+                validate_proof(result)
+                result_data = result.get_proven_data()
+                assert result_data[0 : len(content)] == content
+
+            nursery.cancel_scope.cancel()


### PR DESCRIPTION
replaces #165 

## What was wrong?

We need high level APIs for retrieving content in Alexandria

## How was it fixed?

Implemented `AlexandriaNetworkAPI.get_content_proof` and `AlexandriaNetworkAPI.get_content_from_nodes`

#### Cute Animal Picture

![raccoon-nasty-face](https://user-images.githubusercontent.com/824194/99556494-d0c32480-297e-11eb-82f4-aeebff697a59.jpg)

