### PR TITLE
Try to firm up flaky RPC tests

### DIFF
--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -230,11 +230,11 @@ async def common_recursive_find_nodes(
 
     async def _monitor_done(send_channel: trio.abc.SendChannel[ENRAPI]) -> None:
         async with send_channel:
-            while True:
-                # this `fail_after` is a failsafe to prevent deadlock situations
-                # which are possible with `Condition` objects.
-                with trio.fail_after(60):
-                    async with condition:
+            async with condition:
+                while True:
+                    # this `fail_after` is a failsafe to prevent deadlock situations
+                    # which are possible with `Condition` objects.
+                    with trio.fail_after(60):
                         node_ids = get_unqueried_node_ids()
 
                         if not node_ids and not in_flight:


### PR DESCRIPTION
## What was wrong?

There was some fixture cleanup in the RPC tests and a subtle mis-use of the `trio.Condition` object used in RFN

## How was it fixed?

Removed the redundant fixture code

Moved the acqusition of the condition lock to the outermost layer to avoid race conditions where the condition is triggered between the time when the lock is released and acquired.

#### Cute Animal Picture

![adelie-penguin-jumping-ocean ngsversion 1396530997321 adapt 1900 1](https://user-images.githubusercontent.com/824194/101378501-65c78800-3870-11eb-90ae-63069cfc8b27.jpg)

