### PR TITLE
Extend ContentStorageAPI to support atomic batching

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -3,6 +3,7 @@ from typing import (
     Any,
     AsyncContextManager,
     Collection,
+    ContextManager,
     Iterable,
     Optional,
     Sequence,
@@ -44,7 +45,9 @@ class ContentStorageAPI(ABC):
         ...
 
     @abstractmethod
-    def set_content(self, content_key: ContentKey, content: bytes) -> None:
+    def set_content(
+        self, content_key: ContentKey, content: bytes, exists_ok: bool = False
+    ) -> None:
         ...
 
     @abstractmethod
@@ -57,6 +60,10 @@ class ContentStorageAPI(ABC):
         start_key: Optional[ContentKey] = None,
         end_key: Optional[ContentKey] = None,
     ) -> Iterable[ContentKey]:
+        ...
+
+    @abstractmethod
+    def atomic(self) -> ContextManager["ContentStorageAPI"]:
         ...
 
 

--- a/ddht/v5_1/alexandria/content_storage.py
+++ b/ddht/v5_1/alexandria/content_storage.py
@@ -1,7 +1,8 @@
 import bisect
+import contextlib
 import pathlib
 import sqlite3
-from typing import Any, Dict, Iterable, Optional, Tuple
+from typing import Any, ContextManager, Dict, Iterator, Optional, Set, Tuple
 
 from ddht.v5_1.alexandria.abc import ContentStorageAPI
 from ddht.v5_1.alexandria.content import content_key_to_content_id
@@ -10,6 +11,106 @@ from ddht.v5_1.alexandria.typing import ContentKey
 
 class ContentNotFound(Exception):
     pass
+
+
+class ContentAlreadyExists(Exception):
+    pass
+
+
+class BatchDecomissioned(Exception):
+    pass
+
+
+class _AtomicBatch(ContentStorageAPI):
+    _deleted: Set[ContentKey]
+    is_decomissioned: bool
+
+    def __init__(self, storage: ContentStorageAPI) -> None:
+        self._storage = storage
+        self._batch = MemoryContentStorage()
+        self._deleted = set()
+        self.is_decomissioned = False
+
+    def has_content(self, content_key: ContentKey) -> bool:
+        if self.is_decomissioned:
+            raise BatchDecomissioned
+
+        if content_key in self._deleted:
+            return False
+        elif self._batch.has_content(content_key):
+            return True
+        else:
+            return self._storage.has_content(content_key)
+
+    def get_content(self, content_key: ContentKey) -> bytes:
+        if self.is_decomissioned:
+            raise BatchDecomissioned
+
+        if content_key in self._deleted:
+            raise ContentNotFound(f"Not Found: content_key={content_key.hex()}")
+
+        try:
+            return self._batch.get_content(content_key)
+        except ContentNotFound:
+            return self._storage.get_content(content_key)
+
+    def set_content(
+        self, content_key: ContentKey, content: bytes, exists_ok: bool = False
+    ) -> None:
+        if self.is_decomissioned:
+            raise BatchDecomissioned
+
+        if self.has_content(content_key) and not exists_ok:
+            raise ContentAlreadyExists(
+                f"Content already exists for key: content_key={content_key.hex()}"
+            )
+
+        self._batch.set_content(content_key, content, exists_ok=exists_ok)
+        self._deleted.discard(content_key)
+
+    def delete_content(self, content_key: ContentKey) -> None:
+        if self.is_decomissioned:
+            raise BatchDecomissioned
+
+        if not self.has_content(content_key):
+            raise ContentNotFound(f"Not Found: content_key={content_key.hex()}")
+
+        if self._batch.has_content(content_key):
+            self._batch.delete_content(content_key)
+
+        if self._storage.has_content(content_key):
+            self._deleted.add(content_key)
+
+    def enumerate_keys(
+        self,
+        start_key: Optional[ContentKey] = None,
+        end_key: Optional[ContentKey] = None,
+    ) -> Iterator[ContentKey]:
+        if self.is_decomissioned:
+            raise BatchDecomissioned
+
+        base_keys = set(self._storage.enumerate_keys(start_key, end_key)).difference(
+            self._deleted
+        )
+        batch_keys = set(self._batch.enumerate_keys(start_key, end_key))
+        yield from sorted(base_keys | batch_keys)
+
+    def atomic(self) -> ContextManager[ContentStorageAPI]:
+        raise NotImplementedError("Atomic batch recursion not supported")
+
+    def finalize(self) -> Tuple[Set[ContentKey], Tuple[Tuple[ContentKey, bytes], ...]]:
+        if self.is_decomissioned:
+            raise BatchDecomissioned
+
+        self.is_decomissioned = True
+        to_write = tuple(
+            (content_key, self._batch.get_content(content_key))
+            for content_key in self._batch.enumerate_keys()
+        )
+        return (
+            self._deleted,
+            to_write,
+        )
 
 
 class MemoryContentStorage(ContentStorageAPI):
@@ -27,7 +128,13 @@ class MemoryContentStorage(ContentStorageAPI):
         except KeyError:
             raise ContentNotFound(f"Not Found: content_key={content_key.hex()}")
 
-    def set_content(self, content_key: ContentKey, content: bytes) -> None:
+    def set_content(
+        self, content_key: ContentKey, content: bytes, exists_ok: bool = False
+    ) -> None:
+        if content_key in self._db and exists_ok is False:
+            raise ContentAlreadyExists(
+                f"Content already exists for key: content_key={content_key.hex()}"
+            )
         self._db[content_key] = content
 
     def delete_content(self, content_key: ContentKey) -> None:
@@ -40,7 +147,7 @@ class MemoryContentStorage(ContentStorageAPI):
         self,
         start_key: Optional[ContentKey] = None,
         end_key: Optional[ContentKey] = None,
-    ) -> Iterable[ContentKey]:
+    ) -> Iterator[ContentKey]:
         all_keys = sorted(self._db.keys())
 
         if start_key is None:
@@ -54,6 +161,18 @@ class MemoryContentStorage(ContentStorageAPI):
             right = bisect.bisect_right(all_keys, end_key)
 
         yield from all_keys[left:right]
+
+    @contextlib.contextmanager
+    def atomic(self) -> Iterator[ContentStorageAPI]:
+        batch = _AtomicBatch(self)
+
+        yield batch
+
+        to_delete, to_write = batch.finalize()
+        for content_key in to_delete:
+            self.delete_content(content_key)
+        for content_key, content in to_write:
+            self.set_content(content_key, content, exists_ok=True)
 
 
 STORAGE_CREATE_STATEMENT = """CREATE TABLE storage (
@@ -93,7 +212,8 @@ STORAGE_INSERT_QUERY = """INSERT INTO storage
 def insert_content(
     conn: sqlite3.Connection, content_key: ContentKey, path: pathlib.Path,
 ) -> None:
-    conn.execute(STORAGE_INSERT_QUERY, (content_key, str(path)))
+    with conn:
+        conn.execute(STORAGE_INSERT_QUERY, (content_key, str(path)))
 
 
 STORAGE_EXISTS_QUERY = """SELECT EXISTS (
@@ -132,7 +252,8 @@ DELETE_CONTENT_QUERY = """DELETE FROM storage WHERE storage.content_key = ?"""
 
 
 def delete_content(conn: sqlite3.Connection, content_key: ContentKey) -> bool:
-    cursor = conn.execute(DELETE_CONTENT_QUERY, (content_key,))
+    with conn:
+        cursor = conn.execute(DELETE_CONTENT_QUERY, (content_key,))
     return bool(cursor.rowcount)
 
 
@@ -149,7 +270,7 @@ def enumerate_content_keys(
     conn: sqlite3.Connection,
     left_bound: Optional[ContentKey],
     right_bound: Optional[ContentKey],
-) -> Iterable[ContentKey]:
+) -> Iterator[ContentKey]:
     query: str
     params: Tuple[Any, ...]
 
@@ -195,12 +316,19 @@ class FileSystemContentStorage(ContentStorageAPI):
         content_path = self.base_dir / content_path_rel
         return content_path.read_bytes()
 
-    def set_content(self, content_key: ContentKey, content: bytes) -> None:
+    def set_content(
+        self, content_key: ContentKey, content: bytes, exists_ok: bool = False
+    ) -> None:
         """
         /content_id.hex()[:2]/content_id.hex()[2:4]/content_id.hex()
         """
         if self.has_content(content_key):
-            raise Exception("Unhandled")
+            if exists_ok:
+                self.delete_content(content_key)
+            else:
+                raise ContentAlreadyExists(
+                    f"Content already exists for key: content_key={content_key.hex()}"
+                )
         content_id = content_key_to_content_id(content_key)
         content_id_hex = content_id.hex()
 
@@ -210,9 +338,6 @@ class FileSystemContentStorage(ContentStorageAPI):
             self.base_dir / content_id_hex[:2] / content_id_hex[2:4] / content_id_hex
         )
         content_path_rel = content_path.relative_to(self.base_dir)
-
-        if content_path.exists():
-            raise Exception("Unhandled")
 
         # Lazily create the directory structure
         content_path.parent.mkdir(parents=True, exist_ok=True)
@@ -241,5 +366,17 @@ class FileSystemContentStorage(ContentStorageAPI):
         self,
         start_key: Optional[ContentKey] = None,
         end_key: Optional[ContentKey] = None,
-    ) -> Iterable[ContentKey]:
+    ) -> Iterator[ContentKey]:
         yield from enumerate_content_keys(self._conn, start_key, end_key)
+
+    @contextlib.contextmanager
+    def atomic(self) -> Iterator[ContentStorageAPI]:
+        batch = _AtomicBatch(self)
+
+        yield batch
+
+        to_delete, to_write = batch.finalize()
+        for content_key in to_delete:
+            self.delete_content(content_key)
+        for content_key, content in to_write:
+            self.set_content(content_key, content, exists_ok=True)

--- a/tests/core/v5_1/alexandria/test_content_storage.py
+++ b/tests/core/v5_1/alexandria/test_content_storage.py
@@ -13,7 +13,7 @@ import pytest
 from ddht.tools.factories.content import ContentFactory
 from ddht.v5_1.alexandria.abc import ContentStorageAPI
 from ddht.v5_1.alexandria.content_storage import (
-    BatchDecomissioned,
+    BatchDecommissioned,
     ContentAlreadyExists,
     ContentNotFound,
     FileSystemContentStorage,
@@ -147,7 +147,7 @@ def test_content_storage_atomic_batch(base_storage):
         assert not batch.has_content(b"key-d")
         assert not base_storage.has_content(b"key-d")
 
-        # delete a pre-exisitng key and then write something new to it
+        # delete a pre-existing key and then write something new to it
         batch.delete_content(b"key-b")
         batch.set_content(b"key-b", b"updated-content-b")
 
@@ -161,15 +161,15 @@ def test_content_storage_atomic_batch(base_storage):
         assert base_keys == {b"key-a", b"key-b", b"key-c"}
 
     # batch operations should now raise exceptions
-    with pytest.raises(BatchDecomissioned):
+    with pytest.raises(BatchDecommissioned):
         batch.has_content(b"key-a")
-    with pytest.raises(BatchDecomissioned):
+    with pytest.raises(BatchDecommissioned):
         batch.get_content(b"key-a")
-    with pytest.raises(BatchDecomissioned):
+    with pytest.raises(BatchDecommissioned):
         batch.set_content(b"key-a", b"dummy")
-    with pytest.raises(BatchDecomissioned):
+    with pytest.raises(BatchDecommissioned):
         batch.delete_content(b"key-a")
-    with pytest.raises(BatchDecomissioned):
+    with pytest.raises(BatchDecommissioned):
         set(batch.enumerate_keys())
 
     assert not base_storage.has_content(b"key-a")

--- a/tests/core/v5_1/alexandria/test_content_storage.py
+++ b/tests/core/v5_1/alexandria/test_content_storage.py
@@ -1,15 +1,25 @@
+from contextlib import ExitStack
+import enum
 import pathlib
 import random
+import sqlite3
 import tempfile
+from typing import Optional
 
+from hypothesis import given
+from hypothesis import strategies as st
 import pytest
 
 from ddht.tools.factories.content import ContentFactory
+from ddht.v5_1.alexandria.abc import ContentStorageAPI
 from ddht.v5_1.alexandria.content_storage import (
+    BatchDecomissioned,
+    ContentAlreadyExists,
     ContentNotFound,
     FileSystemContentStorage,
     MemoryContentStorage,
 )
+from ddht.v5_1.alexandria.typing import ContentKey
 
 
 @pytest.fixture()
@@ -19,12 +29,23 @@ def filesystem_base_dir():
 
 
 @pytest.fixture(params=("memory", "filesystem"))
-def content_storage(request):
+def base_storage(request):
     if request.param == "memory":
         return MemoryContentStorage()
     elif request.param == "filesystem":
         base_dir = request.getfixturevalue("filesystem_base_dir")
         return FileSystemContentStorage(base_dir=base_dir)
+    else:
+        raise Exception(f"Unhandled parameter: {request.param}")
+
+
+@pytest.fixture(params=("base", "batch"))
+def content_storage(request, base_storage):
+    if request.param == "base":
+        yield base_storage
+    elif request.param == "batch":
+        with base_storage.atomic() as batch:
+            yield batch
     else:
         raise Exception(f"Unhandled parameter: {request.param}")
 
@@ -53,6 +74,351 @@ def test_content_storage_read_write_exists_delete(content_storage):
         content_storage.get_content(content_key)
     with pytest.raises(ContentNotFound):
         content_storage.delete_content(content_key)
+
+
+def test_content_storage_set_content_exists_ok(content_storage):
+    content_key = b"\x00test-key"
+    content = ContentFactory(128)
+
+    assert content_storage.has_content(content_key) is False
+
+    content_storage.set_content(content_key, content)
+
+    with pytest.raises(ContentAlreadyExists):
+        content_storage.set_content(content_key, content)
+    with pytest.raises(ContentAlreadyExists):
+        content_storage.set_content(content_key, content, exists_ok=False)
+
+    # sanity check
+    assert content_storage.get_content(content_key) == content
+
+    new_content = ContentFactory(256)
+    assert new_content != content
+
+    content_storage.set_content(content_key, new_content, exists_ok=True)
+
+    # sanity check
+    assert content_storage.get_content(content_key) == new_content
+
+
+def test_content_storage_atomic_batch(base_storage):
+    base_storage.set_content(b"key-a", b"content-a")
+    base_storage.set_content(b"key-b", b"content-b")
+    base_storage.set_content(b"key-c", b"content-c")
+
+    with base_storage.atomic() as batch:
+        # known keys should exist
+        assert batch.has_content(b"key-a")
+        assert batch.has_content(b"key-b")
+        assert batch.has_content(b"key-c")
+
+        # unkown keys shouldn't
+        assert not batch.has_content(b"key-d")
+        assert not batch.has_content(b"key-e")
+
+        # set new keys
+        batch.set_content(b"key-d", b"content-d")
+        batch.set_content(b"key-e", b"content-e")
+
+        # new keys should now exist in batch but not base
+        assert batch.has_content(b"key-d")
+        assert batch.has_content(b"key-e")
+        assert not base_storage.has_content(b"key-d")
+        assert not base_storage.has_content(b"key-e")
+
+        # delete an unknown key
+        with pytest.raises(ContentNotFound):
+            batch.delete_content(b"key-f")
+
+        # delete an pre-existing key
+        batch.delete_content(b"key-a")
+
+        # key should now be gone in batch but still present in underlying storage
+        assert not batch.has_content(b"key-a")
+        assert base_storage.has_content(b"key-a")
+
+        with pytest.raises(ContentNotFound):
+            batch.get_content(b"key-a")
+        base_storage.get_content(b"key-a")
+
+        # delete a key only in the batch
+        batch.delete_content(b"key-d")
+
+        assert not batch.has_content(b"key-d")
+        assert not base_storage.has_content(b"key-d")
+
+        # delete a pre-exisitng key and then write something new to it
+        batch.delete_content(b"key-b")
+        batch.set_content(b"key-b", b"updated-content-b")
+
+        assert batch.get_content(b"key-b") == b"updated-content-b"
+        assert base_storage.get_content(b"key-b") == b"content-b"
+
+        batch_keys = set(batch.enumerate_keys())
+        assert batch_keys == {b"key-b", b"key-c", b"key-e"}
+
+        base_keys = set(base_storage.enumerate_keys())
+        assert base_keys == {b"key-a", b"key-b", b"key-c"}
+
+    # batch operations should now raise exceptions
+    with pytest.raises(BatchDecomissioned):
+        batch.has_content(b"key-a")
+    with pytest.raises(BatchDecomissioned):
+        batch.get_content(b"key-a")
+    with pytest.raises(BatchDecomissioned):
+        batch.set_content(b"key-a", b"dummy")
+    with pytest.raises(BatchDecomissioned):
+        batch.delete_content(b"key-a")
+    with pytest.raises(BatchDecomissioned):
+        set(batch.enumerate_keys())
+
+    assert not base_storage.has_content(b"key-a")
+    assert base_storage.get_content(b"key-b") == b"updated-content-b"
+    assert base_storage.has_content(b"key-c")
+    assert not base_storage.has_content(b"key-d")
+    assert base_storage.has_content(b"key-e")
+
+    final_keys = set(base_storage.enumerate_keys())
+    assert final_keys == {b"key-b", b"key-c", b"key-e"}
+
+
+class Action(enum.Enum):
+    GET_RANDOM_KEY = enum.auto()
+    SET_RANDOM_KEY = enum.auto()
+    SET_RANDOM_KEY_EXISTS_OK = enum.auto()
+    CHECK_RANDOM_KEY = enum.auto()
+    DELETE_RANDOM_KEY = enum.auto()
+
+    GET_KNOWN_KEY = enum.auto()
+    SET_KNOWN_KEY = enum.auto()
+    SET_KNOWN_KEY_EXISTS_OK = enum.auto()
+    CHECK_KNOWN_KEY = enum.auto()
+    DELETE_KNOWN_KEY = enum.auto()
+
+    ENUMERATE_KEYS = enum.auto()
+
+
+RANDOM_KEY_ACTIONS = {
+    Action.GET_RANDOM_KEY,
+    Action.SET_RANDOM_KEY,
+    Action.SET_RANDOM_KEY_EXISTS_OK,
+    Action.CHECK_RANDOM_KEY,
+    Action.DELETE_RANDOM_KEY,
+}
+KNOWN_KEY_ACTIONS = {
+    Action.GET_KNOWN_KEY,
+    Action.SET_KNOWN_KEY,
+    Action.SET_KNOWN_KEY_EXISTS_OK,
+    Action.CHECK_KNOWN_KEY,
+    Action.DELETE_KNOWN_KEY,
+}
+
+
+GET_ACTIONS = {
+    Action.GET_RANDOM_KEY,
+    Action.GET_KNOWN_KEY,
+}
+SET_ACTIONS = {
+    Action.SET_RANDOM_KEY,
+    Action.SET_RANDOM_KEY_EXISTS_OK,
+    Action.SET_KNOWN_KEY,
+    Action.SET_KNOWN_KEY_EXISTS_OK,
+}
+CHECK_ACTIONS = {
+    Action.CHECK_RANDOM_KEY,
+    Action.CHECK_KNOWN_KEY,
+}
+DELETE_ACTIONS = {
+    Action.DELETE_RANDOM_KEY,
+    Action.DELETE_KNOWN_KEY,
+}
+
+
+def apply_action(
+    action: Action,
+    content_key: Optional[ContentKey],
+    content: Optional[bytes],
+    *storages: ContentStorageAPI,
+) -> None:
+    """
+    Apply an action to some set of `ContentStorageAPI`.  The first *storage*
+    dictates the behavior expected on the other storages.  If an exception is
+    thrown, the other storages are expected to throw the same exception.
+    Otherwise, the return value is expected ot be equivalent.
+    """
+    base, *others = storages
+
+    if action in GET_ACTIONS:
+        assert content is None
+        assert content_key is not None
+
+        try:
+            expected_content = base.get_content(content_key)
+        except Exception as err:
+            for other in others:
+                with pytest.raises(type(err)):
+                    other.get_content(content_key)
+        else:
+            for other in others:
+                actual_content = other.get_content(content_key)
+                assert actual_content == expected_content
+    elif action in SET_ACTIONS:
+        assert content is not None
+        assert content_key is not None
+
+        exists_ok = (
+            action is Action.SET_RANDOM_KEY_EXISTS_OK
+            or action is Action.SET_KNOWN_KEY_EXISTS_OK
+        )
+        try:
+            base.set_content(content_key, content, exists_ok=exists_ok)
+        except Exception as err:
+            for other in others:
+                with pytest.raises(type(err)):
+                    other.set_content(content_key, content, exists_ok=exists_ok)
+        else:
+            for other in others:
+                other.set_content(content_key, content, exists_ok=exists_ok)
+    elif action in CHECK_ACTIONS:
+        assert content is None
+        assert content_key is not None
+
+        expected = base.has_content(content_key)
+        for other in others:
+            actual = other.has_content(content_key)
+            assert actual == expected
+    elif action in DELETE_ACTIONS:
+        assert content is None
+        assert content_key is not None
+
+        try:
+            expected_content = base.delete_content(content_key)
+        except Exception as err:
+            for other in others:
+                with pytest.raises(type(err)):
+                    other.delete_content(content_key)
+        else:
+            for other in others:
+                other.delete_content(content_key)
+    elif action is Action.ENUMERATE_KEYS:
+        assert content is None
+        assert content_key is None
+
+        expected_keys = set(base.enumerate_keys())
+        for other in others:
+            actual_keys = set(other.enumerate_keys())
+            assert actual_keys == expected_keys
+    else:
+        raise NotImplementedError(f"Unsupported action: {action}")
+
+
+def assert_storages_equal(left: ContentStorageAPI, right: ContentStorageAPI) -> None:
+    """
+    Helper to assert that two storages are identical.
+    """
+    left_keys = set(left.enumerate_keys())
+    right_keys = set(right.enumerate_keys())
+
+    assert left_keys == right_keys
+
+    for content_key in left_keys:
+        left_value = left.get_content(content_key)
+        right_value = right.get_content(content_key)
+
+        assert left_value == right_value
+
+
+class _RevertBatch(Exception):
+    """
+    Exception just used to test atomic batch reversion to ensure we aren't
+    catching any other legitimate exception my mistake.
+    """
+
+    pass
+
+
+actions_st = st.lists(st.sampled_from(Action), min_size=0, max_size=100)
+content_key_st = st.binary(min_size=4, max_size=8)
+content_st = st.binary(min_size=8, max_size=8)
+
+
+@given(data=st.data(),)
+def test_content_storage_atomic_batch_fuzzy(data):
+    """
+    Fuzz test the `ContentStorageAPI.atomic()` API.
+    """
+    with ExitStack() as stack:
+        storage_class = data.draw(
+            st.sampled_from((MemoryContentStorage, FileSystemContentStorage))
+        )
+        if storage_class is MemoryContentStorage:
+            base_storage = MemoryContentStorage()
+        elif storage_class is FileSystemContentStorage:
+            base_dir = pathlib.Path(stack.enter_context(tempfile.TemporaryDirectory()))
+            base_storage = FileSystemContentStorage(
+                base_dir, sqlite3.connect(":memory:")
+            )
+        else:
+            raise Exception(f"Unhandled storage class: {storage_class}")
+
+        before_batch_actions = data.draw(actions_st)
+        during_batch_actions = data.draw(actions_st)
+        # throw about 5% of the time
+        should_throw = st.sampled_from((False,) * 19 + (True,))
+
+        # storage_a is managed such that it should be equivalent to
+        # `base_storage` **after** the batch operations.
+        storage_a = MemoryContentStorage()
+
+        # storage_a is managed such that it should be equivalent to
+        # `base_storage` **during** the batch operations.
+        storage_b = MemoryContentStorage()
+
+        # pre-populate with a single known key so that `KNOWN` actions don't
+        # have to special case creating the first key.
+        known_keys = [b"sentinal"]
+
+        def apply_action_sequence(actions, *storages):
+            for action in actions:
+                if action in RANDOM_KEY_ACTIONS:
+                    content_key = data.draw(content_key_st)
+                    known_keys.append(content_key)
+                elif action in KNOWN_KEY_ACTIONS:
+                    content_key = data.draw(st.sampled_from(known_keys))
+                else:
+                    content_key = None
+
+                if action in SET_ACTIONS:
+                    content = data.draw(content_st)
+                else:
+                    content = None
+
+                apply_action(action, content_key, content, *storages)
+
+        apply_action_sequence(before_batch_actions, base_storage, storage_a, storage_b)
+
+        # should be the same before the batch
+        assert_storages_equal(base_storage, storage_a)
+        assert_storages_equal(base_storage, storage_b)
+
+        try:
+            with base_storage.atomic() as batch:
+                if should_throw:
+                    storages = (batch, storage_b)
+                else:
+                    storages = (batch, storage_a, storage_b)
+
+                apply_action_sequence(during_batch_actions, *storages)
+
+                assert_storages_equal(batch, storage_b)
+
+                if should_throw:
+                    raise _RevertBatch
+        except _RevertBatch:
+            pass
+
+        # should be the same after the batch.
+        assert_storages_equal(base_storage, storage_a)
 
 
 def test_content_storage_enumerate_keys(content_storage):


### PR DESCRIPTION
## What was wrong?

Ended up needing batch operations on the storage to avoid getting into inconsistent states when needing to write multiple pieces of dependent data such as an epoch of headers, the epoch accumulator, and then the updated master accumulator. 

## How was it fixed?

Applied a pretty well established pattern.  Kept things simple by disallowing nested batching.  Solid manual and fuzz testing.


#### Cute Animal Picture

![animals-bunny](https://user-images.githubusercontent.com/824194/100260875-35462c80-2f07-11eb-8361-8706c9ba8f90.jpg)

