### PR TITLE
Cleanup periodic routing table log

### DIFF
--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -360,15 +360,22 @@ class Network(Service, NetworkAPI):
         await self.manager.wait_finished()
 
     async def _periodically_report_routing_table(self) -> None:
-        async for _ in every(30, initial_delay=30):
+        async for _ in every(30, initial_delay=10):
             non_empty_buckets = tuple(
-                (idx, bucket)
-                for idx, bucket in enumerate(reversed(self.routing_table.buckets))
-                if bucket
+                reversed(
+                    tuple(
+                        (idx, bucket)
+                        for idx, bucket in enumerate(self.routing_table.buckets, 1)
+                        if bucket
+                    )
+                )
             )
             total_size = sum(len(bucket) for idx, bucket in non_empty_buckets)
             bucket_info = "|".join(
-                tuple(f"{idx}:{len(bucket)}" for idx, bucket in non_empty_buckets)
+                tuple(
+                    f"{idx}:{'F' if len(bucket) == self.routing_table.bucket_size else len(bucket)}"
+                    for idx, bucket in non_empty_buckets
+                )
             )
             self.logger.debug(
                 "routing-table-info: size=%d  buckets=%s", total_size, bucket_info,


### PR DESCRIPTION
## What was wrong?

The format of the periodic routing table number the buckets using `0` as the furthest bucket which is opposite of how they are numbered everywhere else.

## How was it fixed?

Now the buckets are numbers according to their actual numbers with the furthest bucket being 256

#### Cute Animal Picture

![baby-raccoon-stuck-exploring-85143642](https://user-images.githubusercontent.com/824194/99853953-28a98900-2b41-11eb-882c-461672fc7261.jpg)

