### PR TITLE
bugfix for last_message_received_at race condition

### DIFF
--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -317,9 +317,9 @@ class SessionInitiator(BaseSession):
                     cast(Packet[WhoAreYouPacket], envelope.packet)
                 )
                 self._status = SessionStatus.AFTER
+                self._last_message_received_at = trio.current_time()
                 await self._events.session_handshake_complete.trigger(self)
 
-                self._last_message_received_at = trio.current_time()
                 await self._send_handshake_completion(
                     self._keys,
                     ephemeral_public_key,


### PR DESCRIPTION
## What was wrong?

There was a race condition causing an `AttributeError` when two messages are received in quick succession just as the handshake completes.

## How was it fixed?

Moved the initialization of the `_last_message_received_at` to happen before the `await`.

#### Cute Animal Picture

![93hf6iov4spx](https://user-images.githubusercontent.com/824194/99705969-a98c5600-2a57-11eb-86e9-d18453dabed7.png)

