### PR TITLE
Piper/implement alexandria network api.local advertisement radius

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -17,6 +17,7 @@ from ddht.v5_1.abc import (
     SessionAPI,
 )
 from ddht.v5_1.alexandria.abc import (
+    AdvertisementDatabaseAPI,
     AlexandriaClientAPI,
     AlexandriaNetworkAPI,
     ContentStorageAPI,
@@ -28,6 +29,7 @@ from ddht.v5_1.packets import AnyPacket
 
 class AlexandriaNodeAPI(ABC):
     content_storage: ContentStorageAPI
+    advertisement_db: AdvertisementDatabaseAPI
 
     @abstractmethod
     def client(

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -285,10 +285,12 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     client: AlexandriaClientAPI
     routing_table: RoutingTableAPI
 
-    advertisement_db: AdvertisementDatabaseAPI
+    max_advertisement_count: int
 
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI
+
+    advertisement_db: AdvertisementDatabaseAPI
 
     @property
     @abstractmethod
@@ -308,6 +310,14 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     @property
     @abstractmethod
     def enr_db(self) -> QueryableENRDatabaseAPI:
+        ...
+
+    #
+    # Local properties
+    #
+    @property
+    @abstractmethod
+    def local_advertisement_radius(self) -> int:
         ...
 
     #

--- a/ddht/v5_1/alexandria/app.py
+++ b/ddht/v5_1/alexandria/app.py
@@ -1,8 +1,10 @@
 import argparse
+import sqlite3
 
 from ddht.app import BaseApplication
 from ddht.boot_info import BootInfo
-from ddht.v5_1.alexandria.abc import ContentStorageAPI
+from ddht.v5_1.alexandria.abc import AdvertisementDatabaseAPI, ContentStorageAPI
+from ddht.v5_1.alexandria.advertisement_db import AdvertisementDatabase
 from ddht.v5_1.alexandria.boot_info import AlexandriaBootInfo
 from ddht.v5_1.alexandria.content_storage import MemoryContentStorage
 from ddht.v5_1.alexandria.network import AlexandriaNetwork
@@ -24,10 +26,16 @@ class AlexandriaApplication(BaseApplication):
 
         content_storage: ContentStorageAPI = MemoryContentStorage()
 
+        # Temporarily we just use an in memory database for advertisements.
+        advertisement_db: AdvertisementDatabaseAPI = AdvertisementDatabase(
+            sqlite3.connect(":memory:"),
+        )
+
         alexandria_network = AlexandriaNetwork(
             network=self.base_protocol_app.network,
             bootnodes=self._alexandria_boot_info.bootnodes,
             content_storage=content_storage,
+            advertisement_db=advertisement_db,
         )
 
         self.manager.run_daemon_child_service(alexandria_network)


### PR DESCRIPTION
Builds on #200 

## What was wrong?

We need common API for accessing the local advertisement radius.  This is needed for both inclusion in the `Ack/Ping/Pong` messages and for the `AdvertisementManagerAPI` to properly handle incoming advertisements.

## How was it fixed?

Query our local database for the radius and expose it as a property on the `AlexandriaNetworkAPI`.

#### Cute Animal Picture

![Jumping-Fox-wild-animals-2870945-468-351](https://user-images.githubusercontent.com/824194/100465745-1671a280-308d-11eb-8402-3a4f286dbd9a.jpg)

