### PR TITLE
Implement AdvertisementProviderAPI

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -86,6 +86,12 @@ class ContentProviderAPI(ServiceAPI):
         ...
 
 
+class AdvertisementProviderAPI(ServiceAPI):
+    @abstractmethod
+    async def ready(self) -> None:
+        ...
+
+
 class RadiusTrackerAPI(ServiceAPI):
     @abstractmethod
     async def ready(self) -> None:
@@ -347,10 +353,11 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
 
     radius_tracker: RadiusTrackerAPI
 
+    advertisement_db: AdvertisementDatabaseAPI
+    advertisement_provider: AdvertisementProviderAPI
+
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI
-
-    advertisement_db: AdvertisementDatabaseAPI
 
     @abstractmethod
     async def ready(self) -> None:

--- a/ddht/v5_1/alexandria/advertisement_provider.py
+++ b/ddht/v5_1/alexandria/advertisement_provider.py
@@ -1,0 +1,64 @@
+import logging
+
+from async_service import Service
+from eth_utils.toolz import take
+import trio
+
+from ddht.base_message import InboundMessage
+from ddht.v5_1.alexandria.abc import (
+    AdvertisementDatabaseAPI,
+    AdvertisementProviderAPI,
+    AlexandriaClientAPI,
+)
+from ddht.v5_1.alexandria.messages import LocateMessage
+
+MAX_RESPONSE_ADVERTISEMENTS = 32
+
+
+class AdvertisementProvider(Service, AdvertisementProviderAPI):
+    logger = logging.getLogger("ddht.AdvertisementProvider")
+
+    def __init__(
+        self,
+        client: AlexandriaClientAPI,
+        advertisement_db: AdvertisementDatabaseAPI,
+        concurrency: int = 3,
+    ) -> None:
+        self._client = client
+        self._advertisement_db = advertisement_db
+        self._concurrency_lock = trio.Semaphore(concurrency)
+        self._ready = trio.Event()
+
+    async def ready(self) -> None:
+        await self._ready.wait()
+
+    async def run(self) -> None:
+        async with trio.open_nursery() as nursery:
+            async with self._client.subscribe(LocateMessage) as subscription:
+                self._ready.set()
+                async for request in subscription:
+                    nursery.start_soon(self.serve_request, request)
+
+    async def serve_request(self, request: InboundMessage[LocateMessage]) -> None:
+        with trio.move_on_after(10):
+            async with self._concurrency_lock:
+                content_key = request.message.payload.content_key
+
+                advertisements = tuple(
+                    take(
+                        MAX_RESPONSE_ADVERTISEMENTS,
+                        self._advertisement_db.query(content_key=content_key),
+                    )
+                )
+                self.logger.debug(
+                    "Serving request: id=%s  content_key=%s  num=%d",
+                    request.request_id.hex(),
+                    content_key.hex(),
+                    len(advertisements),
+                )
+                await self._client.send_locations(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    advertisements=advertisements,
+                    request_id=request.request_id,
+                )

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -22,6 +22,7 @@ from ddht.v5_1.alexandria.abc import (
     AlexandriaNetworkAPI,
     ContentStorageAPI,
 )
+from ddht.v5_1.alexandria.advertisement_provider import AdvertisementProvider
 from ddht.v5_1.alexandria.advertisements import Advertisement
 from ddht.v5_1.alexandria.client import AlexandriaClient
 from ddht.v5_1.alexandria.content import compute_content_distance
@@ -84,6 +85,11 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         )
 
         self.advertisement_db = advertisement_db
+        self.advertisement_provider = AdvertisementProvider(
+            client=self.client, advertisement_db=self.advertisement_db,
+        )
+
+        self.radius_tracker = RadiusTracker(self)
 
         self._last_pong_at = LRU(2048)
         self._routing_table_ready = trio.Event()

--- a/tests/core/v5_1/alexandria/test_advertisement_provider.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_provider.py
@@ -1,0 +1,55 @@
+import sqlite3
+
+from async_service import background_trio_service
+import pytest
+import trio
+
+from ddht.tools.factories.alexandria import AdvertisementFactory
+from ddht.v5_1.alexandria.advertisement_db import AdvertisementDatabase
+from ddht.v5_1.alexandria.advertisement_provider import AdvertisementProvider
+
+
+@pytest.mark.trio
+async def test_content_provider_serves_advertisements(
+    alice, bob, alice_alexandria_network, bob_alexandria_client,
+):
+    content_key = b"test-content-key"
+    advertisement_db = AdvertisementDatabase(sqlite3.connect(":memory:"))
+    advertisements = tuple(
+        AdvertisementFactory(content_key=content_key) for _ in range(5)
+    )
+    for advertisement in advertisements:
+        advertisement_db.add(advertisement)
+
+    advertisement_provider = AdvertisementProvider(
+        bob_alexandria_client, advertisement_db
+    )
+    async with background_trio_service(advertisement_provider):
+        # this ensures that the subscription is in place.
+        await advertisement_provider.ready()
+
+        with trio.fail_after(2):
+            result = await alice_alexandria_network.locate(
+                bob.node_id, content_key=content_key,
+            )
+            assert set(result) == set(advertisements)
+
+
+@pytest.mark.trio
+async def test_content_provider_serves_unknown_content_key_request(
+    alice, bob, alice_alexandria_network, bob_alexandria_client,
+):
+    advertisement_db = AdvertisementDatabase(sqlite3.connect(":memory:"))
+
+    advertisement_provider = AdvertisementProvider(
+        bob_alexandria_client, advertisement_db
+    )
+    async with background_trio_service(advertisement_provider):
+        # this ensures that the subscription is in place.
+        await advertisement_provider.ready()
+
+        with trio.fail_after(2):
+            result = await alice_alexandria_network.locate(
+                bob.node_id, content_key=b"test-content-key",
+            )
+            assert len(result) == 0


### PR DESCRIPTION
## What was wrong?

We need a process that listens for LOCATE messages and responds with information from our advertisement table

## How was it fixed?

A new `AdvertisementProviderAPI` service which subscriibes to `LocateMessage` and responds with the relevant information from the advertisement database.

#### Cute Animal Picture

![show-jumping-rabbit](https://user-images.githubusercontent.com/824194/101409981-e51e8100-389b-11eb-8172-93e5bfe03bb5.jpg)

