### PR TITLE
Harden recursive_find_nodes against timeouts

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -442,7 +442,9 @@ class NetworkProtocol(Protocol):
     ) -> Tuple[ENRAPI, ...]:
         ...
 
-    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
+    def recursive_find_nodes(
+        self, target: NodeID
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:
         ...
 
 
@@ -538,7 +540,9 @@ class NetworkAPI(ServiceAPI):
         ...
 
     @abstractmethod
-    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
+    def recursive_find_nodes(
+        self, target: NodeID
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:
         ...
 
     @abstractmethod

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -281,5 +281,7 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         ...
 
     @abstractmethod
-    async def recursive_find_nodes(self, target: NodeID) -> Tuple[ENRAPI, ...]:
+    def recursive_find_nodes(
+        self, target: NodeID
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:
         ...

--- a/ddht/v5_1/dispatcher.py
+++ b/ddht/v5_1/dispatcher.py
@@ -387,7 +387,9 @@ class Dispatcher(Service, DispatcherAPI):
                         yield receive_channel
                     # Wrap EOC error with TSE to make the timeouts obvious
                     except trio.EndOfChannel as err:
-                        raise trio.TooSlowError from err
+                        raise trio.TooSlowError(
+                            f"Timout waiting for response: request_id={request_id.hex()}"
+                        ) from err
             finally:
                 nursery.cancel_scope.cancel()
 

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -137,7 +137,11 @@ async def common_recursive_find_nodes(
 
         try:
             found_enrs = await network.find_nodes(node_id, distance)
-        except (trio.TooSlowError, MissingEndpointFields):
+        except trio.TooSlowError:
+            unresponsive_node_ids.add(node_id)
+            unresponsive_cache[node_id] = trio.current_time()
+            return
+        except MissingEndpointFields:
             unresponsive_node_ids.add(node_id)
             unresponsive_cache[node_id] = trio.current_time()
             return

--- a/tests/core/test_adaptive_timeout_util.py
+++ b/tests/core/test_adaptive_timeout_util.py
@@ -1,0 +1,84 @@
+import pytest
+import trio
+
+from ddht._utils import adaptive_timeout
+
+
+@pytest.mark.trio
+async def test_adaptive_timeout_all_complete(autojump_clock):
+    did_complete = []
+
+    async def do_sleep(task_id, seconds):
+        await trio.sleep(seconds)
+        did_complete.append(task_id)
+
+    tasks = (
+        (do_sleep, (1, 0.9)),
+        (do_sleep, (1, 1.0)),
+        (do_sleep, (1, 1.1)),
+    )
+
+    # with a threshold of 1 and variance of 2.0 all tasks should complete.
+    await adaptive_timeout(*tasks, threshold=1, variance=2.0)
+
+    assert len(did_complete) == 3
+
+
+@pytest.mark.trio
+async def test_adaptive_timeout_some_timeout(autojump_clock):
+    did_complete = []
+
+    async def do_sleep(task_id, seconds):
+        await trio.sleep(seconds)
+        did_complete.append(task_id)
+
+    tasks = (
+        (do_sleep, (1, 0.9)),
+        (do_sleep, (1, 1.0)),
+        (do_sleep, (1, 2.5)),  # this one should not complete
+    )
+
+    # with a threshold of 1 and variance of 2.0 all tasks should complete.
+    await adaptive_timeout(*tasks, threshold=1, variance=2.0)
+
+    assert len(did_complete) == 2
+
+
+@pytest.mark.trio
+async def test_adaptive_timeout_higher_threshold_all_complete(autojump_clock):
+    did_complete = []
+
+    async def do_sleep(task_id, seconds):
+        await trio.sleep(seconds)
+        did_complete.append(task_id)
+
+    tasks = (
+        (do_sleep, (1, 1.0)),
+        (do_sleep, (1, 3.0)),
+        (do_sleep, (1, 3.5)),
+    )
+
+    # with a threshold of 1 and variance of 2.0 all tasks should complete.
+    await adaptive_timeout(*tasks, threshold=2, variance=2.0)
+
+    assert len(did_complete) == 3
+
+
+@pytest.mark.trio
+async def test_adaptive_timeout_higher_threshold_some_timeout(autojump_clock):
+    did_complete = []
+
+    async def do_sleep(task_id, seconds):
+        await trio.sleep(seconds)
+        did_complete.append(task_id)
+
+    tasks = (
+        (do_sleep, (1, 1.0)),
+        (do_sleep, (1, 3.0)),
+        (do_sleep, (1, 4.5)),
+    )
+
+    # with a threshold of 1 and variance of 2.0 all tasks should complete.
+    await adaptive_timeout(*tasks, threshold=2, variance=2.0)
+
+    assert len(did_complete) == 2

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -264,7 +264,7 @@ async def test_network_recursive_find_nodes(tester, alice, bob):
         await stack.enter_async_context(bob.network())
         bootnodes = collections.deque((bob.enr,), maxlen=4)
         nodes = [bob, alice]
-        for _ in range(20):
+        for _ in range(10):
             node = tester.node()
             nodes.append(node)
             await stack.enter_async_context(node.network(bootnodes=bootnodes))
@@ -293,8 +293,10 @@ async def test_network_recursive_find_nodes(tester, alice, bob):
         )
         best_node_ids_by_distance = set(node_ids_by_distance[:3])
 
-        with trio.fail_after(60):
-            found_enrs = await alice_network.recursive_find_nodes(target_node_id)
+        async with alice_network.recursive_find_nodes(target_node_id) as enr_aiter:
+            with trio.fail_after(60):
+                found_enrs = tuple([enr async for enr in enr_aiter])
+
         found_node_ids = tuple(enr.node_id for enr in found_enrs)
 
         # Ensure that one of the three closest node ids was in the returned node ids

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -884,7 +884,7 @@ async def test_v51_rpc_recursiveFindNodes(tester, bob, make_request):
         bootnodes = collections.deque((bob.enr,), maxlen=4)
         nodes = [bob]
         target_node_id = None
-        for _ in range(20):
+        for _ in range(8):
             node = tester.node()
             nodes.append(node)
             await stack.enter_async_context(node.network(bootnodes=bootnodes))
@@ -896,13 +896,13 @@ async def test_v51_rpc_recursiveFindNodes(tester, bob, make_request):
                 target_node_id = node.node_id
 
         # give the the network some time to interconnect.
-        with trio.fail_after(20):
-            for _ in range(200):
+        with trio.fail_after(60):
+            for _ in range(1000):
                 await trio.lowlevel.checkpoint()
 
         await make_request("discv5_bond", [bob.node_id.hex()])
 
-        with trio.fail_after(20):
+        with trio.fail_after(60):
             found_enrs = await make_request(
                 "discv5_recursiveFindNodes", [target_node_id.hex()]
             )
@@ -918,7 +918,7 @@ async def test_v51_rpc_recursiveFindNodes_web3(tester, bob, w3):
         bootnodes = collections.deque((bob.enr,), maxlen=4)
         nodes = [bob]
         target_node_id = None
-        for _ in range(20):
+        for _ in range(8):
             node = tester.node()
             nodes.append(node)
             await stack.enter_async_context(node.network(bootnodes=bootnodes))
@@ -930,15 +930,15 @@ async def test_v51_rpc_recursiveFindNodes_web3(tester, bob, w3):
                 target_node_id = node.node_id
 
         # give the the network some time to interconnect.
-        with trio.fail_after(20):
-            for _ in range(200):
+        with trio.fail_after(60):
+            for _ in range(1000):
                 await trio.lowlevel.checkpoint()
 
         await trio.to_thread.run_sync(
             w3.discv5.bond, bob.node_id.hex(),
         )
 
-        with trio.fail_after(20):
+        with trio.fail_after(60):
             found_enrs = await trio.to_thread.run_sync(
                 w3.discv5.recursive_find_nodes, target_node_id
             )


### PR DESCRIPTION
## What was wrong?

The way that `recursive_find_nodes` was implemented was subject to significant slowdowns by unresponsive nodes.

Additionally, many use cases for `recursive_find_nodes` don't actually **require** we complete the lookup.  For example: the usage in `NetworkAPI.lookup_enr` can quit as soon as the target node has been found.  Same with future usage in the alexandria network for things like finding nodes that have the content you want.

## How was it fixed?

### Speedups

First, the lookups are now done with two layers of concurrency.  This adds some resistance so that when a single node is unresponsive, other lookups will still continue to happen in other workers.

Second, the new `adaptive_timeout` helper cancels requests that are taking too long when other requests are returning quickly.  This helps us timeout request sooner than the 10 second boundary, speeding up our happy path as long as there are other nodes that are not timing out.

Last, we keep a cache of unresponsive nodes.  This allows us speed up successive calls to `recursive_find_nodes`, not retrying nodes that recently timed out.

Prior to this, I was seeing RFN take as much as 70 seconds to return.  Now the initial request can still take as much as 20-50 seconds, but once the cache has been populated, requests that don't hit any timeouts now return in 1-3 seconds.

### API changes

The `NetworkAPI.recursive_find_nodes` now returns an async iterator (`trio.abc.ReceiveChannel`).  This allows for aborting the lookup partway through if the caller so desired by simply exiting the async iteration.

#### Cute Animal Picture

![12580436_web1_67898147_2495135923858928_7624345396042530816_n](https://user-images.githubusercontent.com/824194/99849459-d8c6c400-2b38-11eb-89bf-3dece9d92c85.jpg)

