### PR TITLE
Implement AlexandriaNetworkAPI.locate

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -446,6 +446,17 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         ...
 
     @abstractmethod
+    async def locate(
+        self,
+        node_id: NodeID,
+        *,
+        content_key: ContentKey,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
+    ) -> Tuple[Advertisement, ...]:
+        ...
+
+    @abstractmethod
     def recursive_find_nodes(
         self, target: NodeID
     ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -473,6 +473,25 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         )
         return tuple(response.payload for response in responses)
 
+    async def locate(
+        self,
+        node_id: NodeID,
+        *,
+        content_key: ContentKey,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
+    ) -> Tuple[Advertisement, ...]:
+        if endpoint is None:
+            endpoint = await self.network.endpoint_for_node_id(node_id)
+        responses = await self.client.locate(
+            node_id, content_key=content_key, endpoint=endpoint, request_id=request_id,
+        )
+        return tuple(
+            advertisement
+            for response in responses
+            for advertisement in response.message.payload.locations
+        )
+
     #
     # Long Running Processes
     #


### PR DESCRIPTION
Builds on #236 

## What was wrong?

#235 and #236 implement the primatives for do location queries down at the `AlexandriaClientAPI`.  We need the high level APIs on `AlexandriaNetworkAPI`.

## How was it fixed?

Implemented `AlexandriaNetworkAPI.locate`

#### Cute Animal Picture

![jumping](https://user-images.githubusercontent.com/824194/100292850-e6b48480-2f3e-11eb-8d40-ddec229f474c.jpg)
