### PR TITLE
Add AdvertisementManagerAPI.new_advertisement

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -17,7 +17,12 @@ from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
 from eth_typing import Hash32, NodeID
 import trio
 
-from ddht.abc import RequestTrackerAPI, RoutingTableAPI, SubscriptionManagerAPI
+from ddht.abc import (
+    EventAPI,
+    RequestTrackerAPI,
+    RoutingTableAPI,
+    SubscriptionManagerAPI,
+)
 from ddht.base_message import InboundMessage
 from ddht.endpoint import Endpoint
 from ddht.v5_1.abc import NetworkAPI, TalkProtocolAPI
@@ -150,6 +155,8 @@ class AdvertisementDatabaseAPI(ABC):
 
 
 class AdvertisementManagerAPI(ServiceAPI):
+    new_advertisement: EventAPI[Advertisement]
+
     @abstractmethod
     async def ready(self) -> None:
         ...


### PR DESCRIPTION
## What was wrong?

We will end up needing to monitor for *new* advertisements.

## How was it fixed?

Create `AdvertisementManager.new_advertisement` which is a `EventAPI` allowing consumers to subscribe to it.

#### Cute Animal Picture

![fb2da24d0e2891ddce5273d770c8ced3--wild-animals-funny-animals](https://user-images.githubusercontent.com/824194/101664280-e620f100-3a08-11eb-8dd6-eb3884298010.jpg)

