### PR TITLE
Implement AlexandriaNetworkAPI.get_content

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -505,6 +505,12 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         ...
 
     @abstractmethod
+    async def get_content(
+        self, content_key: ContentKey, hash_tree_root: Hash32, *, concurrency: int = 3,
+    ) -> Proof:
+        ...
+
+    @abstractmethod
     async def advertise(
         self,
         node_id: NodeID,
@@ -538,7 +544,11 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
 
     @abstractmethod
     def stream_locations(
-        self, content_key: ContentKey, *, hash_tree_root: Optional[Hash32] = None,
+        self,
+        content_key: ContentKey,
+        *,
+        hash_tree_root: Optional[Hash32] = None,
+        concurrency: int = 3,
     ) -> AsyncContextManager[trio.abc.ReceiveChannel[Advertisement]]:
         ...
 

--- a/ddht/v5_1/alexandria/partials/proof.py
+++ b/ddht/v5_1/alexandria/partials/proof.py
@@ -753,6 +753,12 @@ class Proof:
         segments = self.get_proven_data_segments()
         return DataPartial(self.get_content_length(), segments)
 
+    def get_content(self) -> bytes:
+        if not self.is_complete:
+            raise ValueError("Proof does not contain full content")
+        proven_data = self.get_proven_data()
+        return proven_data[: self.get_content_length()]
+
     @to_tuple
     def get_proven_data_segments(self) -> Iterable[DataSegment]:
         length = self.get_content_length()


### PR DESCRIPTION
## What was wrong?

Need an API that can fetch content by it's `content_key` by putting together  1) finding nodes that should have advertisements (`explore(...)`) 2) querying those nodes for advertisements  (`stream_locations(...)`)  3) fetching the content from those nodes and re-assembling it into the full proof  (`retrieve_content(...)`)

## How was it fixed?

Implemented `get_content(...)` which ties all of these together into a single cohesive API for retrieving content by key (and currently `hash_tree_root`)


#### Cute Animal Picture

![252417,xcitefun-animal-phone-6](https://user-images.githubusercontent.com/824194/101825013-49cf1b00-3aea-11eb-947e-5b0034ccdf71.jpg)

