### PR TITLE
Implement RadiusTracker

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -85,6 +85,16 @@ class ContentProviderAPI(ServiceAPI):
         ...
 
 
+class RadiusTrackerAPI(ServiceAPI):
+    @abstractmethod
+    async def ready(self) -> None:
+        ...
+
+    @abstractmethod
+    async def get_advertisement_radius(self, node_id: NodeID) -> int:
+        ...
+
+
 class AdvertisementDatabaseAPI(ABC):
     @abstractmethod
     def exists(self, advertisement: Advertisement) -> bool:
@@ -300,6 +310,8 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     routing_table: RoutingTableAPI
 
     max_advertisement_count: int
+
+    radius_tracker: RadiusTrackerAPI
 
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -31,6 +31,7 @@ from ddht.v5_1.alexandria.partials._utils import get_chunk_count_for_data_length
 from ddht.v5_1.alexandria.partials.chunking import slice_segments_to_max_chunk_count
 from ddht.v5_1.alexandria.partials.proof import Proof, compute_proof, validate_proof
 from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
+from ddht.v5_1.alexandria.radius_tracker import RadiusTracker
 from ddht.v5_1.alexandria.resource_queue import ResourceQueue
 from ddht.v5_1.alexandria.sedes import content_sedes
 from ddht.v5_1.alexandria.typing import ContentKey
@@ -71,6 +72,8 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
 
         self.client = AlexandriaClient(network)
 
+        self.radius_tracker = RadiusTracker(self)
+
         self.routing_table = KademliaRoutingTable(
             self.enr_manager.enr.node_id, ROUTING_TABLE_BUCKET_SIZE,
         )
@@ -104,6 +107,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
     async def run(self) -> None:
         self.manager.run_daemon_child_service(self.client)
         self.manager.run_daemon_child_service(self.content_provider)
+        self.manager.run_daemon_child_service(self.radius_tracker)
 
         # Long running processes
         self.manager.run_daemon_task(self._periodically_report_routing_table)

--- a/ddht/v5_1/alexandria/radius_tracker.py
+++ b/ddht/v5_1/alexandria/radius_tracker.py
@@ -1,0 +1,67 @@
+import logging
+from typing import Dict
+
+from async_service import Service
+from eth_typing import NodeID
+from lru import LRU
+import trio
+
+from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI, RadiusTrackerAPI
+from ddht.v5_1.alexandria.messages import AckMessage, PingMessage, PongMessage
+
+
+class RadiusTracker(Service, RadiusTrackerAPI):
+    logger = logging.getLogger("ddht.RadiusTracker")
+
+    def __init__(self, network: AlexandriaNetworkAPI) -> None:
+        self._network = network
+        self._node_ad_radius: Dict[NodeID, int] = LRU(8129)  # ~ 0.5 mb
+
+        self._ack_ready = trio.Event()
+        self._ping_ready = trio.Event()
+        self._pong_ready = trio.Event()
+
+    async def run(self) -> None:
+        self.manager.run_daemon_task(self._track_radius_from_ping)
+        self.manager.run_daemon_task(self._track_radius_from_pong)
+        self.manager.run_daemon_task(self._track_radius_from_ack)
+
+        await self.manager.wait_finished()
+
+    async def ready(self) -> None:
+        await self._ack_ready.wait()
+        await self._ping_ready.wait()
+        await self._pong_ready.wait()
+
+    async def get_advertisement_radius(self, node_id: NodeID) -> int:
+        if node_id == self._network.local_node_id:
+            raise Exception("Cannot query local node id")
+        elif node_id in self._node_ad_radius:
+            return self._node_ad_radius[node_id]
+        else:
+            pong = await self._network.ping(node_id)
+            return pong.advertisement_radius
+
+    async def _track_radius_from_ping(self) -> None:
+        async with self._network.client.subscribe(PingMessage) as subscription:
+            self._ping_ready.set()
+
+            async for request in subscription:
+                radius = request.message.payload.advertisement_radius
+                self._node_ad_radius[request.sender_node_id] = radius
+
+    async def _track_radius_from_pong(self) -> None:
+        async with self._network.client.subscribe(PongMessage) as subscription:
+            self._pong_ready.set()
+
+            async for response in subscription:
+                radius = response.message.payload.advertisement_radius
+                self._node_ad_radius[response.sender_node_id] = radius
+
+    async def _track_radius_from_ack(self) -> None:
+        async with self._network.client.subscribe(AckMessage) as subscription:
+            self._ack_ready.set()
+
+            async for response in subscription:
+                radius = response.message.payload.advertisement_radius
+                self._node_ad_radius[response.sender_node_id] = radius

--- a/tests/core/test_core_rpc_handlers.py
+++ b/tests/core/test_core_rpc_handlers.py
@@ -44,7 +44,9 @@ async def rpc_server(ipc_path, routing_table, enr_manager):
 
 @pytest.fixture
 def w3(rpc_server, ipc_path):
-    return Web3(IPCProvider(ipc_path), modules={"discv5": (DiscoveryV5Module,)})
+    return Web3(
+        IPCProvider(ipc_path, timeout=30), modules={"discv5": (DiscoveryV5Module,)}
+    )
 
 
 @pytest.mark.trio

--- a/tests/core/v5_1/alexandria/test_radius_tracker.py
+++ b/tests/core/v5_1/alexandria/test_radius_tracker.py
@@ -1,0 +1,143 @@
+from async_service import background_trio_service
+import pytest
+import trio
+
+from ddht.tools.factories.alexandria import AdvertisementFactory
+from ddht.v5_1.alexandria.messages import AdvertiseMessage, PingMessage
+from ddht.v5_1.alexandria.radius_tracker import RadiusTracker
+
+
+@pytest.mark.trio
+async def test_radius_tracker_fetches_radius_when_unknown(
+    alice, bob, alice_alexandria_network, bob_alexandria_client
+):
+    radius_tracker = RadiusTracker(alice_alexandria_network)
+
+    async with bob_alexandria_client.subscribe(PingMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+            did_respond = trio.Event()
+
+            async def _respond():
+                request = await subscription.receive()
+                await bob_alexandria_client.send_pong(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    enr_seq=bob.enr.sequence_number,
+                    advertisement_radius=1234,
+                    request_id=request.request_id,
+                )
+                did_respond.set()
+
+            nursery.start_soon(_respond)
+
+            async with background_trio_service(radius_tracker):
+                await radius_tracker.ready()
+
+                with trio.fail_after(2):
+                    advertisement_radius = await radius_tracker.get_advertisement_radius(
+                        bob.node_id,
+                    )
+
+                    assert advertisement_radius == 1234
+
+                    await did_respond.wait()
+
+
+@pytest.mark.trio
+async def test_radius_tracker_tracks_via_ping(
+    alice, bob, alice_alexandria_network, bob_alexandria_client
+):
+    radius_tracker = RadiusTracker(alice_alexandria_network)
+
+    bob.enr_db.set_enr(alice.enr)
+
+    async with background_trio_service(radius_tracker):
+        await radius_tracker.ready()
+
+        await bob_alexandria_client.ping(
+            alice.node_id, alice.endpoint, enr_seq=0, advertisement_radius=1234,
+        )
+
+        with trio.fail_after(2):
+            advertisement_radius = await radius_tracker.get_advertisement_radius(
+                bob.node_id,
+            )
+
+            assert advertisement_radius == 1234
+
+
+@pytest.mark.trio
+async def test_radius_tracker_tracks_via_pong(
+    alice, bob, alice_alexandria_network, bob_alexandria_client
+):
+    radius_tracker = RadiusTracker(alice_alexandria_network)
+
+    async with bob_alexandria_client.subscribe(PingMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+            did_respond = trio.Event()
+
+            async def _respond():
+                request = await subscription.receive()
+                await bob_alexandria_client.send_pong(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    enr_seq=bob.enr.sequence_number,
+                    advertisement_radius=1234,
+                    request_id=request.request_id,
+                )
+                did_respond.set()
+
+            nursery.start_soon(_respond)
+
+            async with background_trio_service(radius_tracker):
+                await radius_tracker.ready()
+
+                await alice_alexandria_network.ping(bob.node_id,)
+
+                with trio.fail_after(2):
+                    advertisement_radius = await radius_tracker.get_advertisement_radius(
+                        bob.node_id,
+                    )
+
+                    assert advertisement_radius == 1234
+
+                    await did_respond.wait()
+
+
+@pytest.mark.trio
+async def test_radius_tracker_tracks_via_ack(
+    alice, bob, alice_alexandria_network, bob_alexandria_client
+):
+    radius_tracker = RadiusTracker(alice_alexandria_network)
+
+    async with bob_alexandria_client.subscribe(AdvertiseMessage) as subscription:
+        async with trio.open_nursery() as nursery:
+            did_respond = trio.Event()
+
+            async def _respond():
+                request = await subscription.receive()
+                await bob_alexandria_client.send_ack(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    advertisement_radius=1234,
+                    request_id=request.request_id,
+                )
+                did_respond.set()
+
+            nursery.start_soon(_respond)
+
+            async with background_trio_service(radius_tracker):
+                await radius_tracker.ready()
+
+                await alice_alexandria_network.advertise(
+                    bob.node_id, advertisements=(AdvertisementFactory(),),
+                )
+
+                with trio.fail_after(2):
+                    advertisement_radius = await radius_tracker.get_advertisement_radius(
+                        bob.node_id,
+                    )
+
+                    assert advertisement_radius == 1234
+
+                    await did_respond.wait()

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -41,7 +41,9 @@ async def rpc_server(ipc_path, alice):
 
 @pytest.fixture
 def w3(rpc_server, ipc_path):
-    return Web3(IPCProvider(ipc_path), modules={"discv5": (DiscoveryV5Module,)})
+    return Web3(
+        IPCProvider(ipc_path, timeout=30), modules={"discv5": (DiscoveryV5Module,)}
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
depends on #185 #239 #200 #198 #190 

## What was wrong?

In order to conform to the network rules for advertisement gossip we need to keep track of the advertisement radius of the other nodes on the network.

## How was it fixed?

Implement `RadiusTrackerAPI` which is a service that runs under the `AlexandriaNetworkAPI` which tracks the three messages which include the advertisement radius (Ping, Pong, Ack) and exposes and API for querying the radius of a node on the network.


#### Cute Animal Picture

![file01-11-2017-ykjmecjib5k](https://user-images.githubusercontent.com/824194/99578543-37097080-299a-11eb-82b0-0452191ad819.jpg)

