### PR TITLE
Validate advertisements returned by AlexandriaNetworkAPI.locate

### DIFF
--- a/ddht/tools/factories/alexandria.py
+++ b/ddht/tools/factories/alexandria.py
@@ -43,6 +43,9 @@ class AdvertisementFactory(factory.Factory):  # type: ignore
 
     @classmethod
     def expired(cls, **kwargs: Any) -> "Advertisement":
-        assert "expires_at" not in kwargs
         expires_at = datetime.datetime.utcnow().replace(microsecond=0) - ONE_HOUR
         return cls(**kwargs, expires_at=expires_at)
+
+    @classmethod
+    def invalid(cls, **kwargs: Any) -> "Advertisement":
+        return cls(**kwargs, signature_v=1, signature_r=12345, signature_s=24689)

--- a/tests/core/v5_1/alexandria/test_advertisements.py
+++ b/tests/core/v5_1/alexandria/test_advertisements.py
@@ -42,18 +42,8 @@ def test_advertisement_creation():
     assert ad.node_id == expected_node_id
 
 
-@pytest.mark.xfail
 def test_advertisement_with_invalid_signature():
-    base = AdvertisementFactory()
-
-    ad = AdvertisementFactory(
-        signature_v=base.signature_v,
-        signature_r=base.signature_r,
-        signature_s=base.signature_s,
-    )
-    assert ad.signature_v == base.signature_v
-    assert ad.signature_r == base.signature_r
-    assert ad.signature_s == base.signature_s
+    ad = AdvertisementFactory.invalid()
 
     assert not ad.is_valid
 
@@ -63,20 +53,6 @@ def test_advertisement_with_invalid_signature():
         ad.public_key
     with pytest.raises(BadSignature):
         ad.verify()
-
-
-def test_advertisement_with_malformed_signature():
-    ad = AdvertisementFactory(
-        signature_v=1, signature_r=1357924680, signature_s=2468013579,
-    )
-
-    assert not ad.is_valid
-
-    with pytest.raises(BadSignature):
-        ad.node_id
-
-    with pytest.raises(BadSignature):
-        ad.public_key
 
 
 def test_advertisement_to_and_from_sedes_payload():


### PR DESCRIPTION
## What was wrong?

Someone could send us invalid advertisements which would trigger exceptions in certain cases.

## How was it fixed?

Ensure that all ads returned by `AlexandriaNetworkAPI.locate` are valid.

#### Cute Animal Picture

![01becd76acb79ec39e41a37c39ec7949](https://user-images.githubusercontent.com/824194/101665519-4ebc9d80-3a0a-11eb-9bbc-6dc40dc83be4.png)

