### PR TITLE
Fix file logging level

### DIFF
--- a/ddht/logging.py
+++ b/ddht/logging.py
@@ -83,7 +83,6 @@ def setup_stderr_logging(level: int) -> logging.StreamHandler:
     handler_stream.setFormatter(LOG_FORMATTER)
 
     logger = logging.getLogger()
-    logger.setLevel(level)
     logger.addHandler(handler_stream)
 
     return handler_stream


### PR DESCRIPTION
## What was wrong?

The file-based logging wasn't logging at the appropriate level DEBUG (instead was using the stderr log level)

## How was it fixed?

The stderr logging was incorrectly setting the log level on the root logger.

#### Cute Animal Picture

![squirrel-jar](https://user-images.githubusercontent.com/824194/99879964-a024fa00-2bcd-11eb-823b-85ffeb25a6fa.jpg)


