### PR TITLE
Implement messages for Locate/Locations

### DIFF
--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -51,3 +51,12 @@ AdvertisePayload = Tuple[Advertisement, ...]
 
 class AckPayload(NamedTuple):
     advertisement_radius: int
+
+
+class LocatePayload(NamedTuple):
+    content_key: ContentKey
+
+
+class LocationsPayload(NamedTuple):
+    total: int
+    locations: Tuple[Advertisement, ...]

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -26,6 +26,7 @@ class ByteList(List):  # type: ignore
 
 byte_list = ByteList(max_length=2048)
 uint40 = UInt(40)
+content_key_sedes = ByteList(max_length=256)
 
 
 PingSedes = Container(field_sedes=(uint32,))
@@ -42,6 +43,9 @@ AdvertisementSedes = Container(
 )
 AdvertiseSedes = List(AdvertisementSedes, max_length=32)
 AckSedes = Container(field_sedes=(uint256,))
+
+LocateSedes = Container(field_sedes=(content_key_sedes,))
+LocationsSedes = Container(field_sedes=(uint8, List(AdvertisementSedes, max_length=32)))
 
 # sedes used for encoding alexandria content
 content_sedes = ByteList(max_length=GB)

--- a/tests/core/v5_1/alexandria/test_message_encoding.py
+++ b/tests/core/v5_1/alexandria/test_message_encoding.py
@@ -9,6 +9,8 @@ from ddht.v5_1.alexandria.messages import (
     AdvertiseMessage,
     FindNodesMessage,
     FoundNodesMessage,
+    LocateMessage,
+    LocationsMessage,
     PingMessage,
     PongMessage,
     decode_message,
@@ -18,6 +20,8 @@ from ddht.v5_1.alexandria.payloads import (
     Advertisement,
     FindNodesPayload,
     FoundNodesPayload,
+    LocatePayload,
+    LocationsPayload,
     PingPayload,
     PongPayload,
 )
@@ -67,22 +71,14 @@ def test_found_nodes_message_encoding_round_trip(num_enr_records):
 
 PRIVATE_KEY = keys.PrivateKey(b"unicornsrainbowscupcakessparkles")
 
+advertisement_st = st.tuples(
+    st.binary(min_size=1, max_size=128), st.binary(min_size=32, max_size=32),
+).map(lambda key_and_root: Advertisement.create(*key_and_root, PRIVATE_KEY))
 
-@given(
-    raw_advertisements=st.lists(
-        st.tuples(
-            st.binary(min_size=1, max_size=128), st.binary(min_size=32, max_size=32),
-        ),
-        min_size=1,
-        max_size=5,
-    ),
-)
-def test_advertisement_message_encoding_round_trip(raw_advertisements):
-    payload = tuple(
-        Advertisement.create(content_key, hash_tree_root, PRIVATE_KEY)
-        for content_key, hash_tree_root in raw_advertisements
-    )
-    message = AdvertiseMessage(payload)
+
+@given(advertisements=st.lists(advertisement_st, min_size=1, max_size=5).map(tuple),)
+def test_advertisement_message_encoding_round_trip(advertisements):
+    message = AdvertiseMessage(advertisements)
     encoded = message.to_wire_bytes()
     result = decode_message(encoded)
     assert result == message
@@ -92,6 +88,24 @@ def test_advertisement_message_encoding_round_trip(raw_advertisements):
 def test_ack_message_encoding_round_trip(advertisement_radius):
     payload = AckPayload(advertisement_radius)
     message = AckMessage(payload)
+    encoded = message.to_wire_bytes()
+    result = decode_message(encoded)
+    assert result == message
+
+
+@given(content_key=st.binary(min_size=33, max_size=128),)
+def test_locate_message_encoding_round_trip(content_key):
+    payload = LocatePayload(content_key)
+    message = LocateMessage(payload)
+    encoded = message.to_wire_bytes()
+    result = decode_message(encoded)
+    assert result == message
+
+
+@given(advertisements=st.lists(advertisement_st, min_size=1, max_size=5).map(tuple),)
+def test_locations_message_encoding_round_trip(advertisements):
+    payload = LocationsPayload(len(advertisements), advertisements)
+    message = LocationsMessage(payload)
     encoded = message.to_wire_bytes()
     result = decode_message(encoded)
     assert result == message


### PR DESCRIPTION
## What was wrong?

We need message pairs for querying the advertisement tables managed by other nodes so that nodes can find the content they are looking for.

## How was it fixed?

Implemented messages for `Locate` and `Locations` messages.

#### Cute Animal Picture


![Red-Fox-Jumping](https://user-images.githubusercontent.com/824194/100288218-73f1dc00-2f33-11eb-853c-e8762018f7ea.jpg)
