### PR TITLE
Add LRU dict to store sessions in a pool

### DIFF
--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -99,6 +99,9 @@ network_parser.add_argument(
 network_parser.add_argument(
     "--listen-address", type=ipaddress.ip_address, help="IP address to listen on"
 )
+network_parser.add_argument(
+    "--session-cache-size", default=1024, type=int, help="Max number of active sessions"
+)
 
 bootnodes_parser_group = network_parser.add_mutually_exclusive_group()
 bootnodes_parser_group.add_argument(

--- a/ddht/tools/driver/node.py
+++ b/ddht/tools/driver/node.py
@@ -62,6 +62,7 @@ class Node(NodeAPI):
                 local_private_key=self.private_key,
                 listen_on=self.endpoint,
                 enr_db=self.enr_db,
+                session_cache_size=1024,
                 events=self.events,
             )
             async with background_trio_service(client):
@@ -77,6 +78,7 @@ class Node(NodeAPI):
                 local_private_key=self.private_key,
                 listen_on=self.endpoint,
                 enr_db=self.enr_db,
+                session_cache_size=1024,
                 events=self.events,
             )
             network = Network(client, bootnodes)

--- a/ddht/tools/driver/tester.py
+++ b/ddht/tools/driver/tester.py
@@ -93,6 +93,7 @@ class Tester(TesterAPI):
                 enr_db=node.enr_db,
                 outbound_envelope_send_channel=channels.outbound_envelope_send_channel,
                 inbound_message_send_channel=channels.inbound_message_send_channel,
+                session_cache_size=1024,
                 events=node.events,
             )
             self._pools[node.node_id] = PoolAndChannels(pool, channels)

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -98,11 +98,6 @@ class SessionAPI(ABC):
     def timeout_at(self) -> float:
         ...
 
-    @property
-    @abstractmethod
-    def last_message_received_at(self) -> float:
-        ...
-
     #
     # Handshake Status
     #

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -109,6 +109,7 @@ class Application(BaseApplication):
             local_private_key=local_private_key,
             listen_on=listen_on,
             enr_db=enr_db,
+            session_cache_size=self._args.session_cache_size,
             events=events,
             message_type_registry=message_type_registry,
         )

--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -53,6 +53,7 @@ class Client(Service, ClientAPI):
         local_private_key: keys.PrivateKey,
         listen_on: Endpoint,
         enr_db: QueryableENRDatabaseAPI,
+        session_cache_size: int,
         events: EventsAPI = None,
         message_type_registry: MessageTypeRegistry = v51_registry,
     ) -> None:
@@ -107,6 +108,7 @@ class Client(Service, ClientAPI):
             enr_db=self.enr_db,
             outbound_envelope_send_channel=self._outbound_envelope_send_channel,
             inbound_message_send_channel=self._inbound_message_send_channel,
+            session_cache_size=session_cache_size,
             message_type_registry=self._registry,
             events=self.events,
         )

--- a/ddht/v5_1/dispatcher.py
+++ b/ddht/v5_1/dispatcher.py
@@ -148,7 +148,7 @@ class Dispatcher(Service, DispatcherAPI):
         self.manager.run_daemon_task(
             self._handle_outbound_messages, self._outbound_message_receive_channel,
         )
-        self.manager.run_daemon_task(self._monitor_hanshake_completions)
+        self.manager.run_daemon_task(self._monitor_handshake_completions)
         await self.manager.wait_finished()
 
     async def _handle_inbound_envelopes(
@@ -235,7 +235,7 @@ class Dispatcher(Service, DispatcherAPI):
     #
     # Session Management
     #
-    async def _monitor_hanshake_completions(self) -> None:
+    async def _monitor_handshake_completions(self) -> None:
         """
         Ensure that we only ever have one fully handshaked session for any
         given endpoint/node-id.  Anytime we find a duplicate sessions exists we

--- a/ddht/v5_1/pool.py
+++ b/ddht/v5_1/pool.py
@@ -33,6 +33,7 @@ class Pool(PoolAPI):
         enr_db: ENRDatabaseAPI,
         outbound_envelope_send_channel: trio.abc.SendChannel[OutboundEnvelope],
         inbound_message_send_channel: trio.abc.SendChannel[AnyInboundMessage],
+        session_cache_size: int,
         message_type_registry: MessageTypeRegistry = v51_registry,
         events: EventsAPI = None,
     ) -> None:
@@ -46,7 +47,7 @@ class Pool(PoolAPI):
             events = Events()
         self._events = events
 
-        self._sessions = LRU(128, callback=self._evict_session)
+        self._sessions = LRU(session_cache_size, callback=self._evict_session)
         self._sessions_by_endpoint = collections.defaultdict(set)
 
         self._outbound_packet_send_channel = outbound_envelope_send_channel

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -51,23 +51,6 @@ class BaseSession(SessionAPI):
     _last_message_received_at: float
     _handshake_scheme_registry: HandshakeSchemeRegistryAPI = v51_handshake_scheme_registry
 
-    __slots__ = (
-        "_enr_db",
-        "_events",
-        "_inbound_message_send_channel",
-        "_local_node_id",
-        "_local_private_key",
-        "_message_type_registry",
-        "_nonce_counter",
-        "_outbound_envelope_send_channel",
-        "_outbound_message_buffer_receive_channel",
-        "_outbound_message_buffer_send_channel",
-        "_status",
-        "created_at",
-        "id",
-        "remote_endpoint",
-    )
-
     def __init__(
         self,
         local_private_key: bytes,
@@ -232,8 +215,6 @@ class EmptyMessage(BaseMessage):
 #
 class SessionInitiator(BaseSession):
     is_initiator = True
-
-    __slots__ = ("_remote_node_id",)
 
     def __init__(
         self,
@@ -470,11 +451,6 @@ class SessionInitiator(BaseSession):
 
 class SessionRecipient(BaseSession):
     is_initiator = False
-
-    __slots__ = (
-        "_inbound_envelope_buffer_send_channel",
-        "_inbound_envelope_buffer_receive_channel",
-    )
 
     def __init__(
         self,

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -51,6 +51,23 @@ class BaseSession(SessionAPI):
     _last_message_received_at: float
     _handshake_scheme_registry: HandshakeSchemeRegistryAPI = v51_handshake_scheme_registry
 
+    __slots__ = (
+        "_enr_db",
+        "_events",
+        "_inbound_message_send_channel",
+        "_local_node_id",
+        "_local_private_key",
+        "_message_type_registry",
+        "_nonce_counter",
+        "_outbound_envelope_send_channel",
+        "_outbound_message_buffer_receive_channel",
+        "_outbound_message_buffer_send_channel",
+        "_status",
+        "created_at",
+        "id",
+        "remote_endpoint",
+    )
+
     def __init__(
         self,
         local_private_key: bytes,
@@ -215,6 +232,8 @@ class EmptyMessage(BaseMessage):
 #
 class SessionInitiator(BaseSession):
     is_initiator = True
+
+    __slots__ = ("_remote_node_id",)
 
     def __init__(
         self,
@@ -451,6 +470,11 @@ class SessionInitiator(BaseSession):
 
 class SessionRecipient(BaseSession):
     is_initiator = False
+
+    __slots__ = (
+        "_inbound_envelope_buffer_send_channel",
+        "_inbound_envelope_buffer_receive_channel",
+    )
 
     def __init__(
         self,

--- a/tests/core/v5_1/test_client.py
+++ b/tests/core/v5_1/test_client.py
@@ -285,9 +285,7 @@ async def test_client_talk_request_response_timeout(alice, bob_client, autojump_
 
 @given(datagram_bytes=st.binary(max_size=1024))
 @pytest.mark.trio
-async def test_client_handles_malformed_datagrams(
-    tester, datagram_bytes, autojump_clock
-):
+async def test_client_handles_malformed_datagrams(tester, datagram_bytes):
     bob = tester.node()
     async with bob.client() as bob_client:
         alice = tester.node()

--- a/tests/core/v5_1/test_dispatcher_session_management.py
+++ b/tests/core/v5_1/test_dispatcher_session_management.py
@@ -25,9 +25,10 @@ async def test_dispatcher_detects_handshake_timeout_as_initiator(
                     await alice_client.send_ping(
                         endpoint=bob.endpoint, node_id=bob.node_id
                     )
+
+                    bob_client.get_manager().cancel()
                     _, envelope = await subscription.receive()
                     assert envelope.packet.is_who_are_you
-                    bob_client.get_manager().cancel()
         # Here we know that the session with bob was created and that bob has terminated
         #
         # Now we wait for the timeout to be triggered

--- a/tests/core/v5_1/test_pool.py
+++ b/tests/core/v5_1/test_pool.py
@@ -9,7 +9,7 @@ from ddht.v5_1.exceptions import SessionNotFound
 from ddht.v5_1.pool import Pool
 from ddht.v5_1.session import SessionInitiator, SessionRecipient
 
-TEST_CACHE_SESSION_SIZE = 128
+TEST_CACHE_SESSION_SIZE = 16
 
 
 @pytest.fixture
@@ -49,9 +49,7 @@ async def pool(tester, initiator, events, channels):
 
 @pytest.mark.trio
 async def test_pool_lru_caches_sessions(tester, events, pool):
-    recipients = []
-    for _ in range(0, 150):
-        recipients.append(tester.node())
+    recipients = recipients = tuple(tester.node() for _ in range(25))
 
     async with events.session_created.subscribe_and_wait():
         for recipient in recipients:

--- a/tests/core/v5_1/test_pool.py
+++ b/tests/core/v5_1/test_pool.py
@@ -9,6 +9,8 @@ from ddht.v5_1.exceptions import SessionNotFound
 from ddht.v5_1.pool import Pool
 from ddht.v5_1.session import SessionInitiator, SessionRecipient
 
+TEST_CACHE_SESSION_SIZE = 128
+
 
 @pytest.fixture
 def events():
@@ -38,7 +40,7 @@ async def pool(tester, initiator, events, channels):
         enr_db=initiator.enr_db,
         outbound_envelope_send_channel=channels.outbound_envelope_send_channel,
         inbound_message_send_channel=channels.inbound_message_send_channel,
-        session_cache_size=128,
+        session_cache_size=TEST_CACHE_SESSION_SIZE,
         events=initiator.events,
     )
     tester.register_pool(pool, channels)
@@ -60,8 +62,8 @@ async def test_pool_lru_caches_sessions(tester, events, pool):
         for key in pool._sessions_by_endpoint.keys()
     ]
 
-    assert len(pool._sessions) == 128
-    assert sum(session_count_by_endpoint) == 128
+    assert len(pool._sessions) == TEST_CACHE_SESSION_SIZE
+    assert sum(session_count_by_endpoint) == TEST_CACHE_SESSION_SIZE
 
 
 @pytest.mark.trio

--- a/tests/core/v5_1/test_pool.py
+++ b/tests/core/v5_1/test_pool.py
@@ -38,6 +38,7 @@ async def pool(tester, initiator, events, channels):
         enr_db=initiator.enr_db,
         outbound_envelope_send_channel=channels.outbound_envelope_send_channel,
         inbound_message_send_channel=channels.inbound_message_send_channel,
+        session_cache_size=128,
         events=initiator.events,
     )
     tester.register_pool(pool, channels)

--- a/tests/core/v5_1/test_session.py
+++ b/tests/core/v5_1/test_session.py
@@ -326,7 +326,7 @@ async def test_session_invalid_rlp(driver):
 
 
 @pytest.mark.trio
-async def test_session_is_valid_indefinitely_after_handhake(driver, autojump_clock):
+async def test_session_is_valid_indefinitely_after_handshake(driver, autojump_clock):
     initiator = driver.initiator.session
     recipient = driver.recipient.session
 


### PR DESCRIPTION
## What was wrong?
Fixes #84 

Updates sessions to only timeout if handshake **has not** been completed. If the handshake has been completed - they cannot timeout. 

## How was it fixed?

Summary of approach.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/99673783-840e4500-2a75-11eb-8bcb-a59950a91af3.png)
