### PR TITLE
move ResourceQueue

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -5,12 +5,16 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncContextManager,
+    Collection,
+    Container,
     ContextManager,
     Deque,
     Generic,
+    Hashable,
     Iterator,
     List,
     Optional,
+    Set,
     Tuple,
     Type,
     TypedDict,
@@ -305,4 +309,28 @@ class RequestTrackerAPI(ABC):
 class ApplicationAPI(ServiceAPI):
     @abstractmethod
     def __init__(self, args: argparse.Namespace, boot_info: BootInfo) -> None:
+        ...
+
+
+TResource = TypeVar("TResource", bound=Hashable)
+
+
+class ResourceQueueAPI(Container[TResource]):
+    resources: Set[TResource]
+
+    @abstractmethod
+    def __init__(
+        self, resources: Collection[TResource], max_resource_count: int = None,
+    ) -> None:
+        ...
+
+    @abstractmethod
+    async def add(self, resource: TResource) -> None:
+        ...
+
+    @abstractmethod
+    def remove(self, resource: TResource) -> None:
+        ...
+
+    def reserve(self) -> AsyncContextManager[TResource]:
         ...

--- a/ddht/resource_queue.py
+++ b/ddht/resource_queue.py
@@ -1,16 +1,20 @@
-from typing import Any, AsyncIterator, Collection, Container, Hashable, Set, TypeVar
+from typing import Any, AsyncIterator, Collection, Set
 
 from async_generator import asynccontextmanager
 import trio
 
-TResource = TypeVar("TResource", bound=Hashable)
+from ddht.abc import ResourceQueueAPI, TResource
 
 
 class RemoveResource(Exception):
     pass
 
 
-class ResourceQueue(Container[TResource]):
+class EmptyResourceQueue(Exception):
+    pass
+
+
+class ResourceQueue(ResourceQueueAPI[TResource]):
     """
     Allow some set of "worker" processes to share the underlying resources,
     ensuring that any given resource is only in use by a single worker at any

--- a/ddht/resource_queue.py
+++ b/ddht/resource_queue.py
@@ -10,10 +10,6 @@ class RemoveResource(Exception):
     pass
 
 
-class EmptyResourceQueue(Exception):
-    pass
-
-
 class ResourceQueue(ResourceQueueAPI[TResource]):
     """
     Allow some set of "worker" processes to share the underlying resources,

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -15,6 +15,7 @@ from ddht._utils import every, weighted_choice
 from ddht.constants import ROUTING_TABLE_BUCKET_SIZE
 from ddht.endpoint import Endpoint
 from ddht.kademlia import KademliaRoutingTable, at_log_distance
+from ddht.resource_queue import ResourceQueue
 from ddht.token_bucket import TokenBucket
 from ddht.v5_1.abc import NetworkAPI
 from ddht.v5_1.alexandria.abc import (
@@ -35,7 +36,6 @@ from ddht.v5_1.alexandria.partials.chunking import slice_segments_to_max_chunk_c
 from ddht.v5_1.alexandria.partials.proof import Proof, compute_proof, validate_proof
 from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
 from ddht.v5_1.alexandria.radius_tracker import RadiusTracker
-from ddht.v5_1.alexandria.resource_queue import ResourceQueue
 from ddht.v5_1.alexandria.sedes import content_sedes
 from ddht.v5_1.alexandria.typing import ContentID, ContentKey
 from ddht.v5_1.constants import ROUTING_TABLE_KEEP_ALIVE

--- a/tests/core/test_resource_queue.py
+++ b/tests/core/test_resource_queue.py
@@ -3,7 +3,7 @@ import random
 import pytest
 import trio
 
-from ddht.v5_1.alexandria.resource_queue import ResourceQueue
+from ddht.resource_queue import ResourceQueue
 
 
 async def _yield(num: int = 10, base: int = 0):


### PR DESCRIPTION
## What was wrong?

The `ResourceQueue` doesn't need to be in the alexandria module

## How was it fixed?

Moved it to the base of the library.

#### Cute Animal Picture

![penguin-jumping](https://user-images.githubusercontent.com/824194/101662413-b8d34380-3a06-11eb-9bcd-e605771084ac.jpg)

