### PR TITLE
Use cache for NetworkAPI.bond

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -500,7 +500,11 @@ class NetworkAPI(ServiceAPI):
     #
     @abstractmethod
     async def bond(
-        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
+        self,
+        node_id: NodeID,
+        *,
+        endpoint: Optional[Endpoint] = None,
+        max_cache_age: int = 60,
     ) -> bool:
         ...
 

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -392,7 +392,11 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     #
     @abstractmethod
     async def bond(
-        self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None,
+        self,
+        node_id: NodeID,
+        *,
+        endpoint: Optional[Endpoint] = None,
+        max_cache_age: int = 60,
     ) -> bool:
         ...
 


### PR DESCRIPTION
## What was wrong?

We should avoid re-bonding with nodes too often..

## How was it fixed?

Add a cache to `NetworkAPI.bond` which will cache bonding for 60 seconds.


#### Cute Animal Picture


![3578048015_ccf8e25b89_o](https://user-images.githubusercontent.com/824194/100678795-32926f80-332b-11eb-9b54-6d1024bef7c5.jpg)

