### PR TITLE
Jsonrpc talk endpoint support

### DIFF
--- a/ddht/tools/web3.py
+++ b/ddht/tools/web3.py
@@ -165,6 +165,8 @@ class RPC:
     findNodes = RPCEndpoint("discv5_findNodes")
     sendFindNodes = RPCEndpoint("discv5_sendFindNodes")
     sendFoundNodes = RPCEndpoint("discv5_sendFoundNodes")
+    sendTalkRequest = RPCEndpoint("discv5_sendTalkRequest")
+    sendTalkResponse = RPCEndpoint("discv5_sendTalkResponse")
 
 
 NodeIDIdentifier = Union[ENRAPI, str, bytes, NodeID, HexStr]
@@ -278,6 +280,20 @@ def send_found_nodes_munger(
     )
 
 
+def send_talk_request_munger(
+    module: Any, identifier: NodeIDIdentifier, protocol: HexStr, payload: HexStr,
+) -> Tuple[str, Sequence[str], HexStr]:
+    """
+    Normalizes the inputs for the `discv5_sendTalkRequest` JSON-RPC endpoint
+    """
+    # protocol / payload?
+    return (
+        normalize_node_id_identifier(identifier),
+        protocol, # these aren't accurate id names
+        payload,
+    )
+
+
 def find_nodes_response_formatter(enr_reprs: Sequence[str]) -> Tuple[ENRAPI, ...]:
     return tuple(ENR.from_repr(enr_repr) for enr_repr in enr_reprs)
 
@@ -352,4 +368,14 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
         RPC.sendFoundNodes,
         result_formatters=lambda method: IntegerPayload.from_rpc_response,
         mungers=[send_found_nodes_munger],
+    )
+    send_talk_request = Method(
+        RPC.sendTalkRequest,
+        result_formatters=lambda method: HexStrPayload.from_rpc_response,
+        mungers=[send_talk_request_munger],
+    )
+    send_talk_response = Method(
+        RPC.sendTalkResponse,
+        result_formatters=lambda method: EmptyPayload.from_rpc_response,
+        mungers=[send_talk_request_munger],
     )

--- a/ddht/tools/web3.py
+++ b/ddht/tools/web3.py
@@ -12,7 +12,7 @@ from typing import (
     Union,
 )
 
-from eth_utils import add_0x_prefix, encode_hex, remove_0x_prefix
+from eth_utils import add_0x_prefix, decode_hex, encode_hex, remove_0x_prefix
 
 try:
     import web3  # noqa: F401
@@ -23,7 +23,7 @@ except ImportError:
 from eth_enr import ENR, ENRAPI
 from eth_enr.typing import ENR_KV
 from eth_typing import HexStr, NodeID
-from eth_utils import decode_hex
+from mypy_extensions import VarArg
 from web3.method import Method
 from web3.module import ModuleV2
 from web3.types import RPCEndpoint
@@ -167,6 +167,7 @@ class RPC:
     sendFoundNodes = RPCEndpoint("discv5_sendFoundNodes")
     sendTalkRequest = RPCEndpoint("discv5_sendTalkRequest")
     sendTalkResponse = RPCEndpoint("discv5_sendTalkResponse")
+    talk = RPCEndpoint("discv5_talk")
 
 
 NodeIDIdentifier = Union[ENRAPI, str, bytes, NodeID, HexStr]
@@ -280,17 +281,19 @@ def send_found_nodes_munger(
     )
 
 
-def send_talk_request_munger(
-    module: Any, identifier: NodeIDIdentifier, protocol: HexStr, payload: HexStr,
-) -> Tuple[str, Sequence[str], HexStr]:
+def talk_request_munger(
+    module: Any, identifier: NodeIDIdentifier, hexstr_one: HexStr, hexstr_two: HexStr,
+) -> Tuple[str, HexStr, HexStr]:
     """
-    Normalizes the inputs for the `discv5_sendTalkRequest` JSON-RPC endpoint
+    Normalizes the inputs for the following JSON-RPC endpoints:
+    - `discv5_sendTalkRequest` (protocol, payload)
+    - `discv5_sendTalkResponse` (protocol, request_id)
+    - `discv5_talk` (protocol, payload)
     """
-    # protocol / payload?
     return (
         normalize_node_id_identifier(identifier),
-        protocol, # these aren't accurate id names
-        payload,
+        hexstr_one,
+        hexstr_two,
     )
 
 
@@ -308,7 +311,7 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
     get_node_info: Method[Callable[[], NodeInfo]] = Method(
         RPC.nodeInfo, result_formatters=lambda method: NodeInfo.from_rpc_response,
     )
-    update_node_info: Method[Callable[[], NodeInfo]] = Method(
+    update_node_info: Method[Callable[[VarArg(ENR_KV)], UpdateENRPayload]] = Method(
         RPC.updateNodeInfo,
         result_formatters=lambda method: UpdateENRPayload.from_rpc_response,
         mungers=[kv_pair_munger],
@@ -322,7 +325,7 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
         result_formatters=lambda method: GetENRPayload.from_rpc_response,
         mungers=[node_identifier_munger],
     )
-    set_enr: Method[Callable[[NodeIDIdentifier], EmptyPayload]] = Method(
+    set_enr: Method[Callable[[str], EmptyPayload]] = Method(
         RPC.setENR,
         result_formatters=lambda method: EmptyPayload.from_rpc_response,
         mungers=[node_identifier_munger],
@@ -347,7 +350,7 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
         result_formatters=lambda method: SendPingPayload.from_rpc_response,
         mungers=[node_identifier_munger],
     )
-    send_pong: Method[Callable[[NodeIDIdentifier], EmptyPayload]] = Method(
+    send_pong: Method[Callable[[NodeIDIdentifier, HexStr], EmptyPayload]] = Method(
         RPC.sendPong,
         result_formatters=lambda method: EmptyPayload.from_rpc_response,
         mungers=[send_pong_munger],
@@ -359,23 +362,36 @@ class DiscoveryV5Module(ModuleV2):  # type: ignore
         result_formatters=lambda method: find_nodes_response_formatter,
         mungers=[find_nodes_munger],
     )
-    send_find_nodes = Method(
+    send_find_nodes: Method[
+        Callable[[NodeIDIdentifier, Union[int, Sequence[int]]], HexStrPayload]
+    ] = Method(
         RPC.sendFindNodes,
         result_formatters=lambda method: HexStrPayload.from_rpc_response,
         mungers=[find_nodes_munger],
     )
-    send_found_nodes = Method(
+    send_found_nodes: Method[
+        Callable[[NodeIDIdentifier, Tuple[ENRAPI], HexStr], IntegerPayload]
+    ] = Method(
         RPC.sendFoundNodes,
         result_formatters=lambda method: IntegerPayload.from_rpc_response,
         mungers=[send_found_nodes_munger],
     )
-    send_talk_request = Method(
+    send_talk_request: Method[
+        Callable[[NodeIDIdentifier, HexStr, HexStr], HexStrPayload]
+    ] = Method(
         RPC.sendTalkRequest,
         result_formatters=lambda method: HexStrPayload.from_rpc_response,
-        mungers=[send_talk_request_munger],
+        mungers=[talk_request_munger],
     )
-    send_talk_response = Method(
+    send_talk_response: Method[
+        Callable[[NodeIDIdentifier, HexStr, HexStr], EmptyPayload]
+    ] = Method(
         RPC.sendTalkResponse,
         result_formatters=lambda method: EmptyPayload.from_rpc_response,
-        mungers=[send_talk_request_munger],
+        mungers=[talk_request_munger],
+    )
+    talk: Method[Callable[[NodeIDIdentifier, HexStr, HexStr], HexStrPayload]] = Method(
+        RPC.talk,
+        result_formatters=lambda method: HexStrPayload.from_rpc_response,
+        mungers=[talk_request_munger],
     )

--- a/ddht/v5_1/rpc_handlers.py
+++ b/ddht/v5_1/rpc_handlers.py
@@ -19,6 +19,7 @@ from ddht.endpoint import Endpoint
 from ddht.rpc import RPCError, RPCHandler, RPCRequest
 from ddht.v5_1.abc import NetworkAPI
 from ddht.validation import (
+    validate_and_convert_hexstr,
     validate_and_extract_destination,
     validate_and_normalize_distances,
     validate_params_length,
@@ -126,8 +127,6 @@ class SendPongHandler(RPCHandler[Tuple[NodeID, Optional[Endpoint], HexStr], None
 
 FindNodesRPCParams = Tuple[NodeID, Optional[Endpoint], Tuple[int, ...]]
 
-SendFoundNodesRPCParams = Tuple[NodeID, Optional[Endpoint], Sequence[ENRAPI], bytes]
-
 
 class FindNodesHandler(RPCHandler[FindNodesRPCParams, Tuple[str, ...]]):
     def __init__(self, network: NetworkAPI) -> None:
@@ -171,6 +170,9 @@ class SendFindNodesHandler(RPCHandler[FindNodesRPCParams, HexStr]):
         return encode_hex(request_id)
 
 
+SendFoundNodesRPCParams = Tuple[NodeID, Optional[Endpoint], Sequence[ENRAPI], bytes]
+
+
 class SendFoundNodesHandler(RPCHandler[SendFoundNodesRPCParams, int]):
     def __init__(self, network: NetworkAPI) -> None:
         self._network = network
@@ -195,22 +197,27 @@ class SendFoundNodesHandler(RPCHandler[SendFoundNodesRPCParams, int]):
         return num_batches
 
 
-class SendTalkRequestHandler(RPCHandler[FindNodesRPCParams, HexStr]):
+TalkRPCParams = Tuple[NodeID, Optional[Endpoint], bytes, bytes]
+
+
+class SendTalkRequestHandler(RPCHandler[TalkRPCParams, HexStr]):
     def __init__(self, network: NetworkAPI) -> None:
         self._network = network
 
-    def extract_params(self, request: RPCRequest) -> FindNodesRPCParams:
-        # should we accept request_id as a param here? 
-        # it's typically default=None - but what right now we can't pass
-        # one in if we wanted to
+    def extract_params(self, request: RPCRequest) -> TalkRPCParams:
         raw_params = extract_params(request)
         validate_params_length(raw_params, 3)
         raw_destination, raw_protocol, raw_payload = raw_params
         node_id, endpoint = validate_and_extract_destination(raw_destination)
-        # normalize protocol / payload?
-        return node_id, endpoint, to_bytes(hexstr=raw_protocol), to_bytes(hexstr=raw_payload)
+        protocol, payload = validate_and_convert_hexstr(raw_protocol, raw_payload)
+        return (
+            node_id,
+            endpoint,
+            protocol,
+            payload,
+        )
 
-    async def do_call(self, params: FindNodesRPCParams) -> HexStr:
+    async def do_call(self, params: TalkRPCParams) -> HexStr:
         node_id, endpoint, protocol, payload = params
         if endpoint is None:
             enr = await self._network.lookup_enr(node_id)
@@ -221,19 +228,24 @@ class SendTalkRequestHandler(RPCHandler[FindNodesRPCParams, HexStr]):
         return encode_hex(message_request_id)
 
 
-class SendTalkResponseHandler(RPCHandler[FindNodesRPCParams, HexStr]):
+class SendTalkResponseHandler(RPCHandler[TalkRPCParams, None]):
     def __init__(self, network: NetworkAPI) -> None:
         self._network = network
 
-    def extract_params(self, request: RPCRequest) -> FindNodesRPCParams:
+    def extract_params(self, request: RPCRequest) -> TalkRPCParams:
         raw_params = extract_params(request)
         validate_params_length(raw_params, 3)
         raw_destination, raw_payload, raw_request_id = raw_params
         node_id, endpoint = validate_and_extract_destination(raw_destination)
-        # normalize protocol / payload?
-        return node_id, endpoint, to_bytes(hexstr=raw_payload), to_bytes(hexstr=raw_request_id)
+        payload, request_id = validate_and_convert_hexstr(raw_payload, raw_request_id)
+        return (
+            node_id,
+            endpoint,
+            payload,
+            request_id,
+        )
 
-    async def do_call(self, params: FindNodesRPCParams) -> None:
+    async def do_call(self, params: TalkRPCParams) -> None:
         node_id, endpoint, payload, request_id = params
         if endpoint is None:
             enr = await self._network.lookup_enr(node_id)
@@ -242,6 +254,34 @@ class SendTalkResponseHandler(RPCHandler[FindNodesRPCParams, HexStr]):
             node_id, endpoint, payload=payload, request_id=request_id,
         )
         return response
+
+
+class TalkHandler(RPCHandler[TalkRPCParams, HexStr]):
+    def __init__(self, network: NetworkAPI) -> None:
+        self._network = network
+
+    def extract_params(self, request: RPCRequest) -> TalkRPCParams:
+        raw_params = extract_params(request)
+        validate_params_length(raw_params, 3)
+        raw_destination, raw_protocol, raw_payload = raw_params
+        node_id, endpoint = validate_and_extract_destination(raw_destination)
+        protocol, payload = validate_and_convert_hexstr(raw_protocol, raw_payload)
+        return (
+            node_id,
+            endpoint,
+            protocol,
+            payload,
+        )
+
+    async def do_call(self, params: TalkRPCParams) -> HexStr:
+        node_id, endpoint, protocol, payload = params
+        if endpoint is None:
+            enr = await self._network.lookup_enr(node_id)
+            endpoint = Endpoint.from_enr(enr)
+        response = await self._network.talk(
+            node_id, protocol=protocol, payload=payload, endpoint=endpoint,
+        )
+        return encode_hex(response)
 
 
 class GetENRHandler(RPCHandler[NodeID, GetENRResponse]):
@@ -331,15 +371,16 @@ class LookupENRHandler(
 
 @to_dict
 def get_v51_rpc_handlers(network: NetworkAPI) -> Iterable[Tuple[str, RPCHandlerAPI]]:
-    yield ("discv5_ping", PingHandler(network))
+    yield ("discv5_deleteENR", DeleteENRHandler(network))
     yield ("discv5_findNodes", FindNodesHandler(network))
+    yield ("discv5_getENR", GetENRHandler(network))
+    yield ("discv5_lookupENR", LookupENRHandler(network))
+    yield ("discv5_ping", PingHandler(network))
     yield ("discv5_sendFindNodes", SendFindNodesHandler(network))
     yield ("discv5_sendFoundNodes", SendFoundNodesHandler(network))
     yield ("discv5_sendPing", SendPingHandler(network))
     yield ("discv5_sendPong", SendPongHandler(network))
     yield ("discv5_sendTalkRequest", SendTalkRequestHandler(network))
     yield ("discv5_sendTalkResponse", SendTalkResponseHandler(network))
-    yield ("discv5_getENR", GetENRHandler(network))
-    yield ("discv5_deleteENR", DeleteENRHandler(network))
-    yield ("discv5_lookupENR", LookupENRHandler(network))
     yield ("discv5_setENR", SetENRHandler(network))
+    yield ("discv5_talk", TalkHandler(network))

--- a/ddht/validation.py
+++ b/ddht/validation.py
@@ -1,5 +1,5 @@
 import ipaddress
-from typing import Any, Collection, List, Optional, Tuple
+from typing import Any, Collection, Iterable, List, Optional, Tuple
 
 from eth_enr import ENR
 from eth_typing import HexStr, NodeID
@@ -10,6 +10,8 @@ from eth_utils import (
     is_integer,
     is_list_like,
     remove_0x_prefix,
+    to_bytes,
+    to_tuple,
 )
 
 from ddht.endpoint import Endpoint
@@ -96,6 +98,15 @@ def validate_and_normalize_distances(value: Any) -> Tuple[int, ...]:
             f"Distances must be either a single integer distance or a non-empty list of "
             f"distances: {value}"
         )
+
+
+@to_tuple
+def validate_and_convert_hexstr(*args: Any) -> Iterable[bytes]:
+    for value in args:
+        try:
+            yield to_bytes(hexstr=value)
+        except TypeError:
+            raise RPCError(f"Invalid hexstr parameter: {value}")
 
 
 def validate_and_extract_destination(value: Any) -> Tuple[NodeID, Optional[Endpoint]]:

--- a/newsfragments/224.feature.rst
+++ b/newsfragments/224.feature.rst
@@ -1,0 +1,1 @@
+Add support for disvc5 talk json rpc endpoints.

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -5,7 +5,7 @@ from socket import inet_ntoa
 from async_service import background_trio_service
 from eth_enr import ENR
 from eth_enr.tools.factories import ENRFactory
-from eth_utils import encode_hex
+from eth_utils import encode_hex, is_hex
 import pytest
 import trio
 from web3 import IPCProvider, Web3
@@ -19,6 +19,8 @@ from ddht.v5_1.messages import (
     FoundNodesMessage,
     PingMessage,
     PongMessage,
+    TalkRequestMessage,
+    TalkResponseMessage,
 )
 from ddht.v5_1.rpc_handlers import get_v51_rpc_handlers
 
@@ -528,10 +530,10 @@ async def test_v51_rpc_sendFindNodes(make_request, bob_node_id_param, bob, bob_n
             "discv5_sendFindNodes", [bob_node_id_param, 0]
         )
         with trio.fail_after(2):
-            first_receive = await subscription.receive()
+            first_receipt = await subscription.receive()
 
-        assert encode_hex(first_receive.message.request_id) == single_response
-        assert first_receive.message.distances == (0,)
+        assert encode_hex(first_receipt.message.request_id) == single_response
+        assert first_receipt.message.distances == (0,)
 
         # request with multiple distances
         multiple_response = await make_request(
@@ -539,9 +541,9 @@ async def test_v51_rpc_sendFindNodes(make_request, bob_node_id_param, bob, bob_n
         )
 
         with trio.fail_after(2):
-            second_receive = await subscription.receive()
-        assert encode_hex(second_receive.message.request_id) == multiple_response
-        assert second_receive.message.distances == tuple(distances)
+            second_receipt = await subscription.receive()
+        assert encode_hex(second_receipt.message.request_id) == multiple_response
+        assert second_receipt.message.distances == tuple(distances)
 
 
 @pytest.mark.trio
@@ -560,10 +562,10 @@ async def test_v51_rpc_sendFindNodes_web3(
             w3.discv5.send_find_nodes, bob_node_id_param_w3, 0
         )
         with trio.fail_after(2):
-            first_receive = await subscription.receive()
+            first_receipt = await subscription.receive()
 
-        assert encode_hex(first_receive.message.request_id) == first_response.value
-        assert first_receive.message.distances == (0,)
+        assert encode_hex(first_receipt.message.request_id) == first_response.value
+        assert first_receipt.message.distances == (0,)
 
         # request with multiple distances
         second_response = await trio.to_thread.run_sync(
@@ -571,9 +573,9 @@ async def test_v51_rpc_sendFindNodes_web3(
         )
 
         with trio.fail_after(2):
-            second_receive = await subscription.receive()
-        assert encode_hex(second_receive.message.request_id) == second_response.value
-        assert second_receive.message.distances == tuple(distances)
+            second_receipt = await subscription.receive()
+        assert encode_hex(second_receipt.message.request_id) == second_response.value
+        assert second_receipt.message.distances == tuple(distances)
 
 
 @pytest.mark.trio
@@ -599,10 +601,10 @@ async def test_v51_rpc_sendFoundNodes(
             "discv5_sendFoundNodes", [bob_node_id_param, (single_enr,), request_id]
         )
         with trio.fail_after(2):
-            first_receive = await subscription.receive()
+            first_receipt = await subscription.receive()
 
-        assert first_receive.message.total == first_response
-        assert encode_hex(first_receive.message.request_id) == request_id
+        assert first_receipt.message.total == first_response
+        assert encode_hex(first_receipt.message.request_id) == request_id
 
         # request with multiple enrs
         second_response = await make_request(
@@ -610,10 +612,10 @@ async def test_v51_rpc_sendFoundNodes(
         )
 
         with trio.fail_after(2):
-            second_receive = await subscription.receive()
+            second_receipt = await subscription.receive()
 
-        assert second_receive.message.total == second_response
-        assert encode_hex(second_receive.message.request_id) == request_id
+        assert second_receipt.message.total == second_response
+        assert encode_hex(second_receipt.message.request_id) == request_id
 
 
 @pytest.mark.trio
@@ -640,10 +642,10 @@ async def test_v51_rpc_sendFoundNodes_web3(
             w3.discv5.send_found_nodes, bob_node_id_param_w3, (single_enr,), request_id
         )
         with trio.fail_after(2):
-            first_receive = await subscription.receive()
+            first_receipt = await subscription.receive()
 
-        assert first_receive.message.total == first_response.value
-        assert encode_hex(first_receive.message.request_id) == request_id
+        assert first_receipt.message.total == first_response.value
+        assert encode_hex(first_receipt.message.request_id) == request_id
 
         # request with multiple enrs
         second_response = await trio.to_thread.run_sync(
@@ -651,7 +653,121 @@ async def test_v51_rpc_sendFoundNodes_web3(
         )
 
         with trio.fail_after(2):
-            second_receive = await subscription.receive()
+            second_receipt = await subscription.receive()
 
-        assert second_receive.message.total == second_response.value
-        assert encode_hex(second_receive.message.request_id) == request_id
+        assert second_receipt.message.total == second_response.value
+        assert encode_hex(second_receipt.message.request_id) == request_id
+
+
+@pytest.mark.trio
+async def test_v51_rpc_sendTalkRequest(
+    make_request, bob_node_id_param, bob_network
+):
+    async with bob_network.client.dispatcher.subscribe(
+        TalkRequestMessage
+    ) as subscription:
+        response = await make_request(
+            "discv5_sendTalkRequest", [bob_node_id_param, '0x1234', '0x1234']
+        )
+        with trio.fail_after(2):
+            receipt = await subscription.receive()
+
+        assert encode_hex(receipt.request_id) == response
+
+
+@pytest.mark.trio
+async def test_v51_rpc_sendTalkRequest_web3(
+    make_request, bob_node_id_param_w3, bob_network, w3
+):
+    async with bob_network.client.dispatcher.subscribe(
+        TalkRequestMessage
+    ) as subscription:
+        response = await trio.to_thread.run_sync(
+            w3.discv5.send_talk_request, bob_node_id_param_w3, "0x2134", "0x1234",
+        )
+        with trio.fail_after(2):
+            receipt = await subscription.receive()
+
+        assert encode_hex(receipt.request_id) == response.value
+
+
+@pytest.mark.trio
+async def test_v51_rpc_sendTalkResponse(
+    make_request, bob_node_id_param, bob_network
+):
+    async with bob_network.client.dispatcher.subscribe(
+        TalkResponseMessage
+    ) as subscription:
+        response = await make_request(
+            "discv5_sendTalkResponse", [bob_node_id_param, '0x1234', '0x1234']
+        )
+        with trio.fail_after(2):
+            receipt = await subscription.receive()
+
+        assert response is None
+        assert encode_hex(receipt.request_id) == '0x1234'
+
+
+@pytest.mark.trio
+async def test_v51_rpc_sendTalkResponse_web3(
+    make_request, bob_node_id_param_w3, bob_network, w3
+):
+    async with bob_network.client.dispatcher.subscribe(
+        TalkResponseMessage
+    ) as subscription:
+        response = await trio.to_thread.run_sync(
+            w3.discv5.send_talk_response, bob_node_id_param_w3, "0x2134", "0x1234",
+        )
+        with trio.fail_after(2):
+            receipt = await subscription.receive()
+
+        assert response is None
+        assert encode_hex(receipt.request_id) == '0x1234'
+
+
+@pytest.mark.parametrize("endpoint", ("discv5_sendTalkRequest", "discv5_sendTalkResponse",))
+@pytest.mark.trio
+async def test_v51_rpc_findNodes_invalid_params(
+    make_request, invalid_node_id, bob, endpoint
+):
+    # bad node_id
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [invalid_node_id, '0x12', '0x12'])
+
+    # invalid 1st bytes arg
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), 1, '0x12'])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), 257, '0x12'])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), 1.2, '0x12'])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), [], '0x12'])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), "xyz", "0x12"])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), [1, "2"], "0x12"])
+
+    # invalid 2nd bytes arg
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12', 1])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12', 257])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12', 1.2])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12', []])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12', "xyz"])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12', [1, "2"]])
+
+    # wrong params count
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex()])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12'])
+    with pytest.raises(Exception, match="'error':"):
+        await make_request(endpoint, [bob.node_id.hex(), '0x12', "0x12", "0x12"])

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -5,7 +5,7 @@ from socket import inet_ntoa
 from async_service import background_trio_service
 from eth_enr import ENR
 from eth_enr.tools.factories import ENRFactory
-from eth_utils import encode_hex, is_hex
+from eth_utils import decode_hex, encode_hex
 import pytest
 import trio
 from web3 import IPCProvider, Web3
@@ -14,6 +14,7 @@ from ddht.kademlia import compute_log_distance
 from ddht.rpc import RPCServer
 from ddht.tools.factories.node_id import NodeIDFactory
 from ddht.tools.web3 import DiscoveryV5Module
+from ddht.v5_1.abc import TalkProtocolAPI
 from ddht.v5_1.messages import (
     FindNodeMessage,
     FoundNodesMessage,
@@ -660,14 +661,12 @@ async def test_v51_rpc_sendFoundNodes_web3(
 
 
 @pytest.mark.trio
-async def test_v51_rpc_sendTalkRequest(
-    make_request, bob_node_id_param, bob_network
-):
+async def test_v51_rpc_sendTalkRequest(make_request, bob_node_id_param, bob_network):
     async with bob_network.client.dispatcher.subscribe(
         TalkRequestMessage
     ) as subscription:
         response = await make_request(
-            "discv5_sendTalkRequest", [bob_node_id_param, '0x1234', '0x1234']
+            "discv5_sendTalkRequest", [bob_node_id_param, "0x1234", "0x1234"]
         )
         with trio.fail_after(2):
             receipt = await subscription.receive()
@@ -683,7 +682,7 @@ async def test_v51_rpc_sendTalkRequest_web3(
         TalkRequestMessage
     ) as subscription:
         response = await trio.to_thread.run_sync(
-            w3.discv5.send_talk_request, bob_node_id_param_w3, "0x2134", "0x1234",
+            w3.discv5.send_talk_request, bob_node_id_param_w3, "0x1234", "0x1234",
         )
         with trio.fail_after(2):
             receipt = await subscription.receive()
@@ -692,20 +691,18 @@ async def test_v51_rpc_sendTalkRequest_web3(
 
 
 @pytest.mark.trio
-async def test_v51_rpc_sendTalkResponse(
-    make_request, bob_node_id_param, bob_network
-):
+async def test_v51_rpc_sendTalkResponse(make_request, bob_node_id_param, bob_network):
     async with bob_network.client.dispatcher.subscribe(
         TalkResponseMessage
     ) as subscription:
         response = await make_request(
-            "discv5_sendTalkResponse", [bob_node_id_param, '0x1234', '0x1234']
+            "discv5_sendTalkResponse", [bob_node_id_param, "0x1234", "0x1234"]
         )
         with trio.fail_after(2):
             receipt = await subscription.receive()
 
         assert response is None
-        assert encode_hex(receipt.request_id) == '0x1234'
+        assert encode_hex(receipt.request_id) == "0x1234"
 
 
 @pytest.mark.trio
@@ -716,33 +713,113 @@ async def test_v51_rpc_sendTalkResponse_web3(
         TalkResponseMessage
     ) as subscription:
         response = await trio.to_thread.run_sync(
-            w3.discv5.send_talk_response, bob_node_id_param_w3, "0x2134", "0x1234",
+            w3.discv5.send_talk_response, bob_node_id_param_w3, "0x1234", "0x1234",
         )
         with trio.fail_after(2):
             receipt = await subscription.receive()
 
         assert response is None
-        assert encode_hex(receipt.request_id) == '0x1234'
+        assert encode_hex(receipt.request_id) == "0x1234"
 
 
-@pytest.mark.parametrize("endpoint", ("discv5_sendTalkRequest", "discv5_sendTalkResponse",))
 @pytest.mark.trio
-async def test_v51_rpc_findNodes_invalid_params(
+async def test_v51_rpc_talk(make_request, bob_network, bob_node_id_param):
+    class ProtocolTest(TalkProtocolAPI):
+        protocol_id = b"test"
+
+    async def _do_talk_response(network):
+        network.add_talk_protocol(ProtocolTest())
+
+        async with network.dispatcher.subscribe(TalkRequestMessage) as subscription:
+            request = await subscription.receive()
+            await network.client.send_talk_response(
+                request.sender_node_id,
+                request.sender_endpoint,
+                payload=b"test-response-payload",
+                request_id=request.message.request_id,
+            )
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(_do_talk_response, bob_network)
+
+        with trio.fail_after(2):
+            response = await make_request(
+                "discv5_talk", [bob_node_id_param, encode_hex(b"test"), "0x1234"]
+            )
+
+    assert decode_hex(response) == b"test-response-payload"
+
+
+@pytest.mark.trio
+async def test_v51_rpc_talk_web3(make_request, bob_network, bob_node_id_param_w3, w3):
+    class ProtocolTest(TalkProtocolAPI):
+        protocol_id = b"test"
+
+    async def _do_talk_response(network):
+        network.add_talk_protocol(ProtocolTest())
+
+        async with network.dispatcher.subscribe(TalkRequestMessage) as subscription:
+            request = await subscription.receive()
+            await network.client.send_talk_response(
+                request.sender_node_id,
+                request.sender_endpoint,
+                payload=b"test-response-payload",
+                request_id=request.message.request_id,
+            )
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(_do_talk_response, bob_network)
+
+        with trio.fail_after(2):
+
+            response = await trio.to_thread.run_sync(
+                w3.discv5.talk, bob_node_id_param_w3, encode_hex(b"test"), "0x1234",
+            )
+
+    assert decode_hex(response.value) == b"test-response-payload"
+
+
+@pytest.mark.trio
+async def test_v51_rpc_talk_with_unsupported_protocol(make_request, bob):
+    async with bob.network() as bob_network:
+        with pytest.raises(Exception, match="'error':"):
+            await make_request(
+                "discv5_talk", [bob_network.local_node_id.hex(), "0x1234", "0x1234"]
+            )
+
+
+@pytest.mark.trio
+async def test_v51_rpc_talk_web3_with_unsupported_protocol(make_request, bob, w3):
+    async with bob.network() as bob_network:
+        with pytest.raises(Exception, match="Unexpected Error"):
+            await trio.to_thread.run_sync(
+                w3.discv5.talk,
+                bob_network.local_node_id.hex(),
+                encode_hex(b"test"),
+                "0x1234",
+            )
+
+
+@pytest.mark.parametrize(
+    "endpoint", ("discv5_sendTalkRequest", "discv5_sendTalkResponse", "discv5_talk")
+)
+@pytest.mark.trio
+async def test_v51_rpc_talk_invalid_params(
     make_request, invalid_node_id, bob, endpoint
 ):
     # bad node_id
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [invalid_node_id, '0x12', '0x12'])
+        await make_request(endpoint, [invalid_node_id, "0x12", "0x12"])
 
     # invalid 1st bytes arg
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), 1, '0x12'])
+        await make_request(endpoint, [bob.node_id.hex(), 1, "0x12"])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), 257, '0x12'])
+        await make_request(endpoint, [bob.node_id.hex(), 257, "0x12"])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), 1.2, '0x12'])
+        await make_request(endpoint, [bob.node_id.hex(), 1.2, "0x12"])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), [], '0x12'])
+        await make_request(endpoint, [bob.node_id.hex(), [], "0x12"])
     with pytest.raises(Exception, match="'error':"):
         await make_request(endpoint, [bob.node_id.hex(), "xyz", "0x12"])
     with pytest.raises(Exception, match="'error':"):
@@ -750,17 +827,17 @@ async def test_v51_rpc_findNodes_invalid_params(
 
     # invalid 2nd bytes arg
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12', 1])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12", 1])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12', 257])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12", 257])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12', 1.2])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12", 1.2])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12', []])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12", []])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12', "xyz"])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12", "xyz"])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12', [1, "2"]])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12", [1, "2"]])
 
     # wrong params count
     with pytest.raises(Exception, match="'error':"):
@@ -768,6 +845,6 @@ async def test_v51_rpc_findNodes_invalid_params(
     with pytest.raises(Exception, match="'error':"):
         await make_request(endpoint, [bob.node_id.hex()])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12'])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12"])
     with pytest.raises(Exception, match="'error':"):
-        await make_request(endpoint, [bob.node_id.hex(), '0x12', "0x12", "0x12"])
+        await make_request(endpoint, [bob.node_id.hex(), "0x12", "0x12", "0x12"])


### PR DESCRIPTION
## What was wrong?
Add support for the following jsonrpc endpoints
- `discv5_talk`
- `discv5_sendTalkRequest`
- `discv5_sendTalkResponse`

## How was it fixed?
Added support for the endpoints. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/99947634-9095e480-2d78-11eb-9508-7fdef7e13049.png)
