### PR TITLE
Implement AlexandriaNetworkAPI.broadcast

### DIFF
--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -31,6 +31,11 @@ class AlexandriaNodeAPI(ABC):
     content_storage: ContentStorageAPI
     advertisement_db: AdvertisementDatabaseAPI
 
+    @property
+    @abstractmethod
+    def enr(self) -> ENRAPI:
+        ...
+
     @abstractmethod
     def client(
         self, network: Optional[NetworkAPI] = None
@@ -128,7 +133,21 @@ class SessionPairAPI(ABC):
         ...
 
 
+class AlexandriaTesterAPI(ABC):
+    @abstractmethod
+    def node(self) -> AlexandriaNodeAPI:
+        ...
+
+    @abstractmethod
+    def network_group(
+        self, num_networks: int, bootnodes: Collection[ENRAPI] = (),
+    ) -> AsyncContextManager[Tuple[AlexandriaNetworkAPI, ...]]:
+        ...
+
+
 class TesterAPI(ABC):
+    alexandria: AlexandriaTesterAPI
+
     @abstractmethod
     def register_pool(self, pool: PoolAPI, channels: SessionChannels) -> None:
         ...

--- a/ddht/tools/driver/tester.py
+++ b/ddht/tools/driver/tester.py
@@ -13,6 +13,7 @@ import trio
 from ddht._utils import humanize_node_id
 from ddht.endpoint import Endpoint
 from ddht.tools.driver.abc import NodeAPI, SessionPairAPI, TesterAPI
+from ddht.tools.driver.alexandria import AlexandriaTester
 from ddht.tools.driver.node import Node
 from ddht.tools.driver.session import SessionPair
 from ddht.tools.factories.endpoint import EndpointFactory
@@ -78,6 +79,8 @@ class Tester(TesterAPI):
         self._pools = {}
         self._managed_dispatchers = {}
         self._running_dispatchers = set()
+
+        self.alexandria = AlexandriaTester(self)
 
     def register_pool(self, pool: PoolAPI, channels: SessionChannels) -> None:
         if pool.local_node_id in self._pools:

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -9,6 +9,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    Union,
 )
 
 from async_service import ServiceAPI
@@ -346,6 +347,7 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     max_advertisement_count: int
 
     radius_tracker: RadiusTrackerAPI
+    broadcast_log: BroadcastLogAPI
 
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI
@@ -465,12 +467,18 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
 
     @abstractmethod
     def recursive_find_nodes(
-        self, target: NodeID
+        self, target: Union[NodeID, ContentID],
     ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:
         ...
 
     @abstractmethod
     def explore(
-        self, target: NodeID, concurrency: int = 3,
+        self, target: Union[NodeID, ContentID], concurrency: int = 3,
     ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:
+        ...
+
+    @abstractmethod
+    async def broadcast(
+        self, advertisement: Advertisement, redundancy_factor: int = 3
+    ) -> Tuple[NodeID, ...]:
         ...

--- a/ddht/v5_1/alexandria/broadcast_log.py
+++ b/ddht/v5_1/alexandria/broadcast_log.py
@@ -5,11 +5,12 @@ from typing import Dict
 from eth_typing import Hash32, NodeID
 from lru import LRU
 
+from ddht.v5_1.alexandria.abc import BroadcastLogAPI
 from ddht.v5_1.alexandria.advertisements import Advertisement
 from ddht.v5_1.alexandria.constants import ONE_HOUR
 
 
-class BroadcastLog:
+class BroadcastLog(BroadcastLogAPI):
     """
     Tracks the last time each advertisement was broadcast to each peer.
     """

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -1,5 +1,5 @@
 import logging
-from typing import AsyncContextManager, Collection, List, Optional, Tuple
+from typing import AsyncContextManager, Collection, List, Optional, Set, Tuple, Union
 
 from async_service import Service
 from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
@@ -23,6 +23,7 @@ from ddht.v5_1.alexandria.abc import (
     ContentStorageAPI,
 )
 from ddht.v5_1.alexandria.advertisements import Advertisement
+from ddht.v5_1.alexandria.broadcast_log import BroadcastLog
 from ddht.v5_1.alexandria.client import AlexandriaClient
 from ddht.v5_1.alexandria.content import compute_content_distance
 from ddht.v5_1.alexandria.content_provider import ContentProvider
@@ -34,7 +35,7 @@ from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
 from ddht.v5_1.alexandria.radius_tracker import RadiusTracker
 from ddht.v5_1.alexandria.resource_queue import ResourceQueue
 from ddht.v5_1.alexandria.sedes import content_sedes
-from ddht.v5_1.alexandria.typing import ContentKey
+from ddht.v5_1.alexandria.typing import ContentID, ContentKey
 from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE
 from ddht.v5_1.network import common_explore_network, common_recursive_find_nodes
 
@@ -60,6 +61,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         self.client = AlexandriaClient(network)
 
         self.radius_tracker = RadiusTracker(self)
+        self.broadcast_log = BroadcastLog()
 
         self.routing_table = KademliaRoutingTable(
             self.enr_manager.enr.node_id, ROUTING_TABLE_BUCKET_SIZE,
@@ -213,14 +215,14 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         )
 
     def recursive_find_nodes(
-        self, target: NodeID
+        self, target: Union[NodeID, ContentID],
     ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:
-        return common_recursive_find_nodes(self, target)
+        return common_recursive_find_nodes(self, NodeID(target))
 
     def explore(
-        self, target: NodeID, concurrency: int = 3,
+        self, target: Union[NodeID, ContentID], concurrency: int = 3,
     ) -> AsyncContextManager[trio.abc.ReceiveChannel[ENRAPI]]:
-        return common_explore_network(self, target, concurrency=concurrency)
+        return common_explore_network(self, NodeID(target), concurrency=concurrency)
 
     async def get_content_proof(
         self,
@@ -490,6 +492,83 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
             for response in responses
             for advertisement in response.message.payload.locations
         )
+
+    async def broadcast(
+        self, advertisement: Advertisement, redundancy_factor: int = 3
+    ) -> Tuple[NodeID, ...]:
+        self.logger.debug("Broadcasting: advertisement=%s", advertisement)
+        acked_nodes: Set[NodeID] = set()
+
+        # Use the redundancy_factor also as the concurrency limit
+        lock = trio.Semaphore(redundancy_factor)
+        condition = trio.Condition()
+
+        async def _do_advertise(node_id: NodeID) -> None:
+            nonlocal acked_nodes
+
+            async with lock:
+                if len(acked_nodes) >= redundancy_factor:
+                    return
+
+                # verify we haven't recently sent this node the same advertisement
+                if self.broadcast_log.was_logged(node_id, advertisement):
+                    return
+
+                # verify the node should be interested in the advertisement based
+                # on their advertisement radius.
+                advertisement_radius = await self.radius_tracker.get_advertisement_radius(
+                    node_id,
+                )
+                distance_to_content = compute_content_distance(
+                    node_id, advertisement.content_id
+                )
+
+                if distance_to_content > advertisement_radius:
+                    return
+
+                # attempt to send the advertisement to the node.
+                try:
+                    await self.advertise(node_id, advertisements=(advertisement,))
+                except trio.TooSlowError:
+                    self.logger.debug(
+                        "Broadcast timeout: node_id=%s  advertisement=%s",
+                        node_id.hex(),
+                        advertisement,
+                    )
+                    return
+                else:
+                    self.logger.debug(
+                        "Broadcast successful: node_id=%s  advertisement=%s",
+                        node_id.hex(),
+                        advertisement,
+                    )
+                    # log the broadcast
+                    self.broadcast_log.log(node_id, advertisement)
+                finally:
+                    async with condition:
+                        acked_nodes.add(node_id)
+                        condition.notify_all()
+
+        async with trio.open_nursery() as nursery:
+
+            async def _source_nodes_for_broadcast() -> None:
+                async with self.explore(advertisement.content_id) as enr_aiter:
+                    async for enr in enr_aiter:
+                        if len(acked_nodes) >= redundancy_factor:
+                            break
+
+                        nursery.start_soon(_do_advertise, enr.node_id)
+
+            nursery.start_soon(_source_nodes_for_broadcast)
+
+            # exit as soon as there are either no more child tasks or we have
+            # successfully broadcast to enough nodes.
+            while nursery.child_tasks and len(acked_nodes) < redundancy_factor:
+                with trio.move_on_after(1):
+                    async with condition:
+                        await condition.wait()
+
+        return tuple(acked_nodes)
 
     #
     # Long Running Processes


### PR DESCRIPTION
## What was wrong?

We need a new high level API primative on the AlexandriaNetworkAPI for broadcasting an advertisement to the appropriate set of peers.

## How was it fixed?

Originally this got implemented in the `AdvertisementManagerAPI` in #201 , however, as development continues and I began implementing the logic for actually managing individual content, it became clear that this belonged at the core API layer as it needs to be accessed by both the `AdvertisementManagerAPI` and the in-progress-not-yet-pull-requested-or-fully-implemented `ContentManagerAPI`

This implements a simplified/optimized version of the broadcast gossip logic (that will probably need to be further refined) which seeks out a minimum number of peers which are interested in the advertisement and advertises it to them.

#### Cute Animal Picture

![Amazing Animals Jumping (20)](https://user-images.githubusercontent.com/824194/100471135-e29b7a80-3096-11eb-928c-a66e03da2877.jpg)

