### PR TITLE
Implement locate locations message sending

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -27,6 +27,7 @@ from ddht.v5_1.alexandria.messages import (
     AlexandriaMessage,
     ContentMessage,
     FoundNodesMessage,
+    LocationsMessage,
     PongMessage,
     TAlexandriaMessage,
 )
@@ -246,6 +247,28 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     ) -> None:
         ...
 
+    @abstractmethod
+    async def send_locate(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        content_key: ContentKey,
+        request_id: bytes,
+    ) -> bytes:
+        ...
+
+    @abstractmethod
+    async def send_locations(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        advertisements: Sequence[Advertisement],
+        request_id: bytes,
+    ) -> int:
+        ...
+
     #
     # High Level Request/Response
     #
@@ -292,6 +315,17 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         *,
         advertisements: Collection[Advertisement],
     ) -> Tuple[AckMessage, ...]:
+        ...
+
+    @abstractmethod
+    async def locate(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        content_key: ContentKey,
+        request_id: Optional[bytes] = None,
+    ) -> Tuple[InboundMessage[LocationsMessage], ...]:
         ...
 
 

--- a/ddht/v5_1/alexandria/messages.py
+++ b/ddht/v5_1/alexandria/messages.py
@@ -204,13 +204,6 @@ class LocateMessage(AlexandriaMessage[LocatePayload]):
 
     payload: LocatePayload
 
-    @classmethod
-    def from_payload_args(
-        cls: Type[TAlexandriaMessage], payload_args: Any
-    ) -> TAlexandriaMessage:
-        payload = tuple(payload_args)
-        return cls(payload)
-
 
 @register
 class LocationsMessage(AlexandriaMessage[LocationsPayload]):


### PR DESCRIPTION
builds on #235

## What was wrong?

#235 implements the message types for requesting and sending the locations of content.  We still need message primatives on the `AlexandriaClientAPI` for sending them.

## How was it fixed?

Implemented the standard message sending APIs for both individual message sending and for doing the round trip request/response.

#### Cute Animal Picture

![A-dreamstime_xxl_32311527_rjm4k4](https://user-images.githubusercontent.com/824194/100288553-2b86ee00-2f34-11eb-8516-7b2d43e1a87f.jpg)
