### PR TITLE
Make v5.1 the default protocol

### DIFF
--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -29,7 +29,7 @@ jsonrpc_parser = parser.add_argument_group("jsonrpc")
 ddht_parser.add_argument("--private-key", help="Hex encoded 32 byte private key")
 ddht_parser.add_argument(
     "--protocol-version",
-    default=ProtocolVersion.v5,
+    default=ProtocolVersion.v5_1,
     type=ProtocolVersion,
     choices=ProtocolVersion,
     help="Protocol version which should be used",
@@ -39,7 +39,13 @@ base_dir_parser = ddht_parser.add_mutually_exclusive_group()
 
 base_dir_parser.add_argument("--base-dir", type=pathlib.Path)
 base_dir_parser.add_argument(
-    "--ephemeral", action="store_true",
+    "--ephemeral",
+    action="store_true",
+    help=(
+        "Run the application in *ephemeral* mode which generates a random "
+        "single use private key and uses a temporary directory which will be "
+        "removed when the application shuts down."
+    ),
 )
 
 #

--- a/ddht/tools/factories/boot_info.py
+++ b/ddht/tools/factories/boot_info.py
@@ -22,7 +22,7 @@ class BootInfoFactory(factory.Factory):  # type: ignore
     class Meta:
         model = BootInfo
 
-    protocol_version = ProtocolVersion.v5
+    protocol_version = ProtocolVersion.v5_1
     private_key = None
     base_dir = factory.LazyFunction(get_xdg_ddht_root)
     port = DEFAULT_PORT

--- a/tests/core/test_cli_parsing_to_boot_info.py
+++ b/tests/core/test_cli_parsing_to_boot_info.py
@@ -6,7 +6,7 @@ import pytest
 
 from ddht.boot_info import BootInfo
 from ddht.constants import ProtocolVersion
-from ddht.tools.factories.boot_info import BOOTNODES_V5_1, BootInfoFactory
+from ddht.tools.factories.boot_info import BOOTNODES_V5, BootInfoFactory
 from ddht.tools.factories.discovery import ENRFactory
 
 KEY_RAW = b"unicornsrainbowsunicornsrainbows"
@@ -44,11 +44,11 @@ ENR_B = ENRFactory()
         ),
         (("--disable-upnp",), (dict(is_upnp_enabled=False)),),
         # protocol version
-        (("--protocol-version", "v5"), {}),
         (
-            ("--protocol-version", "v5.1"),
-            dict(protocol_version=ProtocolVersion.v5_1, bootnodes=BOOTNODES_V5_1),
+            ("--protocol-version", "v5"),
+            dict(protocol_version=ProtocolVersion.v5, bootnodes=BOOTNODES_V5),
         ),
+        (("--protocol-version", "v5.1"), {}),
     ),
 )
 def test_cli_args_to_boot_info(args, factory_kwargs):


### PR DESCRIPTION
## What was wrong?

Time for the v5.1 protocol to be the default

## How was it fixed?

Made it the default

#### Cute Animal Picture

![animals-smelling-flowers-371__880](https://user-images.githubusercontent.com/824194/101991700-a3128800-3c6b-11eb-86be-cf73c543693f.jpg)
