### PR TITLE
Make ContentStorageAPI be Sized

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -7,6 +7,7 @@ from typing import (
     Iterable,
     Optional,
     Sequence,
+    Sized,
     Tuple,
     Type,
     Union,
@@ -45,7 +46,7 @@ from ddht.v5_1.alexandria.payloads import AckPayload, PongPayload
 from ddht.v5_1.alexandria.typing import ContentID, ContentKey
 
 
-class ContentStorageAPI(ABC):
+class ContentStorageAPI(Sized):
     @abstractmethod
     def has_content(self, content_key: ContentKey) -> bool:
         ...

--- a/tests/core/v5_1/alexandria/test_advertisement_manager.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_manager.py
@@ -279,7 +279,7 @@ async def test_advertisement_manager_handle_new_valid_local_advertisement(
 
     assert not alice_alexandria_network.advertisement_db.exists(advertisement)
 
-    with trio.fail_after(2):
+    with trio.fail_after(5):
         await ad_manager.handle_advertisement(advertisement)
 
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
@@ -301,7 +301,7 @@ async def test_advertisement_manager_handle_new_valid_remote_advertisement(
 
     assert not alice_alexandria_network.advertisement_db.exists(advertisement)
 
-    with trio.fail_after(2):
+    with trio.fail_after(5):
         async with ad_manager.new_advertisement.subscribe_and_wait():
             await ad_manager.handle_advertisement(advertisement)
 
@@ -326,10 +326,10 @@ async def test_advertisement_manager_handle_existing_valid_local_advertisement(
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
 
     async with ad_manager.new_advertisement.subscribe() as subscription:
-        with trio.fail_after(2):
+        with trio.fail_after(5):
             await ad_manager.handle_advertisement(advertisement)
         with pytest.raises(trio.TooSlowError):
-            with trio.fail_after(2):
+            with trio.fail_after(5):
                 await subscription.receive()
 
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
@@ -353,10 +353,10 @@ async def test_advertisement_manager_handle_existing_valid_remote_advertisement(
     assert alice_alexandria_network.advertisement_db.exists(advertisement)
 
     async with ad_manager.new_advertisement.subscribe() as subscription:
-        with trio.fail_after(2):
+        with trio.fail_after(5):
             await ad_manager.handle_advertisement(advertisement)
         with pytest.raises(trio.TooSlowError):
-            with trio.fail_after(2):
+            with trio.fail_after(5):
                 await subscription.receive()
 
     assert alice_alexandria_network.advertisement_db.exists(advertisement)

--- a/tests/core/v5_1/alexandria/test_content_storage.py
+++ b/tests/core/v5_1/alexandria/test_content_storage.py
@@ -50,6 +50,26 @@ def content_storage(request, base_storage):
         raise Exception(f"Unhandled parameter: {request.param}")
 
 
+def test_content_storage_sized(base_storage):
+    assert len(base_storage) == 0
+
+    base_storage.set_content(b"key-0", b"content-0")
+
+    assert len(base_storage) == 1
+
+    base_storage.set_content(b"key-0", b"content-0-updated", exists_ok=True)
+
+    assert len(base_storage) == 1
+
+    base_storage.set_content(b"key-1", b"content-1")
+
+    assert len(base_storage) == 2
+
+    base_storage.delete_content(b"key-0")
+
+    assert len(base_storage) == 1
+
+
 def test_content_storage_read_write_exists_delete(content_storage):
     content_key = b"\x00test-key"
     content = ContentFactory(128)


### PR DESCRIPTION
## What was wrong?

Need to know how many items are in the ContentStorageAPI

## How was it fixed?

Made it be `Sized`

#### Cute Animal Picture

![animals-smelling-flowers-131__880](https://user-images.githubusercontent.com/824194/101990130-1fa06900-3c62-11eb-857a-5ec1517a07a5.jpg)

