### PR TITLE
Implement AdvertisementDatabaseAPI

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -32,7 +32,7 @@ from ddht.v5_1.alexandria.messages import (
 )
 from ddht.v5_1.alexandria.partials.proof import Proof
 from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
-from ddht.v5_1.alexandria.typing import ContentKey
+from ddht.v5_1.alexandria.typing import ContentID, ContentKey
 
 
 class ContentStorageAPI(ABC):
@@ -82,6 +82,52 @@ class BroadcastLogAPI(ABC):
 class ContentProviderAPI(ServiceAPI):
     @abstractmethod
     async def ready(self) -> None:
+        ...
+
+
+class AdvertisementDatabaseAPI(ABC):
+    @abstractmethod
+    def exists(self, advertisement: Advertisement) -> bool:
+        ...
+
+    @abstractmethod
+    def add(self, advertisement: Advertisement) -> None:
+        ...
+
+    @abstractmethod
+    def remove(self, advertisement: Advertisement) -> bool:
+        ...
+
+    @abstractmethod
+    def query(
+        self,
+        node_id: Optional[NodeID] = None,
+        content_id: Optional[ContentID] = None,
+        content_key: Optional[bytes] = None,
+        hash_tree_root: Optional[Hash32] = None,
+    ) -> Iterable[Advertisement]:
+        ...
+
+    @abstractmethod
+    def closest(self, node_id: NodeID) -> Iterable[Advertisement]:
+        ...
+
+    @abstractmethod
+    def furthest(self, node_id: NodeID) -> Iterable[Advertisement]:
+        ...
+
+    @abstractmethod
+    def get_hash_tree_roots_for_content_id(
+        self, content_id: ContentID
+    ) -> Iterable[Hash32]:
+        ...
+
+    @abstractmethod
+    def count(self) -> int:
+        ...
+
+    @abstractmethod
+    def expired(self) -> Iterable[Advertisement]:
         ...
 
 
@@ -238,6 +284,8 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
 class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     client: AlexandriaClientAPI
     routing_table: RoutingTableAPI
+
+    advertisement_db: AdvertisementDatabaseAPI
 
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI

--- a/ddht/v5_1/alexandria/advertisement_db.py
+++ b/ddht/v5_1/alexandria/advertisement_db.py
@@ -1,0 +1,330 @@
+import datetime
+import logging
+import sqlite3
+from typing import Any, Iterable, Optional, Tuple
+
+from eth_keys import keys
+from eth_typing import Hash32, NodeID
+from eth_utils import to_tuple
+
+from ddht.v5_1.alexandria.abc import AdvertisementDatabaseAPI
+from ddht.v5_1.alexandria.payloads import Advertisement
+from ddht.v5_1.alexandria.typing import ContentID
+
+logger = logging.getLogger("ddht.advertisement.sqlite3")
+
+
+ADVERTISEMENT_CREATE_STATEMENT = """CREATE TABLE advertisement (
+    node_id BLOB NOT NULL,
+    content_id BLOB NOT NULL,
+    short_content_id INTEGER NOT NULL,
+    content_key BLOB NOT NULL,
+    hash_tree_root BLOB NOT NULL,
+    signature BLOB UNIQUE NOT NULL PRIMARY KEY,
+    expires_at DATETIME NOT NULL,
+    created_at DATETIME NOT NULL,
+    CONSTRAINT _node_id_length_32 CHECK (length(node_id) == 32),
+    CONSTRAINT _content_id_length_32 CHECK (length(content_id) == 32),
+    CONSTRAINT _content_key_length_lte_160 CHECK (length(content_key) <= 160),
+    CONSTRAINT _hash_tree_root_length_32 CHECK (length(hash_tree_root) == 32),
+    CONSTRAINT _signature_length_65 CHECK (length(signature) == 65)
+)
+"""
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    record_table_exists = (
+        conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+            ("advertisement",),
+        ).fetchone()
+        is not None
+    )
+
+    if record_table_exists:
+        return
+
+    with conn:
+        conn.execute(ADVERTISEMENT_CREATE_STATEMENT)
+        conn.commit()
+
+
+ADVERTISEMENT_INSERT_QUERY = """INSERT INTO advertisement
+    (
+        node_id,
+        content_id,
+        short_content_id,
+        content_key,
+        hash_tree_root,
+        signature,
+        expires_at,
+        created_at
+    )
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+DB_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+def insert_advertisement(
+    conn: sqlite3.Connection, advertisement: Advertisement
+) -> None:
+    with conn:
+        params = (
+            advertisement.node_id,
+            advertisement.content_id,
+            # The high 64 bits of the content id for doing proximate queries
+            int.from_bytes(advertisement.content_id, "big") >> 193,
+            advertisement.content_key,
+            advertisement.hash_tree_root,
+            advertisement.signature.to_bytes(),
+            advertisement.expires_at,
+            datetime.datetime.utcnow().replace(microsecond=0),
+        )
+        conn.execute(ADVERTISEMENT_INSERT_QUERY, params)
+
+
+ADVERTISEMENT_EXISTS_QUERY = """SELECT EXISTS (
+    SELECT 1
+    FROM advertisement
+    WHERE advertisement.signature = ?
+)
+"""
+
+
+def check_advertisement_exists(
+    conn: sqlite3.Connection, signature: keys.Signature
+) -> bool:
+    row = conn.execute(ADVERTISEMENT_EXISTS_QUERY, (signature.to_bytes(),)).fetchone()
+    return row == (1,)  # type: ignore
+
+
+ADVERTISEMENT_GET_BY_SIGNATURE_QUERY = """SELECT
+    advertisement.content_key AS advertisement_content_key,
+    advertisement.hash_tree_root AS advertisement_hash_tree_root,
+    advertisement.signature AS advertisement_signature,
+    advertisement.expires_at AS advertisement_expires_at
+
+    FROM advertisement
+    WHERE advertisement.signature = ?
+    LIMIT 1
+"""
+
+
+class AdvertisementNotFound(Exception):
+    pass
+
+
+def get_advertisement_by_signature(
+    conn: sqlite3.Connection, signature: keys.Signature
+) -> Advertisement:
+    row = conn.execute(
+        ADVERTISEMENT_GET_BY_SIGNATURE_QUERY, (signature.to_bytes(),)
+    ).fetchone()
+    if row is None:
+        raise AdvertisementNotFound(f"No advertisement found: signature={signature}")
+
+    content_key, hash_tree_root, signature_bytes, raw_expires_at = row
+    expires_at = datetime.datetime.strptime(raw_expires_at, DB_DATETIME_FORMAT)
+    signature = keys.Signature(signature_bytes)
+    return Advertisement(
+        content_key, hash_tree_root, expires_at, signature.v, signature.r, signature.s,
+    )
+
+
+DELETE_ADVERTISEMENT_QUERY = (
+    """DELETE FROM advertisement WHERE advertisement.signature = ?"""
+)
+
+
+def delete_advertisement(conn: sqlite3.Connection, signature: keys.Signature) -> bool:
+    cursor = conn.execute(DELETE_ADVERTISEMENT_QUERY, (signature.to_bytes(),))
+    return bool(cursor.rowcount)
+
+
+ADVERTISEMENT_QUERY = """SELECT
+    advertisement.content_key AS advertisement_content_key,
+    advertisement.hash_tree_root AS advertisement_hash_tree_root,
+    advertisement.signature AS advertisement_signature,
+    advertisement.expires_at AS advertisement_expires_at
+
+    FROM advertisement
+    {where_clause}
+"""
+
+
+@to_tuple
+def _build_clauses(
+    node_id: Optional[NodeID],
+    content_id: Optional[ContentID],
+    content_key: Optional[bytes],
+    hash_tree_root: Optional[Hash32],
+) -> Iterable[Tuple[str, Any]]:
+    if node_id is not None:
+        yield "advertisement.node_id == ?", node_id
+    if content_id is not None:
+        yield "advertisement.content_id == ?", content_id
+    if content_key is not None:
+        yield "advertisement_content_key == ?", content_key
+    if hash_tree_root is not None:
+        yield "advertisement_hash_tree_root == ?", hash_tree_root
+
+
+def _build_where_clause(
+    node_id: Optional[NodeID],
+    content_id: Optional[ContentID],
+    content_key: Optional[bytes],
+    hash_tree_root: Optional[Hash32],
+) -> Tuple[str, Tuple[Any, ...]]:
+    if not any((node_id, content_key, content_id, hash_tree_root)):
+        raise Exception("Must provide at least one parameter to filter on")
+
+    clauses_and_params = _build_clauses(
+        node_id, content_id, content_key, hash_tree_root
+    )
+    clauses, params = zip(*clauses_and_params)
+    combined_clauses = " AND ".join(clauses)
+    where_clause = f"WHERE {combined_clauses}"
+    return where_clause, params
+
+
+def query_advertisements(
+    conn: sqlite3.Connection,
+    node_id: Optional[NodeID],
+    content_id: Optional[ContentID],
+    content_key: Optional[bytes],
+    hash_tree_root: Optional[Hash32],
+) -> Iterable[Advertisement]:
+    if any((node_id, content_id, content_key, hash_tree_root)):
+        where_clause, params = _build_where_clause(
+            node_id, content_id, content_key, hash_tree_root
+        )
+        query = ADVERTISEMENT_QUERY.format(where_clause=where_clause)
+    else:
+        query = ADVERTISEMENT_QUERY.format(where_clause="")
+        params = ()
+
+    for row in conn.execute(query, params):
+        ad_content_key, ad_hash_tree_root, signature_bytes, raw_expires_at = row
+
+        expires_at = datetime.datetime.strptime(raw_expires_at, DB_DATETIME_FORMAT)
+        signature = keys.Signature(signature_bytes)
+        yield Advertisement(
+            ad_content_key,
+            ad_hash_tree_root,
+            expires_at,
+            signature.v,
+            signature.r,
+            signature.s,
+        )
+
+
+ADVERTISEMENT_CLOSEST_QUERY = """SELECT
+    advertisement.content_key AS advertisement_content_key,
+    advertisement.hash_tree_root AS advertisement_hash_tree_root,
+    advertisement.signature AS advertisement_signature,
+    advertisement.expires_at AS advertisement_expires_at
+
+    FROM advertisement
+    ORDER BY ((?1 | advertisement.short_content_id) - (?1 & advertisement.short_content_id)) {order}
+"""
+
+
+def get_proximate_advertisements(
+    conn: sqlite3.Connection, node_id: NodeID, reverse: bool
+) -> Iterable[Advertisement]:
+    short_node_id = int.from_bytes(node_id, "big") >> 193
+    query = ADVERTISEMENT_CLOSEST_QUERY.format(order="DESC" if reverse else "")
+    for row in conn.execute(query, (short_node_id,)):
+        content_key, hash_tree_root, signature_bytes, raw_expires_at = row
+
+        expires_at = datetime.datetime.strptime(raw_expires_at, DB_DATETIME_FORMAT)
+        signature = keys.Signature(signature_bytes)
+        yield Advertisement(
+            content_key,
+            hash_tree_root,
+            expires_at,
+            signature.v,
+            signature.r,
+            signature.s,
+        )
+
+
+HASH_TREE_ROOTS_QUERY = """SELECT DISTINCT
+    advertisement.hash_tree_root AS advertisement_hash_tree_root
+
+    FROM advertisement
+    WHERE advertisement.content_id == ?
+"""
+
+
+def get_hash_tree_roots_for_content_id(
+    conn: sqlite3.Connection, content_id: ContentID
+) -> Iterable[Hash32]:
+    for row in conn.execute(HASH_TREE_ROOTS_QUERY, (content_id,)):
+        (hash_tree_root,) = row
+        yield Hash32(hash_tree_root)
+
+
+ADVERTISEMENT_COUNT_QUERY = """SELECT count(*) FROM advertisement"""
+
+
+def get_advertisement_count(conn: sqlite3.Connection) -> int:
+    row = conn.execute(ADVERTISEMENT_COUNT_QUERY).fetchone()
+    (row_count,) = row
+    return row_count  # type: ignore
+
+
+class AdvertisementDatabase(AdvertisementDatabaseAPI):
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        create_tables(conn)
+        self._conn = conn
+
+    def exists(self, advertisement: Advertisement) -> bool:
+        return check_advertisement_exists(self._conn, advertisement.signature)
+
+    def add(self, advertisement: Advertisement) -> None:
+        try:
+            insert_advertisement(self._conn, advertisement)
+        except sqlite3.IntegrityError:
+            # The IntegrityError here could either mean that this advertisement
+            # is already in the database, **or** that one of the fields isn't
+            # valid.  This `exists(...)` check ensures that we only swallow the
+            # exception if the advertisement is not already present.
+            if self.exists(advertisement):
+                pass
+            else:
+                raise
+
+    def remove(self, advertisement: Advertisement) -> bool:
+        return delete_advertisement(self._conn, advertisement.signature)
+
+    def query(
+        self,
+        node_id: Optional[NodeID] = None,
+        content_id: Optional[ContentID] = None,
+        content_key: Optional[bytes] = None,
+        hash_tree_root: Optional[Hash32] = None,
+    ) -> Iterable[Advertisement]:
+        yield from query_advertisements(
+            self._conn, node_id, content_id, content_key, hash_tree_root,
+        )
+
+    def closest(self, node_id: NodeID) -> Iterable[Advertisement]:
+        yield from get_proximate_advertisements(self._conn, node_id, reverse=False)
+
+    def furthest(self, node_id: NodeID) -> Iterable[Advertisement]:
+        yield from get_proximate_advertisements(self._conn, node_id, reverse=True)
+
+    def get_hash_tree_roots_for_content_id(
+        self, content_id: ContentID
+    ) -> Iterable[Hash32]:
+        yield from get_hash_tree_roots_for_content_id(self._conn, content_id)
+
+    def count(self) -> int:
+        return get_advertisement_count(self._conn)
+
+    def expired(self) -> Iterable[Advertisement]:
+        # TODO
+        ...

--- a/tests/core/v5_1/alexandria/conftest.py
+++ b/tests/core/v5_1/alexandria/conftest.py
@@ -1,4 +1,8 @@
+import sqlite3
+
 import pytest
+
+from ddht.v5_1.alexandria.advertisement_db import create_tables
 
 
 @pytest.fixture
@@ -23,3 +27,14 @@ async def alice_alexandria_network(alice, alice_network):
 async def bob_alexandria_network(bob, bob_network):
     async with bob.alexandria.network(bob_network) as bob_alexandria:
         yield bob_alexandria
+
+
+@pytest.fixture
+def base_conn():
+    return sqlite3.connect(":memory:")
+
+
+@pytest.fixture
+def conn(base_conn):
+    create_tables(base_conn)
+    return base_conn

--- a/tests/core/v5_1/alexandria/test_advertisement_db.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_db.py
@@ -1,0 +1,226 @@
+import sqlite3
+
+import pytest
+
+from ddht.kademlia import compute_distance
+from ddht.tools.factories.alexandria import AdvertisementFactory
+from ddht.tools.factories.keys import PrivateKeyFactory
+from ddht.tools.factories.node_id import NodeIDFactory
+from ddht.v5_1.alexandria.advertisement_db import (
+    AdvertisementDatabase,
+    AdvertisementNotFound,
+    check_advertisement_exists,
+    get_advertisement_by_signature,
+    insert_advertisement,
+)
+from ddht.v5_1.alexandria.advertisements import Advertisement
+from ddht.v5_1.alexandria.content import content_key_to_content_id
+
+
+def test_sqlite_insert_and_retrieve_advertisement(conn):
+    advertisement = AdvertisementFactory()
+    with pytest.raises(AdvertisementNotFound):
+        get_advertisement_by_signature(conn, advertisement.signature)
+
+    insert_advertisement(conn, advertisement)
+
+    result = get_advertisement_by_signature(conn, advertisement.signature)
+    assert result == advertisement
+
+
+def test_sqlite_check_advertisement_exists(conn):
+    advertisement = AdvertisementFactory()
+    assert check_advertisement_exists(conn, advertisement.signature) is False
+
+    insert_advertisement(conn, advertisement)
+
+    assert check_advertisement_exists(conn, advertisement.signature) is True
+
+
+def test_sqlite_db_validates_field_lengths(conn):
+    private_key = PrivateKeyFactory()
+    base = AdvertisementFactory(private_key=private_key)
+
+    advertisement_long_content_key = Advertisement.create(
+        content_key=b"\x12" * 161,
+        hash_tree_root=base.hash_tree_root,
+        private_key=private_key,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        insert_advertisement(conn, advertisement_long_content_key)
+
+    advertisement_long_hash_tree_root = Advertisement.create(
+        content_key=base.content_key,
+        hash_tree_root=b"\x12" * 33,
+        private_key=private_key,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        insert_advertisement(conn, advertisement_long_hash_tree_root)
+
+    advertisement_short_hash_tree_root = Advertisement.create(
+        content_key=base.content_key,
+        hash_tree_root=b"\x12" * 31,
+        private_key=private_key,
+    )
+
+    with pytest.raises(sqlite3.IntegrityError):
+        insert_advertisement(conn, advertisement_short_hash_tree_root)
+
+
+@pytest.fixture
+def advertisement_db(conn):
+    return AdvertisementDatabase(conn)
+
+
+def test_advertisement_db_add_exists_and_remove(advertisement_db):
+    advertisement = AdvertisementFactory()
+
+    assert not advertisement_db.exists(advertisement)
+
+    advertisement_db.add(advertisement)
+
+    assert advertisement_db.exists(advertisement)
+
+    assert advertisement_db.remove(advertisement) is True
+
+    assert not advertisement_db.exists(advertisement)
+
+    assert advertisement_db.remove(advertisement) is False
+
+
+def test_advertisement_db_query(advertisement_db):
+    private_key = PrivateKeyFactory()
+    ad_a = AdvertisementFactory(private_key=private_key)
+    # content_key (and content_id)
+    ad_b = AdvertisementFactory(content_key=ad_a.content_key)
+
+    # hash_tree_root
+    ad_c = AdvertisementFactory(hash_tree_root=ad_a.hash_tree_root)
+
+    # node_id
+    ad_d = AdvertisementFactory(private_key=private_key)
+
+    # node_id & content_key
+    ad_e = AdvertisementFactory(private_key=private_key, content_key=ad_a.content_key)
+
+    # node_id & hash_tree_root
+    ad_f = AdvertisementFactory(
+        private_key=private_key, hash_tree_root=ad_a.hash_tree_root
+    )
+
+    # content_key & hash_tree_root
+    ad_g = AdvertisementFactory(
+        hash_tree_root=ad_a.hash_tree_root, content_key=ad_a.content_key,
+    )
+
+    advertisement_db.add(ad_a)
+    advertisement_db.add(ad_b)
+    advertisement_db.add(ad_c)
+    advertisement_db.add(ad_d)
+    advertisement_db.add(ad_e)
+    advertisement_db.add(ad_f)
+    advertisement_db.add(ad_g)
+
+    # should match all records
+    result_a = set(advertisement_db.query())
+    assert result_a == {ad_a, ad_b, ad_c, ad_d, ad_e, ad_f, ad_g}
+
+    # should match all records with the node_id
+    result_b = set(advertisement_db.query(node_id=ad_a.node_id))
+    assert result_b == {ad_a, ad_d, ad_e, ad_f}
+
+    # should match all records with the content_id or content_key
+    result_c = set(advertisement_db.query(content_id=ad_a.content_id))
+    assert result_c == {ad_a, ad_b, ad_e, ad_g}
+
+    result_d = set(advertisement_db.query(content_key=ad_a.content_key))
+    assert result_d == {ad_a, ad_b, ad_e, ad_g}
+
+    # should match all records with the hash_tree_root
+    result_e = set(advertisement_db.query(hash_tree_root=ad_a.hash_tree_root))
+    assert result_e == {ad_a, ad_c, ad_f, ad_g}
+
+    # should match only ad_b
+    result_f = set(advertisement_db.query(node_id=ad_b.node_id))
+    assert result_f == {ad_b}
+
+    # should match only ad_c
+    result_g = set(advertisement_db.query(node_id=ad_c.node_id))
+    assert result_g == {ad_c}
+
+
+def test_advertisement_db_get_closest_and_furthest(advertisement_db):
+    node_id = NodeIDFactory()
+    ads = AdvertisementFactory.create_batch(20)
+
+    for ad in ads:
+        advertisement_db.add(ad)
+
+    expected_closest = tuple(
+        ad
+        for ad in sorted(ads, key=lambda ad: compute_distance(ad.content_id, node_id))
+    )
+
+    actual_closest = tuple(advertisement_db.closest(node_id))
+
+    assert expected_closest == actual_closest
+
+    actual_furthest = tuple(advertisement_db.furthest(node_id))
+
+    expected_furthest = tuple(reversed(expected_closest))
+
+    assert expected_furthest == actual_furthest
+
+
+def test_advertisement_db_get_hash_tree_roots_for_content_id(advertisement_db):
+    content_key = b"\x01testkey"
+    content_id = content_key_to_content_id(content_key)
+
+    hash_tree_root_a = b"\x02" * 32
+    hash_tree_root_b = b"\x03" * 32
+    hash_tree_root_c = b"\x04" * 32
+
+    advertisement_db.add(
+        AdvertisementFactory(content_key=content_key, hash_tree_root=hash_tree_root_a)
+    )
+    advertisement_db.add(
+        AdvertisementFactory(content_key=content_key, hash_tree_root=hash_tree_root_a)
+    )
+    advertisement_db.add(
+        AdvertisementFactory(content_key=content_key, hash_tree_root=hash_tree_root_b)
+    )
+    advertisement_db.add(
+        AdvertisementFactory(content_key=content_key, hash_tree_root=hash_tree_root_b)
+    )
+    advertisement_db.add(
+        AdvertisementFactory(content_key=content_key, hash_tree_root=hash_tree_root_c)
+    )
+    advertisement_db.add(
+        AdvertisementFactory(content_key=content_key, hash_tree_root=hash_tree_root_c)
+    )
+
+    expected = {hash_tree_root_a, hash_tree_root_b, hash_tree_root_c}
+
+    actual = set(advertisement_db.get_hash_tree_roots_for_content_id(content_id))
+
+    assert actual == expected
+
+
+def test_advertisement_db_count_api(advertisement_db):
+    assert advertisement_db.count() == 0
+
+    ad_a = AdvertisementFactory()
+    advertisement_db.add(ad_a)
+
+    assert advertisement_db.count() == 1
+
+    for _ in range(3):
+        advertisement_db.add(AdvertisementFactory())
+
+    assert advertisement_db.count() == 4
+
+    advertisement_db.remove(ad_a)
+
+    assert advertisement_db.count() == 3


### PR DESCRIPTION
This is based on a bunch of other PRs:  #191  #190 #199  #196 #186 

## What was wrong?

We need to store advertisements in a manner that allows for a few different types of queries.

## How was it fixed?

Implemented `AdvertisementDatabaseAPI` which supports persistent storage and retrieval patterns for managing advertisments.


#### Cute Animal Picture

![7532425804_c1bbe4dfa3_z](https://user-images.githubusercontent.com/824194/99572382-cfe7be00-2991-11eb-8b23-a8f62249a62a.jpg)

