### PR TITLE
Implement NewType for ContentKey

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -18,7 +18,7 @@ from ddht.v5_1.alexandria.messages import (
     TAlexandriaMessage,
 )
 from ddht.v5_1.alexandria.payloads import PongPayload
-from ddht.v5_1.alexandria.typing import ContentID
+from ddht.v5_1.alexandria.typing import ContentKey
 
 
 class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
@@ -88,7 +88,7 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: ContentID,
+        content_key: ContentKey,
         start_chunk_index: int,
         max_chunks: int,
         request_id: Optional[bytes] = None,
@@ -131,7 +131,7 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: ContentID,
+        content_key: ContentKey,
         start_chunk_index: int,
         max_chunks: int,
         request_id: Optional[bytes] = None,

--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -50,7 +50,7 @@ from ddht.v5_1.alexandria.payloads import (
     PingPayload,
     PongPayload,
 )
-from ddht.v5_1.alexandria.typing import ContentID
+from ddht.v5_1.alexandria.typing import ContentKey
 from ddht.v5_1.constants import REQUEST_RESPONSE_TIMEOUT
 from ddht.v5_1.messages import TalkRequestMessage, TalkResponseMessage
 
@@ -330,13 +330,13 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: ContentID,
+        content_key: ContentKey,
         start_chunk_index: int,
         max_chunks: int,
         request_id: Optional[bytes] = None,
     ) -> bytes:
         message = GetContentMessage(
-            GetContentPayload(content_id, start_chunk_index, max_chunks)
+            GetContentPayload(content_key, start_chunk_index, max_chunks)
         )
         return await self._send_request(
             node_id, endpoint, message, request_id=request_id
@@ -418,13 +418,13 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
         node_id: NodeID,
         endpoint: Endpoint,
         *,
-        content_id: ContentID,
+        content_key: ContentKey,
         start_chunk_index: int,
         max_chunks: int,
         request_id: Optional[bytes] = None,
     ) -> ContentMessage:
         request = GetContentMessage(
-            GetContentPayload(content_id, start_chunk_index, max_chunks)
+            GetContentPayload(content_key, start_chunk_index, max_chunks)
         )
         response = await self._request(
             node_id, endpoint, request, ContentMessage, request_id

--- a/ddht/v5_1/alexandria/content.py
+++ b/ddht/v5_1/alexandria/content.py
@@ -2,10 +2,10 @@ import hashlib
 
 from eth_typing import NodeID
 
-from .typing import ContentID
+from .typing import ContentID, ContentKey
 
 
-def content_key_to_content_id(key: bytes) -> ContentID:
+def content_key_to_content_id(key: ContentKey) -> ContentID:
     return ContentID(hashlib.sha256(key).digest())
 
 

--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, Sequence, Tuple
 from eth_enr import ENR, ENRAPI
 import rlp
 
-from ddht.v5_1.alexandria.typing import ContentID
+from ddht.v5_1.alexandria.typing import ContentKey
 
 
 class PingPayload(NamedTuple):
@@ -35,7 +35,7 @@ class FoundNodesPayload(NamedTuple):
 
 
 class GetContentPayload(NamedTuple):
-    content_id: ContentID
+    content_key: ContentKey
     start_chunk_index: int
     max_chunks: int
 

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -1,4 +1,4 @@
-from ssz.sedes import Container, List, boolean, bytes32, uint8, uint16, uint32
+from ssz.sedes import Container, List, boolean, uint8, uint16, uint32
 
 from ddht.v5_1.alexandria.constants import GB
 
@@ -21,7 +21,7 @@ PingSedes = Container(field_sedes=(uint32,))
 PongSedes = Container(field_sedes=(uint32,))
 FindNodesSedes = Container(field_sedes=(List(uint16, max_length=256),))
 FoundNodesSedes = Container(field_sedes=(uint8, List(byte_list, max_length=32)))
-GetContentSedes = Container(field_sedes=(bytes32, uint32, uint16))
+GetContentSedes = Container(field_sedes=(byte_list, uint32, uint16))
 ContentSedes = Container(field_sedes=(boolean, byte_list,))
 
 # sedes used for encoding alexandria content

--- a/ddht/v5_1/alexandria/typing.py
+++ b/ddht/v5_1/alexandria/typing.py
@@ -1,3 +1,4 @@
 from typing import NewType
 
 ContentID = NewType("ContentID", bytes)
+ContentKey = NewType("ContentKey", bytes)

--- a/tests/core/v5_1/alexandria/test_alexandria_client.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_client.py
@@ -239,7 +239,7 @@ async def test_client_request_response_find_nodes_found_nodes(
 async def test_alexandria_client_send_get_content(
     bob, bob_network, alice_alexandria_client
 ):
-    content_id = b"unicornsrainbowsuniconrsrainbows"
+    content_key = b"test-content-key"
     start_chunk_index = 5
     max_chunks = 16
 
@@ -247,7 +247,7 @@ async def test_alexandria_client_send_get_content(
         await alice_alexandria_client.send_get_content(
             bob.node_id,
             bob.endpoint,
-            content_id=content_id,
+            content_key=content_key,
             start_chunk_index=start_chunk_index,
             max_chunks=max_chunks,
         )
@@ -255,7 +255,7 @@ async def test_alexandria_client_send_get_content(
             talk_response = await subscription.receive()
         message = decode_message(talk_response.message.payload)
         assert isinstance(message, GetContentMessage)
-        assert message.payload.content_id == content_id
+        assert message.payload.content_key == content_key
         assert message.payload.start_chunk_index == start_chunk_index
         assert message.payload.max_chunks == max_chunks
 
@@ -285,7 +285,7 @@ async def test_alexandria_client_send_content(
 async def test_alexandria_client_get_content(
     alice, bob, bob_network, alice_alexandria_client, bob_alexandria_client,
 ):
-    content_id = b"unicornsrainbowsuniconrsrainbows"
+    content_key = b"test-content-key"
 
     async with bob_network.dispatcher.subscribe(TalkRequestMessage) as subscription:
 
@@ -306,7 +306,7 @@ async def test_alexandria_client_get_content(
                 content_message = await alice_alexandria_client.get_content(
                     bob.node_id,
                     bob.endpoint,
-                    content_id=content_id,
+                    content_key=content_key,
                     start_chunk_index=0,
                     max_chunks=1,
                 )


### PR DESCRIPTION
## What was wrong?

We have been using `bytes` as the type for content keys.  This is prone to certain types of mistakes that are harder to make if we use a `NewType`

## How was it fixed?

Changed all `content_key` usage to use a new `ContentKey` type which is just a `NewType("ContentKey", bytes)`

#### Cute Animal Picture

![8694995818_b22314b967_z](https://user-images.githubusercontent.com/824194/99557707-36fc7700-2980-11eb-9aa7-bdcb50b8580b.jpg)

