### PR TITLE
Handling for HandshakeFailure while receiving handshake response

### DIFF
--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -310,12 +310,16 @@ class SessionInitiator(BaseSession):
                 return False
         elif self.is_during_handshake:
             if envelope.packet.is_who_are_you:
-                (
-                    self._keys,
-                    ephemeral_public_key,
-                ) = await self._receive_handshake_response(
-                    cast(Packet[WhoAreYouPacket], envelope.packet)
-                )
+                try:
+                    (
+                        self._keys,
+                        ephemeral_public_key,
+                    ) = await self._receive_handshake_response(
+                        cast(Packet[WhoAreYouPacket], envelope.packet)
+                    )
+                except HandshakeFailure as err:
+                    self.logger.debug("%s: HandshakeFailure: %s", self, err)
+                    return False
                 self._status = SessionStatus.AFTER
                 await self._events.session_handshake_complete.trigger(self)
 


### PR DESCRIPTION
fixes #208 

## What was wrong?

Unhandled `HandshakeFailure` causes node crash.

## How was it fixed?

Simple exception handling.

#### Cute Animal Picture

![racoon-stuck-tree](https://user-images.githubusercontent.com/824194/99697259-d25b1e00-2a4c-11eb-910d-9210ada5d299.jpg)

