### PR TITLE
Make ResourceQueue be Sized

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -15,6 +15,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Sized,
     Tuple,
     Type,
     TypedDict,
@@ -315,7 +316,7 @@ class ApplicationAPI(ServiceAPI):
 TResource = TypeVar("TResource", bound=Hashable)
 
 
-class ResourceQueueAPI(Container[TResource]):
+class ResourceQueueAPI(Sized, Container[TResource]):
     resources: Set[TResource]
 
     @abstractmethod

--- a/ddht/resource_queue.py
+++ b/ddht/resource_queue.py
@@ -73,6 +73,9 @@ class ResourceQueue(ResourceQueueAPI[TResource]):
     def __contains__(self, value: Any) -> bool:
         return value in self.resources
 
+    def __len__(self) -> int:
+        return len(self.resources)
+
     def remove(self, resource: TResource) -> None:
         self.resources.remove(resource)
 

--- a/ddht/v5_1/alexandria/content_retrieval.py
+++ b/ddht/v5_1/alexandria/content_retrieval.py
@@ -138,10 +138,11 @@ class ContentRetrieval(Service, ContentRetrievalAPI):
                             (content_length - still_missing) * 100 / content_length
                         )
                         self.logger.info(
-                            "combined proof: content_key=%s  proof=%s  progress=%.2f%%",
+                            "combined proof: content_key=%s  proof=%s  progress=%.2f%%  nodes=%d",
                             self.content_key.hex(),
                             proof,
                             percent_complete,
+                            len(self.node_queue),
                         )
                         if proof.is_complete:
                             break


### PR DESCRIPTION
## What was wrong?

Ended up needing to have the ability to do `len(...)` calls on the `ResourceQueueAPI`

## How was it fixed?

Added `typing.Sized` to the API definition and implemented `__len__`

#### Cute Animal Picture

![cat_iphone](https://user-images.githubusercontent.com/824194/101823657-5783a100-3ae8-11eb-87af-22b662642d59.jpg)

