### PR TITLE
remove redundant ENR setting in some test fixtures

### DIFF
--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -173,7 +173,7 @@ async def common_recursive_find_nodes(
         for enr in new_enrs:
             try:
                 await send_channel.send(enr)
-            except trio.BrokenResourceError:
+            except (trio.BrokenResourceError, trio.ClosedResourceError):
                 # In the event that the consumer of `recursive_find_nodes`
                 # exits early before the lookup has completed we can end up
                 # operating on a closed channel.
@@ -208,7 +208,7 @@ async def common_recursive_find_nodes(
                         enr = network.enr_db.get_enr(node_id)
                         received_node_ids.add(node_id)
                         await send_channel.send(enr)
-            except trio.BrokenResourceError:
+            except (trio.BrokenResourceError, trio.ClosedResourceError):
                 # In the event that the consumer of `recursive_find_nodes`
                 # exits early before the lookup has completed we can end up
                 # operating on a closed channel.

--- a/tests/core/v5_1/conftest.py
+++ b/tests/core/v5_1/conftest.py
@@ -9,6 +9,9 @@ def tester():
     return Tester()
 
 
+#
+# Nodes
+#
 @pytest.fixture
 async def alice(tester, bob):
     node = tester.node()
@@ -25,45 +28,40 @@ async def bob(tester):
 
 
 @pytest.fixture
+async def carol(tester):
+    return tester.node()
+
+
+@pytest.fixture
 async def driver(tester, alice, bob):
     return tester.session_pair(alice, bob)
 
 
+#
+# Clients
+#
 @pytest.fixture
-async def alice_client(alice, bob):
-    try:
-        alice.enr_db.set_enr(bob.enr)
-    except OldSequenceNumber:
-        pass
+async def alice_client(alice, bob, carol):
     async with alice.client() as alice_client:
         yield alice_client
 
 
 @pytest.fixture
 async def bob_client(alice, bob):
-    try:
-        bob.enr_db.set_enr(alice.enr)
-    except OldSequenceNumber:
-        pass
     async with bob.client() as bob_client:
         yield bob_client
 
 
+#
+# Networks
+#
 @pytest.fixture
 async def alice_network(alice, bob):
-    try:
-        alice.enr_db.set_enr(bob.enr)
-    except OldSequenceNumber:
-        pass
     async with alice.network() as alice_network:
         yield alice_network
 
 
 @pytest.fixture
 async def bob_network(alice, bob):
-    try:
-        bob.enr_db.set_enr(alice.enr)
-    except OldSequenceNumber:
-        pass
     async with bob.network() as bob_network:
         yield bob_network


### PR DESCRIPTION
## What was wrong?

There was some extra ENR setting logic in the test setup that wasn't necessary.

## How was it fixed?

removed it

#### Cute Animal Picture

![jumping-bobcat](https://user-images.githubusercontent.com/824194/100484298-05d72180-30b9-11eb-8944-f78d3597a742.jpg)

