### PR TITLE
Proper exception handling and testing for found nodes

### DIFF
--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -6,6 +6,7 @@ from async_service import Service
 from eth_enr import ENRAPI, ENRManager, QueryableENRDatabaseAPI
 from eth_keys import keys
 from eth_typing import NodeID
+from eth_utils import ValidationError
 import trio
 
 from ddht.base_message import AnyInboundMessage, AnyOutboundMessage, InboundMessage
@@ -389,10 +390,9 @@ class Client(Service, ClientAPI):
                         tail_responses.append(await subscription.receive())
                     responses = (head_response,) + tuple(tail_responses)
                 else:
-                    # TODO: this code path needs to be excercised and
-                    # probably replaced with some sort of
-                    # `SessionTerminated` exception.
-                    raise Exception("Invalid `total` counter in response")
+                    raise ValidationError(
+                        f"Invalid `total` counter in response: total={total}"
+                    )
 
                 return responses
 

--- a/tests/core/test_enr_partitioning.py
+++ b/tests/core/test_enr_partitioning.py
@@ -14,17 +14,20 @@ from ddht.enr import partition_enrs
 
 @settings(max_examples=50, deadline=1000)
 @given(
-    num_enr_records=st.integers(min_value=1, max_value=100),
+    num_enr_records=st.integers(min_value=0, max_value=100),
     max_payload_size=st.integers(
         min_value=MAX_ENR_SIZE, max_value=DISCOVERY_MAX_PACKET_SIZE
     ),
 )
-def test_enr_partitioning(num_enr_records, max_payload_size):
+def test_enr_partitioning_fuzzy(num_enr_records, max_payload_size):
     enrs = ENRFactory.create_batch(num_enr_records)
     batches = partition_enrs(enrs, max_payload_size)
 
     assert sum(len(batch) for batch in batches) == len(enrs)
     assert set(itertools.chain(*batches)) == set(enrs)
+
+    if num_enr_records == 0:
+        assert batches == ((),)
 
     for batch in batches:
         encoded_batch = rlp.encode(batch, sedes=rlp.sedes.CountableList(ENRSedes))


### PR DESCRIPTION
## What was wrong?

An unhandled and untested exception case in the handling of `ClientAPI.find_nodes` when we receive a message with a `total == 0` which is invalid.

## How was it fixed?

Raise a `ValidationError` and add testing.


#### Cute Animal Picture

![2017-04-11-13-01-37](https://user-images.githubusercontent.com/824194/100923461-6e991200-349c-11eb-8bd3-af4d944a46f4.jpg)

