### PR TITLE
Implement AdvertisementManagerAPI

### DIFF
--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -58,6 +58,7 @@ class AlexandriaNode(AlexandriaNodeAPI):
         self,
         network: Optional[NetworkAPI] = None,
         bootnodes: Optional[Collection[ENRAPI]] = None,
+        max_advertisement_count: int = 32,
     ) -> AsyncIterator[AlexandriaNetworkAPI]:
         network_context: AsyncContextManager[NetworkAPI]
 
@@ -74,6 +75,7 @@ class AlexandriaNode(AlexandriaNodeAPI):
                     bootnodes=(),
                     content_storage=self.content_storage,
                     advertisement_db=self.advertisement_db,
+                    max_advertisement_count=max_advertisement_count,
                 )
                 async with background_trio_service(alexandria_network):
                     await alexandria_network.ready()

--- a/ddht/tools/factories/alexandria.py
+++ b/ddht/tools/factories/alexandria.py
@@ -1,5 +1,6 @@
 import datetime
 import secrets
+from typing import Any
 
 import factory
 
@@ -39,3 +40,9 @@ class AdvertisementFactory(factory.Factory):  # type: ignore
 
     class Meta:
         model = Advertisement
+
+    @classmethod
+    def expired(cls, **kwargs: Any) -> "Advertisement":
+        assert "expires_at" not in kwargs
+        expires_at = datetime.datetime.utcnow().replace(microsecond=0) - ONE_HOUR
+        return cls(**kwargs, expires_at=expires_at)

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -149,6 +149,24 @@ class AdvertisementDatabaseAPI(ABC):
         ...
 
 
+class AdvertisementManagerAPI(ServiceAPI):
+    @abstractmethod
+    async def ready(self) -> None:
+        ...
+
+    @abstractmethod
+    def check_interest(self, advertisement: Advertisement) -> bool:
+        ...
+
+    @abstractmethod
+    async def validate_advertisement(self, advertisement: Advertisement) -> None:
+        ...
+
+    @abstractmethod
+    async def handle_advertisement(self, advertisement: Advertisement) -> bool:
+        ...
+
+
 class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     network: NetworkAPI
     request_tracker: RequestTrackerAPI
@@ -357,6 +375,7 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
 
     advertisement_db: AdvertisementDatabaseAPI
     advertisement_provider: AdvertisementProviderAPI
+    advertisement_manager: AdvertisementManagerAPI
 
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI
@@ -403,6 +422,12 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     async def bond(
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
     ) -> bool:
+        ...
+
+    @abstractmethod
+    async def lookup_enr(
+        self, node_id: NodeID, *, enr_seq: int = 0, endpoint: Optional[Endpoint] = None
+    ) -> ENRAPI:
         ...
 
     @abstractmethod

--- a/ddht/v5_1/alexandria/advertisement_manager.py
+++ b/ddht/v5_1/alexandria/advertisement_manager.py
@@ -1,0 +1,257 @@
+import logging
+import secrets
+
+from async_service import Service
+from eth_utils import ValidationError
+import ssz
+from ssz.constants import CHUNK_SIZE
+import trio
+
+from ddht.base_message import InboundMessage
+from ddht.v5_1.alexandria.abc import (
+    AdvertisementDatabaseAPI,
+    AdvertisementManagerAPI,
+    AlexandriaNetworkAPI,
+)
+from ddht.v5_1.alexandria.content import compute_content_distance
+from ddht.v5_1.alexandria.content_storage import ContentNotFound
+from ddht.v5_1.alexandria.messages import AdvertiseMessage
+from ddht.v5_1.alexandria.payloads import Advertisement
+from ddht.v5_1.alexandria.sedes import content_sedes
+
+
+class AdvertisementManager(Service, AdvertisementManagerAPI):
+    logger = logging.getLogger("ddht.AdvertisementManager")
+
+    def __init__(
+        self, network: AlexandriaNetworkAPI, advertisement_db: AdvertisementDatabaseAPI,
+    ) -> None:
+        self._network = network
+        self._advertisement_db = advertisement_db
+        self._ready = trio.Event()
+
+    async def run(self) -> None:
+        self.manager.run_daemon_task(self._handle_advertisement_requests)
+
+        await self.manager.wait_finished()
+
+    async def ready(self) -> None:
+        await self._ready.wait()
+
+    async def _handle_advertisement_requests(self) -> None:
+        async with trio.open_nursery() as nursery:
+            async with self._network.client.subscribe(AdvertiseMessage) as subscription:
+                self._ready.set()
+                async for request in subscription:
+                    if not request.message.payload:
+                        continue
+
+                    nursery.start_soon(self._handle_request, request)
+
+    def check_interest(self, advertisement: Advertisement) -> bool:
+        if self._advertisement_db.exists(advertisement):
+            return False
+
+        distance_from_content = compute_content_distance(
+            self._network.local_node_id, advertisement.content_id,
+        )
+        if distance_from_content > self._network.local_advertisement_radius:
+            return False
+
+        return True
+
+    async def validate_advertisement(self, advertisement: Advertisement) -> None:
+        if not advertisement.is_valid:
+            raise ValidationError(
+                f"Advertisement has invalid signature: signature={advertisement.signature}"
+            )
+
+        if advertisement.is_expired:
+            raise ValidationError(
+                f"Advertisement expired: advertisement={advertisement}"
+            )
+
+        if self._advertisement_db.exists(advertisement):
+            raise ValidationError(
+                f"Advertisement already known: advertisement={advertisement}"
+            )
+
+        # Verify that the `hash_tree_root` matches the known roots.
+        known_hash_tree_roots = set(
+            self._advertisement_db.get_hash_tree_roots_for_content_id(
+                advertisement.content_id
+            )
+        )
+        if len(known_hash_tree_roots) > 1:
+            self.logger.error(
+                "Multiple hash tree roots found: content_id=%s  roots=%s",
+                advertisement.content_id.hex(),
+                known_hash_tree_roots,
+            )
+
+        if (
+            known_hash_tree_roots
+            and advertisement.hash_tree_root not in known_hash_tree_roots
+        ):
+            # TODO: perform full validation of the content to determine the
+            # correct root.
+            raise NotImplementedError("TODO: resolve disccrepancy")
+
+        if advertisement.node_id == self._network.local_node_id:
+            await self._validate_local_advertisement(advertisement)
+        else:
+            await self._validate_remote_advertisement(advertisement)
+
+    async def _validate_local_advertisement(self, advertisement: Advertisement) -> None:
+        if not advertisement.node_id == self._network.local_node_id:
+            raise Exception(
+                "Must be called with an advertisement signed by the local node"
+            )
+
+        try:
+            content = self._network.content_storage.get_content(
+                advertisement.content_key
+            )
+        except ContentNotFound as err:
+            raise ValidationError(
+                f"Content not found: advertisement={advertisement}"
+            ) from err
+
+        hash_tree_root = ssz.get_hash_tree_root(content, sedes=content_sedes)
+
+        if hash_tree_root != advertisement.hash_tree_root:
+            raise ValidationError(
+                f"Mismatched roots: local={hash_tree_root.hex()}  "
+                f"advertisement={advertisement.hash_tree_root.hex}"
+            )
+
+    async def _validate_remote_advertisement(
+        self, advertisement: Advertisement
+    ) -> None:
+        """
+        - valid signature
+        - not expired
+        - within local advertisement radius
+        - node is reachable
+        - proof of custody check
+        """
+        # Verify the liveliness of the node this advertisement is for.
+        did_bond = await self._network.bond(advertisement.node_id)
+        if not did_bond:
+            raise ValidationError(
+                f"Advertisement failed liveliness check: node_id={advertisement.node_id.hex()}"
+            )
+
+        # Perform a proof of custody check
+        try:
+            base_proof = await self._network.get_content_proof(
+                advertisement.node_id,
+                hash_tree_root=advertisement.hash_tree_root,
+                content_key=advertisement.content_key,
+                start_chunk_index=0,
+                max_chunks=2,
+            )
+        except trio.TooSlowError:
+            raise ValidationError(
+                f"Initial proof retrieval failed: advertisement={advertisement}"
+            )
+
+        if not base_proof.is_complete:
+            content_length = base_proof.get_content_length()
+            chunk_count = (content_length + 31) // CHUNK_SIZE
+            if chunk_count > 2:
+                # We avoid fetching the first two chunks since we already have
+                # them from the initial proof.
+                chunk_to_request = secrets.randbelow(chunk_count - 2) + 2
+                if not base_proof.has_chunk(chunk_to_request):
+                    try:
+                        custody_proof = await self._network.get_content_proof(
+                            advertisement.node_id,
+                            hash_tree_root=advertisement.hash_tree_root,
+                            content_key=advertisement.content_key,
+                            start_chunk_index=chunk_to_request,
+                            max_chunks=2,
+                        )
+                    except trio.TooSlowError:
+                        raise ValidationError(
+                            f"Proof of custody check failed: "
+                            f"advertisement={advertisement}"
+                        )
+                    else:
+                        if not custody_proof.has_chunk(chunk_to_request):
+                            # Failed proof of custody check
+                            raise ValidationError(
+                                f"Proof of custody check failed: "
+                                f"advertisement={advertisement}"
+                            )
+
+    async def handle_advertisement(self, advertisement: Advertisement) -> bool:
+        try:
+            await self.validate_advertisement(advertisement)
+        except ValidationError as err:
+            self.logger.debug(
+                "Advertisement failed validation: advertisement=%s err=%s",
+                advertisement,
+                err,
+            )
+            return False
+        else:
+            self._advertisement_db.add(advertisement)
+            await self._network.broadcast(advertisement)
+            return True
+
+    async def _handle_request(self, request: InboundMessage[AdvertiseMessage]) -> None:
+        """
+        Process the advertisements.
+
+        Each advertisement goes through this process:
+
+        - If already present we assume validity
+        - Otherwise validate:
+            - Bond with node to check liveliness
+            - Check `content_key/hash_tree_root` against existing database entries.
+                - If there is a discrepancy we must determine canonical `hash_tree_root`.
+            - Proof of custody check.
+                - Request random chunk(s) of the data and verify against `hash_tree_root`
+
+        Once validated:
+
+        - Broadcast advertisement to logarithmic subset of peers for which the
+          advertisement falls within their ad radius
+        """
+        if not all(ad.is_valid for ad in request.message.payload):
+            # TODO: this is a place where we should consider blacklisting
+            self.logger.debug(
+                "Invalid advertisements: from=%s  advertisements=%s",
+                request.sender_node_id.hex(),
+                request.message.payload,
+            )
+            return
+
+        if any(ad.is_expired for ad in request.message.payload):
+            self.logger.debug(
+                "Expired advertisements: from=%s  advertisements=%s",
+                request.sender_node_id.hex(),
+                request.message.payload,
+            )
+            return
+
+        # We Ack
+        message_has_interesting_ads = all(
+            self.check_interest(advertisement)
+            for advertisement in request.message.payload
+        )
+        if message_has_interesting_ads:
+            await self._network.client.send_ack(
+                request.sender_node_id,
+                request.sender_endpoint,
+                advertisement_radius=self._network.local_advertisement_radius,
+                request_id=request.request_id,
+            )
+
+        for advertisement in request.message.payload:
+            # Log the advertisements on the way in so that we don't try to
+            # rebroadcast back to this node.
+            self._network.broadcast_log.log(request.sender_node_id, advertisement)
+
+            await self.handle_advertisement(advertisement)

--- a/ddht/v5_1/alexandria/radius_tracker.py
+++ b/ddht/v5_1/alexandria/radius_tracker.py
@@ -35,7 +35,7 @@ class RadiusTracker(Service, RadiusTrackerAPI):
 
     async def get_advertisement_radius(self, node_id: NodeID) -> int:
         if node_id == self._network.local_node_id:
-            raise Exception("Cannot query local node id")
+            return self._network.local_advertisement_radius
         elif node_id in self._node_ad_radius:
             return self._node_ad_radius[node_id]
         else:

--- a/tests/core/v5_1/alexandria/test_advertisement_manager.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_manager.py
@@ -1,0 +1,376 @@
+from eth_utils import ValidationError
+import pytest
+import trio
+
+from ddht.tools.factories.alexandria import AdvertisementFactory
+from ddht.tools.factories.content import ContentFactory
+from ddht.tools.factories.keys import PrivateKeyFactory
+from ddht.v5_1.alexandria.content import compute_content_distance
+from ddht.v5_1.alexandria.messages import GetContentMessage
+from ddht.v5_1.alexandria.partials.proof import compute_proof
+from ddht.v5_1.alexandria.sedes import content_sedes
+
+
+#
+# AdvertisementManagerAPI.check_interest
+#
+@pytest.mark.trio
+async def test_advertisement_manager_check_interest_already_in_db(
+    bob, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+
+    advertisement = AdvertisementFactory(private_key=PrivateKeyFactory())
+    alice_alexandria_network.advertisement_db.add(advertisement)
+
+    assert ad_manager.check_interest(advertisement) is False
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_check_interest_outside_radius(
+    alice, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement_db = alice_alexandria_network.advertisement_db
+    assert alice_alexandria_network.max_advertisement_count <= 32
+
+    advertisements = tuple(
+        sorted(
+            (
+                AdvertisementFactory()
+                for _ in range(alice_alexandria_network.max_advertisement_count + 1)
+            ),
+            key=lambda ad: compute_content_distance(ad.content_id, alice.node_id),
+        )
+    )
+    furthest = advertisements[-1]
+
+    assert alice_alexandria_network.local_advertisement_radius == 2 ** 256 - 1
+    assert ad_manager.check_interest(furthest) is True
+
+    for ad in advertisements[: alice_alexandria_network.max_advertisement_count]:
+        advertisement_db.add(ad)
+
+    expected_radius = compute_content_distance(
+        advertisements[-2].content_id, alice.node_id
+    )
+    assert expected_radius < 2 ** 256 - 1
+
+    assert alice_alexandria_network.local_advertisement_radius == expected_radius
+    assert ad_manager.check_interest(furthest) is False
+
+
+#
+# Generic validation checks
+#
+@pytest.mark.trio
+async def test_advertisement_manager_validate_already_in_database(
+    alice, bob, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(private_key=bob.private_key)
+    alice_alexandria_network.advertisement_db.add(advertisement)
+
+    with pytest.raises(ValidationError, match="known"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_invalid_signature(
+    alice, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(
+        signature_v=1, signature_r=1357924680, signature_s=2468013579,
+    )
+
+    with pytest.raises(ValidationError, match="signature"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_unknown_node_id(
+    alice, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+
+    with pytest.raises(ValidationError, match="liveliness"):
+        await ad_manager.validate_advertisement(AdvertisementFactory())
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_mismatched_hash_tree_roots(
+    alice, bob, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+
+    advertisement_a = AdvertisementFactory(private_key=bob.private_key)
+    advertisement_b = AdvertisementFactory(
+        private_key=bob.private_key, content_key=advertisement_a.content_key,
+    )
+    assert advertisement_a.hash_tree_root != advertisement_b.hash_tree_root
+
+    advertisement_db = alice_alexandria_network.advertisement_db
+
+    advertisement_db.add(advertisement_a)
+
+    with pytest.raises(NotImplementedError):
+        await ad_manager.validate_advertisement(advertisement_b)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_multiple_mismatched_hash_tree_roots(
+    alice, bob, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+
+    advertisement_a = AdvertisementFactory(private_key=bob.private_key)
+    advertisement_b = AdvertisementFactory(
+        private_key=bob.private_key, content_key=advertisement_a.content_key,
+    )
+    advertisement_c = AdvertisementFactory(
+        private_key=bob.private_key, content_key=advertisement_a.content_key,
+    )
+
+    assert advertisement_a.hash_tree_root != advertisement_b.hash_tree_root
+    assert advertisement_b.hash_tree_root != advertisement_c.hash_tree_root
+
+    advertisement_db = alice_alexandria_network.advertisement_db
+
+    advertisement_db.add(advertisement_a)
+    advertisement_db.add(advertisement_b)
+
+    with pytest.raises(NotImplementedError):
+        await ad_manager.validate_advertisement(advertisement_c)
+
+
+#
+# Validation checks against *remote* ads
+#
+@pytest.mark.trio
+async def test_advertisement_manager_validate_remote_expired(
+    alice, bob, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory.expired(private_key=bob.private_key)
+
+    with pytest.raises(ValidationError, match="expired"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_remote_node_unreachable(
+    alice, bob, alice_alexandria_network, autojump_clock
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(private_key=bob.private_key)
+
+    with pytest.raises(ValidationError, match="liveliness"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_remote_fail_initial_proof_check(
+    alice, bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(private_key=bob.private_key)
+
+    with pytest.raises(ValidationError, match="proof retrieval"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_remote_fail_custody_proof_check(
+    alice, bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+
+    async with bob_alexandria_network.client.subscribe(
+        GetContentMessage
+    ) as subscription:
+        did_serve_initial_proof = False
+
+        async with trio.open_nursery() as nursery:
+            did_serve_initial_proof = True
+
+            async def _respond():
+                request = await subscription.receive()
+                partial = proof.to_partial(0, 64)
+                await bob_alexandria_network.client.send_content(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    is_proof=True,
+                    payload=partial.serialize(),
+                    request_id=request.request_id,
+                )
+
+            nursery.start_soon(_respond)
+
+            with pytest.raises(ValidationError, match="Proof of custody check failed"):
+                await ad_manager.validate_advertisement(advertisement)
+
+            assert did_serve_initial_proof is True
+
+
+#
+# Validation checks against *local* ads
+#
+@pytest.mark.trio
+async def test_advertisement_manager_validate_local_expired(
+    alice, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory.expired(private_key=alice.private_key)
+
+    with pytest.raises(ValidationError, match="expired"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_local_content_not_found(
+    alice, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(private_key=alice.private_key)
+
+    content_storage = alice_alexandria_network.content_storage
+    assert not content_storage.has_content(advertisement.content_key)
+
+    with pytest.raises(ValidationError, match="not found"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_validate_local_hash_tree_root_mismatch(
+    alice, alice_alexandria_network,
+):
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(private_key=alice.private_key)
+
+    content_storage = alice_alexandria_network.content_storage
+    content_storage.set_content(advertisement.content_key, ContentFactory())
+
+    with pytest.raises(ValidationError, match="Mismatched roots"):
+        await ad_manager.validate_advertisement(advertisement)
+
+
+#
+# Tests against actual handling
+#
+@pytest.mark.trio
+async def test_advertisement_manager_handle_new_valid_local_advertisement(
+    alice, alice_alexandria_network, bob_alexandria_network,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(
+        private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    alice_alexandria_network.content_storage.set_content(
+        advertisement.content_key, content,
+    )
+
+    assert not alice_alexandria_network.advertisement_db.exists(advertisement)
+
+    with trio.fail_after(2):
+        await ad_manager.handle_advertisement(advertisement)
+
+    assert alice_alexandria_network.advertisement_db.exists(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_handle_new_valid_remote_advertisement(
+    alice, bob, alice_alexandria_network, bob_alexandria_network,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    bob_alexandria_network.content_storage.set_content(
+        advertisement.content_key, content,
+    )
+
+    assert not alice_alexandria_network.advertisement_db.exists(advertisement)
+
+    with trio.fail_after(2):
+        await ad_manager.handle_advertisement(advertisement)
+
+    assert alice_alexandria_network.advertisement_db.exists(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_handle_existing_valid_local_advertisement(
+    alice, alice_alexandria_network, bob_alexandria_network,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(
+        private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    alice_alexandria_network.content_storage.set_content(
+        advertisement.content_key, content,
+    )
+    alice_alexandria_network.advertisement_db.add(advertisement)
+
+    assert alice_alexandria_network.advertisement_db.exists(advertisement)
+
+    with trio.fail_after(2):
+        await ad_manager.handle_advertisement(advertisement)
+
+    assert alice_alexandria_network.advertisement_db.exists(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_manager_handle_existing_valid_remote_advertisement(
+    alice, bob, alice_alexandria_network, bob_alexandria_network,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_manager = alice_alexandria_network.advertisement_manager
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    bob_alexandria_network.content_storage.set_content(
+        advertisement.content_key, content,
+    )
+    alice_alexandria_network.advertisement_db.add(advertisement)
+
+    assert alice_alexandria_network.advertisement_db.exists(advertisement)
+
+    with trio.fail_after(2):
+        await ad_manager.handle_advertisement(advertisement)
+
+    assert alice_alexandria_network.advertisement_db.exists(advertisement)
+
+
+#
+# Actual request handling
+#
+@pytest.mark.trio
+async def test_advertisement_manager_does_not_ack_if_advertisements_already_known(
+    alice, bob, alice_alexandria_client, bob_alexandria_network, autojump_clock,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    bob_alexandria_network.content_storage.set_content(
+        advertisement.content_key, content,
+    )
+    bob_alexandria_network.advertisement_db.add(advertisement)
+
+    with pytest.raises(trio.TooSlowError):
+        await alice_alexandria_client.advertise(
+            bob.node_id, bob.endpoint, advertisements=(advertisement,),
+        )


### PR DESCRIPTION
## What was wrong?

When we receive an Advertisement it needs to be processed in accordance with the rules set out in the specification to both validate it, **and** to re-broadcast it to the other nodes that may be interested in it.

## How was it fixed?

Implemented `AdvertisementManagerAPI` which listens for incoming advertisements and runs them through the various validation checks prior to re-broadcasting them to peers.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
