### PR TITLE
Don't enforce maximum on broadcast test

### DIFF
--- a/tests/core/v5_1/alexandria/test_alexandria_network.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_network.py
@@ -464,6 +464,5 @@ async def test_alexandria_network_broadcast_api(
             with trio.fail_after(30):
                 result = await alice_alexandria_network.broadcast(advertisement)
                 assert len(result) > 0
-                assert len(result) <= 3
 
             nursery.cancel_scope.cancel()


### PR DESCRIPTION
## What was wrong?

Flakey test

## How was it fixed?

Don't enforce the upper bound because we don't actually care.

#### Cute Animal Picture

![windowwasher](https://user-images.githubusercontent.com/824194/101664396-0650b000-3a09-11eb-9c84-b0cc3eb74bb6.JPG)

