### PR TITLE
Slight improvement to Alexandria routing table management

### DIFF
--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -739,15 +739,15 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                 pass
 
         # Now repeatedly try to bond with each bootnode until one succeeds.
-        async with trio.open_nursery() as nursery:
-            while self.manager.is_running:
-                for enr in self._bootnodes:
-                    if enr.node_id == self.local_node_id:
-                        continue
-                    endpoint = Endpoint.from_enr(enr)
-                    nursery.start_soon(self._bond, enr.node_id, endpoint)
+        while self.manager.is_running:
+            with trio.move_on_after(10):
+                async with trio.open_nursery() as nursery:
+                    for enr in self._bootnodes:
+                        if enr.node_id == self.local_node_id:
+                            continue
+                        endpoint = Endpoint.from_enr(enr)
+                        nursery.start_soon(self._bond, enr.node_id, endpoint)
 
-                with trio.move_on_after(10):
                     await self._routing_table_ready.wait()
                     break
 


### PR DESCRIPTION
## What was wrong?

A slight improvement to the logic for initializing the routing table that never got ported from the base network into alexandria.

## How was it fixed?

Shuflle the contexts around a little for more efficient timeout management.

#### Cute Animal Picture



![4526122c5d18fb3ed1bca0b728fb4de1](https://user-images.githubusercontent.com/824194/101666364-5b8dc100-3a0b-11eb-9c30-f60544b21441.png)


