### PR TITLE
Change ResourceQueue.add to be idempotent

### DIFF
--- a/ddht/resource_queue.py
+++ b/ddht/resource_queue.py
@@ -66,7 +66,7 @@ class ResourceQueue(ResourceQueueAPI[TResource]):
 
     async def add(self, resource: TResource) -> None:
         if resource in self:
-            raise ValueError("Resource already tracked")
+            return
         self.resources.add(resource)
         await self._send.send(resource)
 


### PR DESCRIPTION
## What was wrong?

Adding items to the queue should be idempotent.

## How was it fixed?

Made it idempotent

#### Cute Animal Picture

![sms-acquisition-masthead-cat-453697](https://user-images.githubusercontent.com/824194/101989126-90905280-3c5b-11eb-90fe-0a771346ccad.jpg)

