### PR TITLE
Handle ConnectionResetError in rpc server

### DIFF
--- a/ddht/rpc.py
+++ b/ddht/rpc.py
@@ -224,12 +224,13 @@ class RPCServer(Service):
             while True:
                 try:
                     request = await read_json(socket, buffer)
-                except DecodingError:
-                    # If the connection receives bad JSON, close the connection.
+                except (DecodingError, ConnectionResetError) as err:
+                    self.logger.debug("Closing socket due to error: %s", err)
+                    # Exit if the connection receives bad JSON or closes
                     return
 
                 if not isinstance(request, collections.abc.Mapping):
-                    logger.debug("Invalid payload: %s", type(request))
+                    self.logger.debug("Invalid payload: %s", type(request))
                     await write_error(socket, "Invalid Request: not a mapping")
                     continue
 


### PR DESCRIPTION
## What was wrong?

A `ConnectionResetError` was causing flakey tests and the crash of the `RPCServer`

## How was it fixed?

Simple error handling.

#### Cute Animal Picture

![Hare-660x330](https://user-images.githubusercontent.com/824194/101413517-ab507900-38a1-11eb-8a20-dcab1d7501a5.jpg)

