### PR TITLE
[WIP] Refactor session timeout monitoring

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -116,6 +116,10 @@ class SessionAPI(ABC):
     def is_after_handshake(self) -> bool:
         ...
 
+    @abstractmethod
+    async def await_handshake_completion(self) -> None:
+        ...
+
     #
     # Message and Envelope handlers
     #

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -159,6 +159,15 @@ class BaseSession(SessionAPI):
     async def _process_message_buffers(self) -> None:
         ...
 
+    async def await_handshake_completion(self) -> None:
+        if self.is_after_handshake:
+            raise Exception("Handshake is already complete")
+
+        async with self._events.session_handshake_complete.subscribe() as subscription:
+            async for session in subscription:
+                if session.id == self.id:
+                    return
+
     def decode_message(self, packet: Packet[MessagePacket]) -> BaseMessage:
         return decode_message(
             self.keys.decryption_key,


### PR DESCRIPTION
## What was wrong?
A more efficient way to timeout sessions was needed, to avoid hitting the max # of child task limit.

## How was it fixed?
Stop monitoring for session timeouts as soon as the handshake is complete.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
