### PR TITLE
bugfix for AlexandriaNetworkAPI.broadcast

### DIFF
--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -576,9 +576,9 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                     )
                     # log the broadcast
                     self.broadcast_log.log(node_id, advertisement)
+                    acked_nodes.add(node_id)
                 finally:
                     async with condition:
-                        acked_nodes.add(node_id)
                         condition.notify_all()
 
         async with trio.open_nursery() as nursery:


### PR DESCRIPTION
## What was wrong?

The `AlexandriaNetworkAPI.broadcast` was incorrectly reporting how many nodes had acked the advertisement.

## How was it fixed?

Ensure that we only mark nodes as acked if they actually acked.

#### Cute Animal Picture

![April-Fool-2](https://user-images.githubusercontent.com/824194/101989271-71de8b80-3c5c-11eb-9153-bd579fd0e76b.jpg)

