### PR TITLE
split content storage to commons/pinned

### DIFF
--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -188,6 +188,9 @@ alexandria_parser = subparser.add_parser(
 
 alexandria_parser.set_defaults(func=do_alexandria)
 
+#
+# Alexandria[Bootnodes]
+#
 alexandria_bootnodes_parser_group = alexandria_parser.add_mutually_exclusive_group()
 alexandria_bootnodes_parser_group.add_argument(
     "--bootnode",
@@ -201,4 +204,48 @@ alexandria_bootnodes_parser_group.add_argument(
     action="store_const",
     const=(),
     dest="alexandria_bootnodes",
+)
+
+#
+# Alexandria[CommonsStorage]
+#
+alexandria_commons_storage_parser_group = (
+    alexandria_parser.add_mutually_exclusive_group()
+)
+alexandria_commons_storage_parser_group.add_argument(
+    "--commons-storage-dir",
+    help=(
+        "The filesystem path where the 'commons' storage should be located."
+        "Use the string `:memory:` to use an in-memory ephemeral data store"
+    ),
+    dest="alexandria_commons_storage",
+)
+alexandria_commons_storage_parser_group.add_argument(
+    "--commons-storage-ephemeral",
+    help=("Use an in-memory ephemeral data store for 'commons' storage"),
+    action="store_const",
+    const=":memory:",
+    dest="alexandria_commons_storage",
+)
+
+#
+# Alexandria[PinnedStorage]
+#
+alexandria_pinned_storage_parser_group = (
+    alexandria_parser.add_mutually_exclusive_group()
+)
+alexandria_pinned_storage_parser_group.add_argument(
+    "--pinned-storage-dir",
+    help=(
+        "The filesystem path where the 'pinned' storage should be located."
+        "Use the string `:memory:` to use an in-memory ephemeral data store"
+    ),
+    dest="alexandria_pinned_storage",
+)
+alexandria_pinned_storage_parser_group.add_argument(
+    "--pinned-storage-ephemeral",
+    help=("Use an in-memory ephemeral data store for 'pinned' storage"),
+    action="store_const",
+    const=":memory:",
+    dest="alexandria_pinned_storage",
 )

--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -28,7 +28,8 @@ from ddht.v5_1.packets import AnyPacket
 
 
 class AlexandriaNodeAPI(ABC):
-    content_storage: ContentStorageAPI
+    commons_content_storage: ContentStorageAPI
+    pinned_content_storage: ContentStorageAPI
     advertisement_db: AdvertisementDatabaseAPI
 
     @property

--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -27,7 +27,8 @@ class AlexandriaNode(AlexandriaNodeAPI):
 
     def __init__(self, node: NodeAPI) -> None:
         self.node = node
-        self.content_storage = MemoryContentStorage()
+        self.commons_content_storage = MemoryContentStorage()
+        self.pinned_content_storage = MemoryContentStorage()
         self.advertisement_db = AdvertisementDatabase(sqlite3.connect(":memory:"),)
         self._lock = NamedLock()
 
@@ -73,7 +74,8 @@ class AlexandriaNode(AlexandriaNodeAPI):
                 alexandria_network = AlexandriaNetwork(
                     network=network,
                     bootnodes=bootnodes,
-                    content_storage=self.content_storage,
+                    commons_content_storage=self.commons_content_storage,
+                    pinned_content_storage=self.pinned_content_storage,
                     advertisement_db=self.advertisement_db,
                     max_advertisement_count=max_advertisement_count,
                 )

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -419,6 +419,14 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     content_storage: ContentStorageAPI
     content_provider: ContentProviderAPI
 
+    commons_content_storage: ContentStorageAPI
+
+    pinned_content_storage: ContentStorageAPI
+
+    @abstractmethod
+    async def routing_table_ready(self) -> None:
+        ...
+
     @abstractmethod
     async def ready(self) -> None:
         ...

--- a/ddht/v5_1/alexandria/advertisement_manager.py
+++ b/ddht/v5_1/alexandria/advertisement_manager.py
@@ -112,9 +112,16 @@ class AdvertisementManager(Service, AdvertisementManagerAPI):
             )
 
         try:
-            content = self._network.content_storage.get_content(
-                advertisement.content_key
-            )
+            try:
+                # First query "pinned" storage
+                content = self._network.pinned_content_storage.get_content(
+                    advertisement.content_key
+                )
+            except ContentNotFound:
+                # Fall back to "commons" storage
+                content = self._network.commons_content_storage.get_content(
+                    advertisement.content_key
+                )
         except ContentNotFound as err:
             raise ValidationError(
                 f"Content not found: advertisement={advertisement}"

--- a/ddht/v5_1/alexandria/app.py
+++ b/ddht/v5_1/alexandria/app.py
@@ -1,4 +1,5 @@
 import argparse
+import pathlib
 import sqlite3
 
 from ddht.app import BaseApplication
@@ -6,8 +7,12 @@ from ddht.boot_info import BootInfo
 from ddht.v5_1.alexandria.abc import AdvertisementDatabaseAPI, ContentStorageAPI
 from ddht.v5_1.alexandria.advertisement_db import AdvertisementDatabase
 from ddht.v5_1.alexandria.boot_info import AlexandriaBootInfo
-from ddht.v5_1.alexandria.content_storage import MemoryContentStorage
+from ddht.v5_1.alexandria.content_storage import (
+    FileSystemContentStorage,
+    MemoryContentStorage,
+)
 from ddht.v5_1.alexandria.network import AlexandriaNetwork
+from ddht.v5_1.alexandria.xdg import get_xdg_alexandria_root
 from ddht.v5_1.app import Application
 
 
@@ -24,22 +29,82 @@ class AlexandriaApplication(BaseApplication):
 
         await self.base_protocol_app.wait_ready()
 
-        content_storage: ContentStorageAPI = MemoryContentStorage()
+        xdg_alexandria_root = get_xdg_alexandria_root()
+        xdg_alexandria_root.mkdir(parents=True, exist_ok=True)
 
-        # Temporarily we just use an in memory database for advertisements.
+        commons_content_storage: ContentStorageAPI
+        commons_storage_display: str
+
+        if self._alexandria_boot_info.commons_storage == ":memory:":
+            commons_content_storage = MemoryContentStorage()
+
+            commons_storage_display = "<memory>"
+        elif self._alexandria_boot_info.commons_storage is None:
+            commons_content_storage_path = xdg_alexandria_root / "content" / "commons"
+            commons_content_storage_path.mkdir(parents=True, exist_ok=True)
+            commons_content_storage = FileSystemContentStorage(
+                commons_content_storage_path
+            )
+
+            commons_storage_display = str(commons_content_storage_path)
+        elif isinstance(self._alexandria_boot_info.commons_storage, pathlib.Path):
+            commons_content_storage = FileSystemContentStorage(
+                self._alexandria_boot_info.commons_storage,
+            )
+
+            commons_storage_display = str(self._alexandria_boot_info.commons_storage)
+        else:
+            raise Exception(
+                f"Unsupported value: "
+                f"commons_storage={self._alexandria_boot_info.commons_storage}"
+            )
+
+        pinned_content_storage: ContentStorageAPI
+        pinned_storage_display: str
+
+        if self._alexandria_boot_info.pinned_storage == ":memory:":
+            pinned_content_storage = MemoryContentStorage()
+
+            pinned_storage_display = "<memory>"
+        elif self._alexandria_boot_info.pinned_storage is None:
+            pinned_content_storage_path = xdg_alexandria_root / "content" / "pinned"
+            pinned_content_storage_path.mkdir(parents=True, exist_ok=True)
+            pinned_content_storage = FileSystemContentStorage(
+                pinned_content_storage_path
+            )
+
+            pinned_storage_display = str(pinned_content_storage_path)
+        elif isinstance(self._alexandria_boot_info.pinned_storage, pathlib.Path):
+            pinned_content_storage = FileSystemContentStorage(
+                self._alexandria_boot_info.pinned_storage,
+            )
+
+            pinned_storage_display = str(self._alexandria_boot_info.pinned_storage)
+        else:
+            raise Exception(
+                f"Unsupported value: "
+                f"pinned_storage={self._alexandria_boot_info.pinned_storage}"
+            )
+
+        advertisement_db_path = xdg_alexandria_root / "advertisements.sqlite3"
         advertisement_db: AdvertisementDatabaseAPI = AdvertisementDatabase(
-            sqlite3.connect(":memory:"),
+            sqlite3.connect(str(advertisement_db_path)),
         )
 
         alexandria_network = AlexandriaNetwork(
             network=self.base_protocol_app.network,
             bootnodes=self._alexandria_boot_info.bootnodes,
-            content_storage=content_storage,
+            commons_content_storage=commons_content_storage,
+            pinned_content_storage=pinned_content_storage,
             advertisement_db=advertisement_db,
         )
 
         self.manager.run_daemon_child_service(alexandria_network)
 
         self.logger.info("Starting Alexandria...")
+        self.logger.info("Root Directory         : %s", xdg_alexandria_root)
+        self.logger.info("ContentStorage[Commons]: %s", commons_storage_display)
+        self.logger.info("ContentStorage[Pinned] : %s", pinned_storage_display)
+        self.logger.info("AdvertisementDB        : %s", advertisement_db_path)
 
         await self.manager.wait_finished()

--- a/ddht/v5_1/alexandria/boot_info.py
+++ b/ddht/v5_1/alexandria/boot_info.py
@@ -1,6 +1,7 @@
 import argparse
 from dataclasses import dataclass
-from typing import Sequence, Tuple, TypedDict
+import pathlib
+from typing import Literal, Optional, Sequence, Tuple, TypedDict, Union
 
 from eth_enr import ENR
 from eth_enr.abc import ENRAPI
@@ -10,6 +11,8 @@ from ddht.v5_1.alexandria.constants import DEFAULT_BOOTNODES
 
 class AlexandriaBootInfoKwargs(TypedDict, total=False):
     bootnodes: Tuple[ENRAPI, ...]
+    commons_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
+    pinned_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
 
 
 def _cli_args_to_boot_info_kwargs(args: argparse.Namespace) -> AlexandriaBootInfoKwargs:
@@ -18,12 +21,40 @@ def _cli_args_to_boot_info_kwargs(args: argparse.Namespace) -> AlexandriaBootInf
     else:
         bootnodes = args.alexandria_bootnodes
 
-    return AlexandriaBootInfoKwargs(bootnodes=bootnodes,)
+    commons_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
+
+    if args.alexandria_commons_storage == ":memory:":
+        commons_storage = ":memory:"
+    elif args.alexandria_commons_storage is not None:
+        commons_storage = (
+            pathlib.Path(args.alexandria_commons_storage).expanduser().resolve()
+        )
+    else:
+        commons_storage = None
+
+    pinned_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
+
+    if args.alexandria_pinned_storage == ":memory:":
+        pinned_storage = ":memory:"
+    elif args.alexandria_pinned_storage is not None:
+        pinned_storage = (
+            pathlib.Path(args.alexandria_pinned_storage).expanduser().resolve()
+        )
+    else:
+        pinned_storage = None
+
+    return AlexandriaBootInfoKwargs(
+        bootnodes=bootnodes,
+        commons_storage=commons_storage,
+        pinned_storage=pinned_storage,
+    )
 
 
 @dataclass(frozen=True)
 class AlexandriaBootInfo:
     bootnodes: Tuple[ENRAPI, ...]
+    commons_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
+    pinned_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
 
     @classmethod
     def from_cli_args(cls, args: Sequence[str]) -> "AlexandriaBootInfo":

--- a/ddht/v5_1/alexandria/xdg.py
+++ b/ddht/v5_1/alexandria/xdg.py
@@ -1,0 +1,14 @@
+import os
+from pathlib import Path
+
+from ddht.xdg import get_xdg_ddht_root
+
+
+def get_xdg_alexandria_root() -> Path:
+    """
+    Returns the base directory under which alexandria will store data.
+    """
+    try:
+        return Path(os.environ["XDG_ALEXANDRIA_ROOT"])
+    except KeyError:
+        return get_xdg_ddht_root() / "alexandria"

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -126,13 +126,15 @@ class Application(BaseApplication):
             rpc_server = RPCServer(self._boot_info.ipc_path, handlers)
             self.manager.run_daemon_child_service(rpc_server)
 
+        self.logger.info("Starting DDHT...")
         self.logger.info("Protocol-Version: %s", self._boot_info.protocol_version.value)
-        self.logger.info("DDHT base dir: %s", self._boot_info.base_dir)
-        self.logger.info("Starting discovery service...")
-        self.logger.info("Listening on %s", listen_on)
-        self.logger.info("Local Node ID: %s", encode_hex(enr_manager.enr.node_id))
+        self.logger.info("DDHT base dir   : %s", self._boot_info.base_dir)
+        self.logger.info("Listening on    : %s", listen_on)
+        self.logger.info("Local Node ID   : %s", encode_hex(enr_manager.enr.node_id))
         self.logger.info(
-            "Local ENR: seq=%d enr=%s", enr_manager.enr.sequence_number, enr_manager.enr
+            "Local ENR       : seq=%d enr=%s",
+            enr_manager.enr.sequence_number,
+            enr_manager.enr,
         )
 
         self.manager.run_daemon_child_service(self.network)

--- a/tests/core/v5_1/alexandria/test_advertisement_manager.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_manager.py
@@ -239,7 +239,7 @@ async def test_advertisement_manager_validate_local_content_not_found(
     ad_manager = alice_alexandria_network.advertisement_manager
     advertisement = AdvertisementFactory(private_key=alice.private_key)
 
-    content_storage = alice_alexandria_network.content_storage
+    content_storage = alice_alexandria_network.commons_content_storage
     assert not content_storage.has_content(advertisement.content_key)
 
     with pytest.raises(ValidationError, match="not found"):
@@ -253,7 +253,7 @@ async def test_advertisement_manager_validate_local_hash_tree_root_mismatch(
     ad_manager = alice_alexandria_network.advertisement_manager
     advertisement = AdvertisementFactory(private_key=alice.private_key)
 
-    content_storage = alice_alexandria_network.content_storage
+    content_storage = alice_alexandria_network.commons_content_storage
     content_storage.set_content(advertisement.content_key, ContentFactory())
 
     with pytest.raises(ValidationError, match="Mismatched roots"):
@@ -273,13 +273,13 @@ async def test_advertisement_manager_handle_new_valid_local_advertisement(
     advertisement = AdvertisementFactory(
         private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
     )
-    alice_alexandria_network.content_storage.set_content(
+    alice_alexandria_network.commons_content_storage.set_content(
         advertisement.content_key, content,
     )
 
     assert not alice_alexandria_network.advertisement_db.exists(advertisement)
 
-    with trio.fail_after(2):
+    with trio.fail_after(5):
         await ad_manager.handle_advertisement(advertisement)
 
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
@@ -295,13 +295,13 @@ async def test_advertisement_manager_handle_new_valid_remote_advertisement(
     advertisement = AdvertisementFactory(
         private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
     )
-    bob_alexandria_network.content_storage.set_content(
+    bob_alexandria_network.commons_content_storage.set_content(
         advertisement.content_key, content,
     )
 
     assert not alice_alexandria_network.advertisement_db.exists(advertisement)
 
-    with trio.fail_after(2):
+    with trio.fail_after(5):
         async with ad_manager.new_advertisement.subscribe_and_wait():
             await ad_manager.handle_advertisement(advertisement)
 
@@ -318,7 +318,7 @@ async def test_advertisement_manager_handle_existing_valid_local_advertisement(
     advertisement = AdvertisementFactory(
         private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
     )
-    alice_alexandria_network.content_storage.set_content(
+    alice_alexandria_network.commons_content_storage.set_content(
         advertisement.content_key, content,
     )
     alice_alexandria_network.advertisement_db.add(advertisement)
@@ -326,10 +326,10 @@ async def test_advertisement_manager_handle_existing_valid_local_advertisement(
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
 
     async with ad_manager.new_advertisement.subscribe() as subscription:
-        with trio.fail_after(2):
+        with trio.fail_after(5):
             await ad_manager.handle_advertisement(advertisement)
         with pytest.raises(trio.TooSlowError):
-            with trio.fail_after(2):
+            with trio.fail_after(5):
                 await subscription.receive()
 
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
@@ -345,7 +345,7 @@ async def test_advertisement_manager_handle_existing_valid_remote_advertisement(
     advertisement = AdvertisementFactory(
         private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
     )
-    bob_alexandria_network.content_storage.set_content(
+    bob_alexandria_network.commons_content_storage.set_content(
         advertisement.content_key, content,
     )
     alice_alexandria_network.advertisement_db.add(advertisement)
@@ -353,10 +353,10 @@ async def test_advertisement_manager_handle_existing_valid_remote_advertisement(
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
 
     async with ad_manager.new_advertisement.subscribe() as subscription:
-        with trio.fail_after(2):
+        with trio.fail_after(5):
             await ad_manager.handle_advertisement(advertisement)
         with pytest.raises(trio.TooSlowError):
-            with trio.fail_after(2):
+            with trio.fail_after(5):
                 await subscription.receive()
 
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
@@ -374,7 +374,7 @@ async def test_advertisement_manager_does_not_ack_if_advertisements_already_know
     advertisement = AdvertisementFactory(
         private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
     )
-    bob_alexandria_network.content_storage.set_content(
+    bob_alexandria_network.commons_content_storage.set_content(
         advertisement.content_key, content,
     )
     bob_alexandria_network.advertisement_db.add(advertisement)

--- a/tests/core/v5_1/alexandria/test_alexandria_network.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_network.py
@@ -550,7 +550,7 @@ async def test_alexandria_network_get_content(
                 private_key=network.client.local_private_key,
             )
             network.advertisement_db.add(advertisement)
-            network.content_storage.set_content(content_key, content)
+            network.pinned_content_storage.set_content(content_key, content)
 
         # give the the network some time to interconnect.
         with trio.fail_after(30):

--- a/tests/core/v5_1/alexandria/test_content_provider.py
+++ b/tests/core/v5_1/alexandria/test_content_provider.py
@@ -20,7 +20,7 @@ async def test_content_provider_serves_short_content(
     content_storage.set_content(content_key, content)
     proof = compute_proof(content, sedes=content_sedes)
 
-    content_provider = ContentProvider(bob_alexandria_client, content_storage)
+    content_provider = ContentProvider(bob_alexandria_client, (content_storage,))
     async with background_trio_service(content_provider):
         async with alice_alexandria_network.client.subscribe(
             ContentMessage
@@ -53,7 +53,7 @@ async def test_content_provider_serves_large_content(
     content_storage = MemoryContentStorage({content_key: content})
     proof = compute_proof(content, sedes=content_sedes)
 
-    content_provider = ContentProvider(bob_alexandria_client, content_storage)
+    content_provider = ContentProvider(bob_alexandria_client, (content_storage,))
     async with background_trio_service(content_provider):
         async with alice_alexandria_network.client.subscribe(
             ContentMessage
@@ -87,7 +87,7 @@ async def test_content_provider_restricts_max_chunks(
     proof = compute_proof(content, sedes=content_sedes)
 
     content_provider = ContentProvider(
-        bob_alexandria_client, content_storage, max_chunks_per_request=16
+        bob_alexandria_client, (content_storage,), max_chunks_per_request=16
     )
     async with background_trio_service(content_provider):
         # this ensures that the subscription is in place.


### PR DESCRIPTION
## What was wrong?

Need a distinction between the storage that the user wants to ensure persists and the storage that we "donate" to the network for interesting content.

## How was it fixed?

Splt storage between "commons" and "pinned"

#### Cute Animal Picture

![584a4e488498e5dfde273b4c52f5cc6b](https://user-images.githubusercontent.com/824194/101989536-4066bf80-3c5e-11eb-803d-9c7cd07b0e3d.jpg)
