### PR TITLE
Handle OldSequenceNumber exception in NetworkAPI.lookup_enr

### DIFF
--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -383,7 +383,10 @@ class Network(Service, NetworkAPI):
                 return enr
 
         enr = await self._fetch_enr(node_id, endpoint=endpoint)
-        self.enr_db.set_enr(enr)
+        try:
+            self.enr_db.set_enr(enr)
+        except OldSequenceNumber:
+            pass
 
         return enr
 


### PR DESCRIPTION
## What was wrong?

```
Traceback (most recent call last):
  File "/home/piper/python-environments/ddht/bin/ddht", line 33, in <module>
    sys.exit(load_entry_point('ddht', 'console_scripts', 'ddht')())
  File "/home/piper/projects/ddht/ddht/_boot.py", line 59, in _boot
    trio.run(manager.run)
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/trio/_core/_run.py", line 1896, in run
    raise runner.main_task_outcome.error
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/trio.py", line 205, in run
    raise trio.MultiError(
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/base.py", line 324, in _run_and_manage_task
    await task.run()
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/trio.py", line 76, in run
    await self._async_fn(*self._async_fn_args)
  File "/home/piper/projects/ddht/ddht/_boot.py", line 27, in run
    await _main()
  File "/home/piper/projects/ddht/ddht/_boot.py", line 13, in _main
    await main()
  File "/home/piper/projects/ddht/ddht/main.py", line 54, in main
    await args.func(args, boot_info)
  File "/home/piper/projects/ddht/ddht/cli_commands.py", line 28, in do_main
    await manager.wait_finished()
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_generator/_util.py", line 42, in __aexit__
    await self._agen.asend(None)
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/trio.py", line 411, in background_trio_service
    await manager.stop()
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/trio/_core/_run.py", line 741, in __aexit__
    raise combined_error_from_nursery
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/trio.py", line 205, in run
    raise trio.MultiError(
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/base.py", line 324, in _run_and_manage_task
    await task.run()
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/base.py", line 169, in run
    await self.child_manager.run()
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/trio.py", line 205, in run
    raise trio.MultiError(
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/base.py", line 324, in _run_and_manage_task
    await task.run()
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/async_service/trio.py", line 76, in run
    await self._async_fn(*self._async_fn_args)
  File "/home/piper/projects/ddht/ddht/v5_1/network.py", line 514, in _manage_routing_table
    nursery.start_soon(self._bond, enr.node_id, endpoint)
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/trio/_core/_run.py", line 741, in __aexit__
    raise combined_error_from_nursery
  File "/home/piper/projects/ddht/ddht/v5_1/network.py", line 293, in _bond
    await self.bond(node_id, endpoint=endpoint)
  File "/home/piper/projects/ddht/ddht/v5_1/network.py", line 268, in bond
    enr = await self.lookup_enr(
  File "/home/piper/projects/ddht/ddht/v5_1/network.py", line 386, in lookup_enr
    self.enr_db.set_enr(enr)
  File "/home/piper/python-environments/ddht/lib/python3.8/site-packages/eth_enr/enr_db.py", line 50, in set_enr
    raise OldSequenceNumber(
eth_enr.exceptions.OldSequenceNumber: Cannot overwrite existing ENR (4) with old one (1)
```

## How was it fixed?

In this case we can simply catch and silence the exception.

#### Cute Animal Picture

![racoon-tank](https://user-images.githubusercontent.com/824194/99584103-be0e1700-29a1-11eb-9a98-09039abfaf1d.jpg)

