### PR TITLE
Removed the get_nodes_near APIs

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -445,9 +445,6 @@ class NetworkProtocol(Protocol):
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         ...
 
-    async def get_nodes_near(self, target: NodeID) -> Tuple[NodeID, ...]:
-        ...
-
 
 class NetworkAPI(ServiceAPI):
     client: ClientAPI
@@ -542,10 +539,6 @@ class NetworkAPI(ServiceAPI):
 
     @abstractmethod
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
-        ...
-
-    @abstractmethod
-    async def get_nodes_near(self, target: NodeID) -> Tuple[NodeID, ...]:
         ...
 
     @abstractmethod

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -226,9 +226,3 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     @abstractmethod
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         ...
-
-    @abstractmethod
-    async def get_nodes_near(
-        self, target: NodeID, max_nodes: int = 32
-    ) -> Tuple[NodeID, ...]:
-        ...

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -20,7 +20,7 @@ from ddht.v5_1.alexandria.client import AlexandriaClient
 from ddht.v5_1.alexandria.messages import FindNodesMessage, PingMessage, PongMessage
 from ddht.v5_1.alexandria.payloads import PongPayload
 from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE
-from ddht.v5_1.network import common_get_nodes_near, common_recursive_find_nodes
+from ddht.v5_1.network import common_recursive_find_nodes
 
 NEIGHBORHOOD_DISTANCES = (
     # First bucket is combined (128 + 64 + 32) since these will rarely be
@@ -151,11 +151,6 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
 
     async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
         return await common_recursive_find_nodes(self, target)
-
-    async def get_nodes_near(
-        self, target: NodeID, max_nodes: int = 32
-    ) -> Tuple[NodeID, ...]:
-        return await common_get_nodes_near(self, target, max_nodes=max_nodes)
 
     #
     # Long Running Processes

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -9,7 +9,7 @@ import pytest
 import trio
 
 from ddht.exceptions import DuplicateProtocol, EmptyFindNodesResponse
-from ddht.kademlia import compute_distance, compute_log_distance
+from ddht.kademlia import compute_log_distance
 from ddht.v5_1.abc import TalkProtocolAPI
 from ddht.v5_1.exceptions import ProtocolNotSupported
 from ddht.v5_1.messages import FoundNodesMessage, TalkRequestMessage
@@ -445,47 +445,3 @@ async def test_network_bond_handles_timeout_retrieving_ENR(
 
                 with trio.fail_after(1):
                     await pong_subscription.receive()
-
-
-@pytest.mark.trio
-async def test_network_get_nodes_near(
-    tester, alice, bob, alice_network, bob_network, autojump_clock
-):
-    await alice_network.bond(bob.node_id)
-
-    await bob_network.bond(alice.node_id)
-
-    nodes = tuple(tester.node() for _ in range(40))
-    enrs = tuple(node.enr for node in nodes)
-
-    enrs_by_distance = tuple(
-        sorted(enrs, key=lambda enr: compute_distance(enr.node_id, bob.node_id))
-    )
-
-    target = enrs_by_distance[0]
-    enrs_for_bob = enrs_by_distance[1:10]
-    enrs_for_alice = enrs_by_distance[10:20]
-
-    bob.enr_db.set_enr(target)
-    bob_network.routing_table.update(target.node_id)
-
-    for enr in enrs_for_bob:
-        bob.enr_db.set_enr(enr)
-        bob_network.routing_table.update(enr.node_id)
-    for enr in enrs_for_alice:
-        alice.enr_db.set_enr(enr)
-        alice_network.routing_table.update(enr.node_id)
-
-    node_ids_near_target = await alice_network.get_nodes_near(
-        target.node_id, max_nodes=30
-    )
-
-    assert node_ids_near_target[0] == target.node_id
-
-    node_ids_from_alice = {enr.node_id for enr in enrs_for_alice}
-    node_ids_from_bob = {enr.node_id for enr in enrs_for_bob}
-
-    assert node_ids_from_alice.issubset(node_ids_near_target)
-    assert len(node_ids_from_bob.intersection(node_ids_near_target)) > 4
-
-    assert bob.node_id in node_ids_near_target


### PR DESCRIPTION
## What was wrong?

The `get_nodes_near` API isn't working as intended.  It takes multiple minutes to complete in main network conditions and suffers from major slowdowns due to long individual node timeouts.

## How was it fixed?

Removed it.

#### Cute Animal Picture

![920x920](https://user-images.githubusercontent.com/824194/99815429-87521100-2b07-11eb-9ee0-f6129851bafb.jpg)

