### PR TITLE
Make the RFN test over RPC less flakey

### DIFF
--- a/tests/core/v5_1/test_v51_rpc_handlers.py
+++ b/tests/core/v5_1/test_v51_rpc_handlers.py
@@ -896,13 +896,13 @@ async def test_v51_rpc_recursiveFindNodes(tester, bob, make_request):
                 target_node_id = node.node_id
 
         # give the the network some time to interconnect.
-        with trio.fail_after(5):
-            for _ in range(10):
+        with trio.fail_after(20):
+            for _ in range(200):
                 await trio.lowlevel.checkpoint()
 
         await make_request("discv5_bond", [bob.node_id.hex()])
 
-        with trio.fail_after(10):
+        with trio.fail_after(20):
             found_enrs = await make_request(
                 "discv5_recursiveFindNodes", [target_node_id.hex()]
             )
@@ -930,15 +930,15 @@ async def test_v51_rpc_recursiveFindNodes_web3(tester, bob, w3):
                 target_node_id = node.node_id
 
         # give the the network some time to interconnect.
-        with trio.fail_after(5):
-            for _ in range(10):
+        with trio.fail_after(20):
+            for _ in range(200):
                 await trio.lowlevel.checkpoint()
 
         await trio.to_thread.run_sync(
             w3.discv5.bond, bob.node_id.hex(),
         )
 
-        with trio.fail_after(10):
+        with trio.fail_after(20):
             found_enrs = await trio.to_thread.run_sync(
                 w3.discv5.recursive_find_nodes, target_node_id
             )


### PR DESCRIPTION
fixes #231 

## What was wrong?

Flakey test

## How was it fixed?

Give more time for the nodes to interconnect before performing the lookup.

#### Cute Animal Picture

![bee77ece0ac31705](https://user-images.githubusercontent.com/824194/100255272-8bfc3800-2f00-11eb-8b4d-fc15247421ad.jpg)

