### PR TITLE
Implement Alexandria JSON-RPC API

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -504,8 +504,10 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     content_provider: ContentProviderAPI
 
     commons_content_storage: ContentStorageAPI
+    commons_content_manager: ContentManagerAPI
 
     pinned_content_storage: ContentStorageAPI
+    pinned_content_manager: ContentManagerAPI
 
     @abstractmethod
     async def routing_table_ready(self) -> None:

--- a/ddht/v5_1/alexandria/app.py
+++ b/ddht/v5_1/alexandria/app.py
@@ -13,6 +13,7 @@ from ddht.v5_1.alexandria.content_storage import (
     MemoryContentStorage,
 )
 from ddht.v5_1.alexandria.network import AlexandriaNetwork
+from ddht.v5_1.alexandria.rpc_handlers import get_alexandria_rpc_handlers
 from ddht.v5_1.alexandria.xdg import get_xdg_alexandria_root
 from ddht.v5_1.app import Application
 
@@ -146,5 +147,12 @@ class AlexandriaApplication(BaseApplication):
             remote_advertisement_db.count(),
             max_advertisement_count,
         )
+
+        await alexandria_network.ready()
+
+        if self._boot_info.is_rpc_enabled:
+            self.base_protocol_app.rpc_server.add_handers(
+                get_alexandria_rpc_handlers(alexandria_network)
+            )
 
         await self.manager.wait_finished()

--- a/ddht/v5_1/alexandria/rpc_handlers.py
+++ b/ddht/v5_1/alexandria/rpc_handlers.py
@@ -1,0 +1,111 @@
+from typing import Iterable, Tuple
+
+from eth_utils import encode_hex, to_dict
+
+from ddht.abc import RPCHandlerAPI
+from ddht.rpc import RPCError, RPCHandler, RPCRequest, extract_params
+from ddht.v5_1.alexandria.abc import (
+    AlexandriaNetworkAPI,
+    ContentManagerAPI,
+    ContentStorageAPI,
+)
+from ddht.v5_1.alexandria.content_storage import ContentNotFound
+from ddht.v5_1.alexandria.typing import ContentKey
+from ddht.validation import validate_and_convert_hexstr, validate_params_length
+
+
+class AddContentHandler(RPCHandler[Tuple[ContentKey, bytes], None]):
+    def __init__(self, content_manager: ContentManagerAPI) -> None:
+        self._content_manager = content_manager
+
+    def extract_params(self, request: RPCRequest) -> Tuple[ContentKey, bytes]:
+        raw_params = extract_params(request)
+
+        validate_params_length(raw_params, 2)
+
+        content_key_hex, content_hex = raw_params
+
+        content_key = ContentKey(validate_and_convert_hexstr(content_key_hex)[0])
+        content = validate_and_convert_hexstr(content_hex)[0]
+
+        return content_key, content
+
+    async def do_call(self, params: Tuple[ContentKey, bytes]) -> None:
+        content_key, content = params
+        await self._content_manager.process_content(content_key, content)
+
+
+class GetContentHandler(RPCHandler[ContentKey, str]):
+    def __init__(self, content_storage: ContentStorageAPI) -> None:
+        self._content_storage = content_storage
+
+    def extract_params(self, request: RPCRequest) -> ContentKey:
+        raw_params = extract_params(request)
+
+        validate_params_length(raw_params, 1)
+
+        content_key_hex = raw_params[0]
+        content_key = ContentKey(validate_and_convert_hexstr(content_key_hex)[0])
+
+        return content_key
+
+    async def do_call(self, params: ContentKey) -> str:
+        content_key = params
+        try:
+            content = self._content_storage.get_content(content_key)
+        except ContentNotFound as err:
+            raise RPCError(str(err)) from err
+        else:
+            return encode_hex(content)
+
+
+class DeleteContentHandler(RPCHandler[ContentKey, None]):
+    def __init__(self, content_storage: ContentStorageAPI) -> None:
+        self._content_storage = content_storage
+
+    def extract_params(self, request: RPCRequest) -> ContentKey:
+        raw_params = extract_params(request)
+
+        validate_params_length(raw_params, 1)
+
+        content_key_hex = raw_params[0]
+        content_key = ContentKey(validate_and_convert_hexstr(content_key_hex)[0])
+
+        return content_key
+
+    async def do_call(self, params: ContentKey) -> None:
+        content_key = params
+        try:
+            self._content_storage.delete_content(content_key)
+        except ContentNotFound as err:
+            raise RPCError(str(err)) from err
+
+
+@to_dict
+def get_alexandria_rpc_handlers(
+    network: AlexandriaNetworkAPI,
+) -> Iterable[Tuple[str, RPCHandlerAPI]]:
+    yield (
+        "alexandria_addPinnedContent",
+        AddContentHandler(network.pinned_content_manager),
+    )
+    yield (
+        "alexandria_addCommonsContent",
+        AddContentHandler(network.commons_content_manager),
+    )
+    yield (
+        "alexandria_getPinnedContent",
+        GetContentHandler(network.pinned_content_storage),
+    )
+    yield (
+        "alexandria_getCommonsContent",
+        GetContentHandler(network.commons_content_storage),
+    )
+    yield (
+        "alexandria_deletePinnedContent",
+        DeleteContentHandler(network.pinned_content_storage),
+    )
+    yield (
+        "alexandria_deleteCommonsContent",
+        DeleteContentHandler(network.commons_content_storage),
+    )

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -46,6 +46,7 @@ def get_local_private_key(boot_info: BootInfo) -> keys.PrivateKey:
 class Application(BaseApplication):
     client: ClientAPI
     network: NetworkAPI
+    rpc_server: RPCServer
 
     def __init__(self, args: argparse.Namespace, boot_info: BootInfo) -> None:
         super().__init__(args, boot_info)
@@ -125,8 +126,8 @@ class Application(BaseApplication):
                 get_core_rpc_handlers(enr_manager, self.network.routing_table),
                 get_v51_rpc_handlers(self.network),
             )
-            rpc_server = RPCServer(self._boot_info.ipc_path, handlers)
-            self.manager.run_daemon_child_service(rpc_server)
+            self.rpc_server = RPCServer(self._boot_info.ipc_path, handlers)
+            self.manager.run_daemon_child_service(self.rpc_server)
 
         self.logger.info("Starting DDHT...")
         self.logger.info("Protocol-Version: %s", self._boot_info.protocol_version.value)

--- a/tests/core/v5_1/alexandria/test_rpc_handlers.py
+++ b/tests/core/v5_1/alexandria/test_rpc_handlers.py
@@ -1,0 +1,140 @@
+from async_service import background_trio_service
+from eth_utils import encode_hex
+import pytest
+
+from ddht.rpc import RPCServer
+from ddht.v5_1.alexandria.rpc_handlers import get_alexandria_rpc_handlers
+
+
+@pytest.fixture
+async def rpc_server(ipc_path, alice, alice_alexandria_network):
+    server = RPCServer(ipc_path, get_alexandria_rpc_handlers(alice_alexandria_network))
+    async with background_trio_service(server):
+        await server.wait_serving()
+        yield server
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_add_pinned_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+    content = b"dummy-content"
+
+    pinned_storage = alice_alexandria_network.pinned_content_storage
+    local_advertisement_db = alice_alexandria_network.local_advertisement_db
+    assert not pinned_storage.has_content(content_key)
+    assert not tuple(local_advertisement_db.query(content_key=content_key))
+
+    await make_request(
+        "alexandria_addPinnedContent", [content_key.hex(), content.hex()]
+    )
+
+    assert pinned_storage.has_content(content_key)
+    assert tuple(local_advertisement_db.query(content_key=content_key))
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_add_commons_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+    content = b"dummy-content"
+
+    commons_storage = alice_alexandria_network.commons_content_storage
+    local_advertisement_db = alice_alexandria_network.local_advertisement_db
+    assert not commons_storage.has_content(content_key)
+    assert not tuple(local_advertisement_db.query(content_key=content_key))
+
+    await make_request(
+        "alexandria_addCommonsContent", [content_key.hex(), content.hex()]
+    )
+
+    assert commons_storage.has_content(content_key)
+    assert tuple(local_advertisement_db.query(content_key=content_key))
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_get_pinned_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+    content = b"dummy-content"
+
+    pinned_storage = alice_alexandria_network.pinned_content_storage
+    pinned_storage.set_content(content_key, content)
+
+    result = await make_request("alexandria_getPinnedContent", [content_key.hex()])
+
+    assert result == encode_hex(content)
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_get_commons_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+    content = b"dummy-content"
+
+    commons_storage = alice_alexandria_network.commons_content_storage
+    commons_storage.set_content(content_key, content)
+
+    result = await make_request("alexandria_getCommonsContent", [content_key.hex()])
+
+    assert result == encode_hex(content)
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_get_unknown_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+
+    with pytest.raises(Exception, match="Not Found"):
+        await make_request("alexandria_getPinnedContent", [content_key.hex()])
+    with pytest.raises(Exception, match="Not Found"):
+        await make_request("alexandria_getCommonsContent", [content_key.hex()])
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_delete_pinned_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+    content = b"dummy-content"
+
+    pinned_storage = alice_alexandria_network.pinned_content_storage
+    pinned_storage.set_content(content_key, content)
+    assert pinned_storage.has_content(content_key)
+
+    await make_request("alexandria_deletePinnedContent", [content_key.hex()])
+
+    assert not pinned_storage.has_content(content_key)
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_delete_commons_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+    content = b"dummy-content"
+
+    commons_storage = alice_alexandria_network.commons_content_storage
+    commons_storage.set_content(content_key, content)
+    assert commons_storage.has_content(content_key)
+
+    await make_request("alexandria_deleteCommonsContent", [content_key.hex()])
+
+    assert not commons_storage.has_content(content_key)
+
+
+@pytest.mark.trio
+async def test_alexandria_rpc_delete_unknown_content(
+    make_request, alice, alice_alexandria_network
+):
+    content_key = b"\x00-dummy-key"
+
+    with pytest.raises(Exception, match="Not Found"):
+        await make_request("alexandria_deletePinnedContent", [content_key.hex()])
+    with pytest.raises(Exception, match="Not Found"):
+        await make_request("alexandria_deleteCommonsContent", [content_key.hex()])


### PR DESCRIPTION
## What was wrong?

Need some JSON-RPC endpoints for interacting with the alexandria network.

## How was it fixed?

Implemented:

- `alexandria_addPinnedContent`
- `alexandria_addCommonsContent`
- `alexandria_getPinnedContent`
- `alexandria_getCommonsContent`
- `alexandria_deletePinnedContent`
- `alexandria_deleteCommonsContent`

#### Cute Animal Picture


![funny-animals-doing-human-things-14](https://user-images.githubusercontent.com/824194/102418068-46d89c80-3fba-11eb-85ef-fc094475cc24.jpg)
