### PR TITLE
Ensure network APIs are ready before using them

### DIFF
--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -66,4 +66,5 @@ class AlexandriaNode(AlexandriaNodeAPI):
                     advertisement_db=self.advertisement_db,
                 )
                 async with background_trio_service(alexandria_network):
+                    await alexandria_network.ready()
                     yield alexandria_network

--- a/ddht/tools/driver/node.py
+++ b/ddht/tools/driver/node.py
@@ -84,4 +84,5 @@ class Node(NodeAPI):
             network = Network(client, bootnodes)
             async with background_trio_service(network):
                 await client.wait_listening()
+                await network.ready()
                 yield network

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -451,6 +451,10 @@ class NetworkAPI(ServiceAPI):
     client: ClientAPI
     routing_table: RoutingTableAPI
 
+    @abstractmethod
+    async def ready(self) -> None:
+        ...
+
     #
     # Proxied ClientAPI properties
     #

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -352,6 +352,13 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
 
     advertisement_db: AdvertisementDatabaseAPI
 
+    @abstractmethod
+    async def ready(self) -> None:
+        ...
+
+    #
+    # Properties from base network
+    #
     @property
     @abstractmethod
     def network(self) -> NetworkAPI:

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -88,6 +88,13 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         self._last_pong_at = LRU(2048)
         self._routing_table_ready = trio.Event()
 
+        self._ping_handler_ready = trio.Event()
+        self._find_nodes_handler_ready = trio.Event()
+
+    async def ready(self) -> None:
+        await self._ping_handler_ready.wait()
+        await self._find_nodes_handler_ready.wait()
+
     @property
     def network(self) -> NetworkAPI:
         return self.client.network
@@ -493,6 +500,8 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
 
     async def _pong_when_pinged(self) -> None:
         async with self.client.subscribe(PingMessage) as subscription:
+            self._ping_handler_ready.set()
+
             async for request in subscription:
                 await self.client.send_pong(
                     request.sender_node_id,
@@ -511,6 +520,8 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
 
     async def _serve_find_nodes(self) -> None:
         async with self.client.subscribe(FindNodesMessage) as subscription:
+            self._find_nodes_handler_ready.set()
+
             async for request in subscription:
                 response_enrs: List[ENRAPI] = []
                 distances = set(request.message.payload.distances)

--- a/tests/core/v5_1/test_network.py
+++ b/tests/core/v5_1/test_network.py
@@ -67,11 +67,9 @@ async def test_network_responds_to_find_node_requests(alice, bob):
 
 
 @pytest.mark.trio
-async def test_network_ping_api(alice, bob):
-    async with alice.network() as alice_network:
-        async with bob.network():
-            with trio.fail_after(2):
-                pong = await alice_network.ping(bob.node_id)
+async def test_network_ping_api(alice, bob, alice_network, bob_network):
+    with trio.fail_after(2):
+        pong = await alice_network.ping(bob.node_id)
 
     assert pong.enr_seq == bob.enr.sequence_number
     assert pong.packet_ip == alice.endpoint.ip_address


### PR DESCRIPTION
## What was wrong?

Occasional timeout due to what I think were race conditions using the `NetworkAPI` before the handlers for certain messages were in place.

## How was it fixed?

Now each API has a `ready()` that can be awaited to ensure these are in place.

#### Cute Animal Picture

![small-dog-jumping-up-in-the-air](https://user-images.githubusercontent.com/824194/101218410-40ecce00-3640-11eb-991e-78e8551e967d.jpg)

