### PR TITLE
Upgrade eth enr

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import AsyncContextManager, Collection, NamedTuple, Optional, Tuple
 
-from eth_enr import ENRAPI, ENRDatabaseAPI
+from eth_enr import ENRAPI, QueryableENRDatabaseAPI
 from eth_keys import keys
 from eth_typing import NodeID
 
@@ -41,7 +41,7 @@ class AlexandriaNodeAPI(ABC):
 class NodeAPI(ABC):
     private_key: keys.PrivateKey
     enr: ENRAPI
-    enr_db: ENRDatabaseAPI
+    enr_db: QueryableENRDatabaseAPI
     events: EventsAPI
     alexandria: AlexandriaNodeAPI
 

--- a/ddht/tools/driver/node.py
+++ b/ddht/tools/driver/node.py
@@ -2,7 +2,7 @@ from typing import AsyncIterator, Collection, Optional
 
 from async_generator import asynccontextmanager
 from async_service import background_trio_service
-from eth_enr import ENRAPI, ENRDatabaseAPI
+from eth_enr import ENRAPI, QueryableENRDatabaseAPI
 from eth_enr.constants import IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY
 from eth_enr.tools.factories import ENRFactory
 from eth_keys import keys
@@ -26,7 +26,7 @@ class Node(NodeAPI):
         self,
         private_key: keys.PrivateKey,
         endpoint: Endpoint,
-        enr_db: ENRDatabaseAPI,
+        enr_db: QueryableENRDatabaseAPI,
         events: Optional[EventsAPI] = None,
     ) -> None:
         self.private_key = private_key

--- a/ddht/tools/driver/tester.py
+++ b/ddht/tools/driver/tester.py
@@ -5,7 +5,7 @@ from typing import AsyncIterator, Dict, NamedTuple, Optional, Set, Tuple
 
 from async_generator import asynccontextmanager
 from async_service import background_trio_service
-from eth_enr import QueryableENRDatabaseAPI, QueryableENRDB, OldSequenceNumber
+from eth_enr import OldSequenceNumber, QueryableENRDatabaseAPI, QueryableENRDB
 from eth_keys import keys
 from eth_typing import NodeID
 import trio

--- a/ddht/tools/factories/socket.py
+++ b/ddht/tools/factories/socket.py
@@ -3,7 +3,7 @@ from typing import Deque
 
 from ddht._utils import get_open_port
 
-RECENT_PORTS: Deque[int] = collections.deque(maxlen=256)
+RECENT_PORTS: Deque[int] = collections.deque(maxlen=2048)
 
 
 def robust_get_open_port() -> int:

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -13,7 +13,7 @@ from typing import (
 import uuid
 
 from async_service import ServiceAPI
-from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI, IdentitySchemeAPI
+from eth_enr import ENRAPI, ENRManagerAPI, IdentitySchemeAPI, QueryableENRDatabaseAPI
 from eth_keys import keys
 from eth_typing import NodeID
 import trio
@@ -235,7 +235,7 @@ class ClientAPI(ServiceAPI):
     events: EventsAPI
     dispatcher: DispatcherAPI
     pool: PoolAPI
-    enr_db: ENRDatabaseAPI
+    enr_db: QueryableENRDatabaseAPI
     request_tracker: RequestTrackerAPI
 
     @property
@@ -430,7 +430,7 @@ class NetworkProtocol(Protocol):
         ...
 
     @property
-    def enr_db(self) -> ENRDatabaseAPI:
+    def enr_db(self) -> QueryableENRDatabaseAPI:
         ...
 
     async def find_nodes(
@@ -480,7 +480,7 @@ class NetworkAPI(ServiceAPI):
 
     @property
     @abstractmethod
-    def enr_db(self) -> ENRDatabaseAPI:
+    def enr_db(self) -> QueryableENRDatabaseAPI:
         ...
 
     #

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -11,7 +11,7 @@ from typing import (
 )
 
 from async_service import ServiceAPI
-from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
+from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
 from eth_typing import NodeID
 import trio
 
@@ -195,7 +195,7 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
 
     @property
     @abstractmethod
-    def enr_db(self) -> ENRDatabaseAPI:
+    def enr_db(self) -> QueryableENRDatabaseAPI:
         ...
 
     #

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -3,7 +3,7 @@ import secrets
 from typing import Collection, List, Optional, Tuple
 
 from async_service import Service
-from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
+from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
 from eth_enr.exceptions import OldSequenceNumber
 from eth_typing import NodeID
 from eth_utils.toolz import cons, first
@@ -67,7 +67,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         return self.network.enr_manager
 
     @property
-    def enr_db(self) -> ENRDatabaseAPI:
+    def enr_db(self) -> QueryableENRDatabaseAPI:
         return self.network.enr_db
 
     async def run(self) -> None:

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -1,7 +1,12 @@
 import argparse
+import sqlite3
 
-from eth.db.backends.level import LevelDB
-from eth_enr import ENRDB, ENRManager, default_identity_scheme_registry
+from eth_enr import (
+    ENRManager,
+    QueryableENRDatabaseAPI,
+    QueryableENRDB,
+    default_identity_scheme_registry,
+)
 from eth_keys import keys
 from eth_utils import encode_hex
 from eth_utils.toolz import merge
@@ -23,7 +28,7 @@ from ddht.v5_1.messages import v51_registry
 from ddht.v5_1.network import Network
 from ddht.v5_1.rpc_handlers import get_v51_rpc_handlers
 
-ENR_DATABASE_DIR_NAME = "enr-db"
+ENR_DATABASE_FILENAME = "enrdb.sqlite3"
 
 
 def get_local_private_key(boot_info: BootInfo) -> keys.PrivateKey:
@@ -66,9 +71,10 @@ class Application(BaseApplication):
 
         message_type_registry = v51_registry
 
-        enr_database_dir = self._boot_info.base_dir / ENR_DATABASE_DIR_NAME
-        enr_database_dir.mkdir(exist_ok=True)
-        enr_db = ENRDB(LevelDB(enr_database_dir), identity_scheme_registry)
+        enr_database_file = self._boot_info.base_dir / ENR_DATABASE_FILENAME
+        enr_db: QueryableENRDatabaseAPI = QueryableENRDB(
+            sqlite3.connect(enr_database_file), identity_scheme_registry
+        )
 
         local_private_key = get_local_private_key(self._boot_info)
 

--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -3,7 +3,7 @@ import socket
 from typing import Collection, List, Optional, Sequence, Tuple
 
 from async_service import Service
-from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManager
+from eth_enr import ENRAPI, ENRManager, QueryableENRDatabaseAPI
 from eth_keys import keys
 from eth_typing import NodeID
 import trio
@@ -52,7 +52,7 @@ class Client(Service, ClientAPI):
         self,
         local_private_key: keys.PrivateKey,
         listen_on: Endpoint,
-        enr_db: ENRDatabaseAPI,
+        enr_db: QueryableENRDatabaseAPI,
         events: EventsAPI = None,
         message_type_registry: MessageTypeRegistry = v51_registry,
     ) -> None:

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -3,7 +3,7 @@ import logging
 from typing import Collection, Dict, List, Optional, Set, Tuple
 
 from async_service import Service
-from eth_enr import ENRAPI, ENRDatabaseAPI, ENRManagerAPI
+from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
 from eth_enr.exceptions import OldSequenceNumber
 from eth_typing import NodeID
 from eth_utils import ValidationError
@@ -174,7 +174,7 @@ class Network(Service, NetworkAPI):
         return self.client.pool
 
     @property
-    def enr_db(self) -> ENRDatabaseAPI:
+    def enr_db(self) -> QueryableENRDatabaseAPI:
         return self.client.enr_db
 
     #

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -6,7 +6,7 @@ import secrets
 from typing import Any, Optional, Tuple, Type, cast
 import uuid
 
-from eth_enr import ENRAPI, ENRDatabaseAPI, IdentitySchemeAPI
+from eth_enr import ENRAPI, ENRDatabaseAPI, IdentitySchemeAPI, OldSequenceNumber
 from eth_keys import keys
 from eth_typing import NodeID
 from eth_utils import ValidationError
@@ -654,7 +654,10 @@ class SessionRecipient(BaseSession):
 
         if packet.auth_data.record is not None:
             remote_enr = packet.auth_data.record
-            self._enr_db.set_enr(remote_enr)
+            try:
+                self._enr_db.set_enr(remote_enr)
+            except OldSequenceNumber:
+                pass
         else:
             remote_enr = self._enr_db.get_enr(self.remote_node_id)
 

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
         "cached-property>=1.5.1,<2",
         "coincurve>=10.0.0,<11.0.0",
         "cryptography>=3.0,<3.2",
-        "eth-enr>=0.3.0,<0.4",
+        "eth-enr>=0.4.1,<0.5",
         "eth-hash[pycryptodome]>=0.1.4,<1",
         "eth-keys>=0.3.3,<0.4.0",
         "eth-typing>=2.2.2,<3",

--- a/tests/core/test_core_rpc_handlers.py
+++ b/tests/core/test_core_rpc_handlers.py
@@ -1,8 +1,8 @@
 import json
+import sqlite3
 
 from async_service import background_trio_service
-from eth_enr import ENR
-from eth_enr.enr_db import ENRDB
+from eth_enr import ENR, QueryableENRDB
 from eth_enr.enr_manager import ENRManager
 from eth_enr.tools.factories import PrivateKeyFactory
 from eth_utils import decode_hex, to_bytes
@@ -20,7 +20,7 @@ from ddht.tools.web3 import DiscoveryV5Module
 
 @pytest.fixture
 def enr_manager():
-    enr_db = ENRDB({})
+    enr_db = QueryableENRDB(sqlite3.connect(":memory:"))
     return ENRManager(PrivateKeyFactory(), enr_db)
 
 

--- a/tests/core/v5_1/conftest.py
+++ b/tests/core/v5_1/conftest.py
@@ -1,3 +1,4 @@
+from eth_enr import OldSequenceNumber
 import pytest
 
 from ddht.tools.driver import Tester
@@ -11,7 +12,10 @@ def tester():
 @pytest.fixture
 async def alice(tester, bob):
     node = tester.node()
-    node.enr_db.set_enr(bob.enr)
+    try:
+        node.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
     return node
 
 
@@ -27,27 +31,39 @@ async def driver(tester, alice, bob):
 
 @pytest.fixture
 async def alice_client(alice, bob):
-    alice.enr_db.set_enr(bob.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
     async with alice.client() as alice_client:
         yield alice_client
 
 
 @pytest.fixture
 async def bob_client(alice, bob):
-    bob.enr_db.set_enr(alice.enr)
+    try:
+        bob.enr_db.set_enr(alice.enr)
+    except OldSequenceNumber:
+        pass
     async with bob.client() as bob_client:
         yield bob_client
 
 
 @pytest.fixture
 async def alice_network(alice, bob):
-    alice.enr_db.set_enr(bob.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
     async with alice.network() as alice_network:
         yield alice_network
 
 
 @pytest.fixture
 async def bob_network(alice, bob):
-    bob.enr_db.set_enr(alice.enr)
+    try:
+        bob.enr_db.set_enr(alice.enr)
+    except OldSequenceNumber:
+        pass
     async with bob.network() as bob_network:
         yield bob_network

--- a/tests/core/v5_1/test_client.py
+++ b/tests/core/v5_1/test_client.py
@@ -12,20 +12,6 @@ from ddht.kademlia import KademliaRoutingTable
 from ddht.v5_1.messages import TalkRequestMessage
 
 
-@pytest.fixture
-async def alice_client(alice, bob):
-    alice.enr_db.set_enr(bob.enr)
-    async with alice.client() as alice_client:
-        yield alice_client
-
-
-@pytest.fixture
-async def bob_client(alice, bob):
-    bob.enr_db.set_enr(alice.enr)
-    async with bob.client() as bob_client:
-        yield bob_client
-
-
 @pytest.mark.trio
 async def test_client_send_ping(alice, bob, alice_client, bob_client):
     with trio.fail_after(2):

--- a/tests/core/v5_1/test_dispatcher_session_management.py
+++ b/tests/core/v5_1/test_dispatcher_session_management.py
@@ -1,3 +1,4 @@
+from eth_enr import OldSequenceNumber
 import pytest
 import trio
 
@@ -8,8 +9,14 @@ from ddht.v5_1.constants import SESSION_IDLE_TIMEOUT
 async def test_dispatcher_detects_handshake_timeout_as_initiator(
     alice, bob, autojump_clock
 ):
-    alice.enr_db.set_enr(bob.enr)
-    bob.enr_db.set_enr(alice.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
+    try:
+        bob.enr_db.set_enr(alice.enr)
+    except OldSequenceNumber:
+        pass
 
     async with alice.client() as alice_client:
         async with bob.client() as bob_client:
@@ -34,8 +41,14 @@ async def test_dispatcher_detects_handshake_timeout_as_initiator(
 async def test_dispatcher_detects_handshake_timeout_as_recipient(
     alice, bob, autojump_clock
 ):
-    alice.enr_db.set_enr(bob.enr)
-    bob.enr_db.set_enr(alice.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
+    try:
+        bob.enr_db.set_enr(alice.enr)
+    except OldSequenceNumber:
+        pass
 
     async with bob.client():
         async with alice.client() as alice_client:
@@ -62,8 +75,14 @@ async def test_dispatcher_detects_handshake_timeout_as_recipient(
 async def test_dispatcher_initiates_new_session_when_packet_cannot_be_decoded(
     alice, bob, autojump_clock
 ):
-    alice.enr_db.set_enr(bob.enr)
-    bob.enr_db.set_enr(alice.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
+    try:
+        bob.enr_db.set_enr(alice.enr)
+    except OldSequenceNumber:
+        pass
 
     async with alice.client():
         async with bob.client() as bob_client:
@@ -87,8 +106,14 @@ async def test_dispatcher_initiates_new_session_when_packet_cannot_be_decoded(
 
 @pytest.mark.trio
 async def test_dispatcher_detects_duplicate_handshakes(alice, bob, autojump_clock):
-    alice.enr_db.set_enr(bob.enr)
-    bob.enr_db.set_enr(alice.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
+    try:
+        bob.enr_db.set_enr(alice.enr)
+    except OldSequenceNumber:
+        pass
 
     async with alice.client() as alice_client:
         async with bob.client() as bob_client:

--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -3,7 +3,7 @@ import secrets
 from socket import inet_ntoa
 
 from async_service import background_trio_service
-from eth_enr import ENR
+from eth_enr import ENR, OldSequenceNumber
 from eth_enr.tools.factories import ENRFactory
 from eth_utils import encode_hex
 import pytest
@@ -45,7 +45,10 @@ async def bob_network(bob):
 
 @pytest.fixture(params=("nodeid", "enode", "enr"))
 def bob_node_id_param(request, alice, bob, bob_network):
-    alice.enr_db.set_enr(bob.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
 
     if request.param == "nodeid":
         return bob.node_id.hex()
@@ -96,7 +99,10 @@ def invalid_node_id(request, bob, bob_network):
 
 @pytest.fixture(params=("nodeid", "nodeid-hex", "enode", "enr", "enr-repr"))
 def bob_node_id_param_w3(request, alice, bob, bob_network):
-    alice.enr_db.set_enr(bob.enr)
+    try:
+        alice.enr_db.set_enr(bob.enr)
+    except OldSequenceNumber:
+        pass
 
     if request.param == "nodeid":
         return bob.node_id


### PR DESCRIPTION
## What was wrong?

New `eth-enr` version with support for queryable ENR database.

## How was it fixed?

Upgraded `eth-enr` to `>=0.4.1,<0.5`

#### Cute Animal Picture

![animals jumping foxes 1500x984 wallpaper_www animalhi com_89](https://user-images.githubusercontent.com/824194/100023298-f21e7900-2da1-11eb-8e9c-30a585c63831.jpg)

