### PR TITLE
Add 'name' concept to Tester.node()

### DIFF
--- a/tests/core/v5_1/conftest.py
+++ b/tests/core/v5_1/conftest.py
@@ -14,7 +14,7 @@ def tester():
 #
 @pytest.fixture
 async def alice(tester, bob):
-    node = tester.node()
+    node = tester.node(name="alice")
     try:
         node.enr_db.set_enr(bob.enr)
     except OldSequenceNumber:
@@ -24,12 +24,12 @@ async def alice(tester, bob):
 
 @pytest.fixture
 async def bob(tester):
-    return tester.node()
+    return tester.node(name="bob")
 
 
 @pytest.fixture
 async def carol(tester):
-    return tester.node()
+    return tester.node(name="carol")
 
 
 @pytest.fixture


### PR DESCRIPTION
## What was wrong?

Need some extra debugging info when running the tests.

## How was it fixed?

Allow naming the network objects that are running from the `TesterAPI`

#### Cute Animal Picture

![monkey_playing_with_iphone_5318024996](https://user-images.githubusercontent.com/824194/101989116-73f41a80-3c5b-11eb-92a2-bf92c857e574.jpg)

