### PR TITLE
Expose AlexandriaClientAPI.local_private_key

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -14,6 +14,7 @@ from typing import (
 
 from async_service import ServiceAPI
 from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
+from eth_keys import keys
 from eth_typing import Hash32, NodeID
 import trio
 
@@ -180,6 +181,11 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
     network: NetworkAPI
     request_tracker: RequestTrackerAPI
     subscription_manager: SubscriptionManagerAPI[AlexandriaMessage[Any]]
+
+    @property
+    @abstractmethod
+    def local_private_key(self) -> keys.PrivateKey:
+        ...
 
     #
     # Proxy API for subscriptions


### PR DESCRIPTION
## What was wrong?

We need access to the node's private key.

## How was it fixed?

Expose it on the `AlexandriaClientAPI`

#### Cute Animal Picture

![bunnyphone](https://user-images.githubusercontent.com/824194/101989191-f7ae0700-3c5b-11eb-9aac-0141f448f39e.jpg)

