### PR TITLE
Implement location streaming APIs for Alexandria

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -372,6 +372,17 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     ) -> Tuple[InboundMessage[LocationsMessage], ...]:
         ...
 
+    @abstractmethod
+    def stream_locate(
+        self,
+        node_id: NodeID,
+        endpoint: Endpoint,
+        *,
+        content_key: ContentKey,
+        request_id: Optional[bytes] = None,
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[InboundMessage[LocationsMessage]]]:
+        ...
+
 
 class ContentRetrievalAPI(ServiceAPI):
     content_key: ContentKey
@@ -512,6 +523,23 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         endpoint: Optional[Endpoint] = None,
         request_id: Optional[bytes] = None,
     ) -> Tuple[Advertisement, ...]:
+        ...
+
+    @abstractmethod
+    def stream_locate(
+        self,
+        node_id: NodeID,
+        *,
+        content_key: ContentKey,
+        endpoint: Optional[Endpoint] = None,
+        request_id: Optional[bytes] = None,
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[Advertisement]]:
+        ...
+
+    @abstractmethod
+    def stream_locations(
+        self, content_key: ContentKey, *, hash_tree_root: Optional[Hash32] = None,
+    ) -> AsyncContextManager[trio.abc.ReceiveChannel[Advertisement]]:
         ...
 
     @abstractmethod


### PR DESCRIPTION
## What was wrong?

When searching for content we need to be able to quickly find advertisements.

## How was it fixed?

Leverages multiple layers of async streaming APIs that allow us to quickly zero in on a part of the network (`recursive_find_nodes(...)`) and then enumerate the nodes in that area of the network (`explore(...)`, and then query them for advertisements  `stream_locate(...)`.

#### Cute Animal Picture

![Funny Animals Using Mobiles (1)](https://user-images.githubusercontent.com/824194/101701272-d373df80-3a3b-11eb-94bc-dc6b3b457d10.jpg)

