### PR TITLE
Use ExtendedDebugLogger to quiet DEBUG logs

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -18,7 +18,7 @@ from async_service import ServiceAPI
 from eth_enr import ENRAPI, ENRManagerAPI, IdentitySchemeAPI, QueryableENRDatabaseAPI
 from eth_keys import keys
 from eth_typing import NodeID
-from eth_utils import humanize_seconds
+from eth_utils import ExtendedDebugLogger, humanize_seconds
 import trio
 
 from ddht.abc import (
@@ -437,7 +437,7 @@ class TalkProtocolAPI(ABC):
 
 
 class NetworkProtocol(Protocol):
-    logger: logging.Logger
+    logger: ExtendedDebugLogger
     routing_table: RoutingTableAPI
 
     @property

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -1,4 +1,3 @@
-import logging
 from typing import (
     AsyncContextManager,
     AsyncIterator,
@@ -15,7 +14,7 @@ from async_service import Service
 from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
 from eth_enr.exceptions import OldSequenceNumber
 from eth_typing import Hash32, NodeID
-from eth_utils import ValidationError
+from eth_utils import ValidationError, get_extended_debug_logger
 from eth_utils.toolz import cons, first
 from lru import LRU
 import trio
@@ -57,8 +56,6 @@ from ddht.v5_1.network import common_recursive_find_nodes
 
 
 class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
-    logger = logging.getLogger("ddht.Alexandria")
-
     # Delegate to the AlexandriaClient for determining `protocol_id`
     protocol_id = AlexandriaClient.protocol_id
 
@@ -71,6 +68,8 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         advertisement_db: AdvertisementDatabaseAPI,
         max_advertisement_count: int = 65536,
     ) -> None:
+        self.logger = get_extended_debug_logger("ddht.Alexandria")
+
         self._bootnodes = tuple(bootnodes)
 
         self.max_advertisement_count = max_advertisement_count
@@ -184,7 +183,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
     async def bond(
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
     ) -> bool:
-        self.logger.debug(
+        self.logger.debug2(
             "Bonding with %s", node_id.hex(),
         )
 

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -1,5 +1,4 @@
 import itertools
-import logging
 from typing import (
     AsyncContextManager,
     AsyncIterator,
@@ -16,7 +15,7 @@ from async_service import Service
 from eth_enr import ENRAPI, ENRManagerAPI, QueryableENRDatabaseAPI
 from eth_enr.exceptions import OldSequenceNumber
 from eth_typing import NodeID
-from eth_utils import ValidationError
+from eth_utils import ValidationError, get_extended_debug_logger
 from eth_utils.toolz import cons, first, take
 from lru import LRU
 import trio
@@ -84,7 +83,7 @@ async def common_recursive_find_nodes(
     mitigate the overall slowdown caused by a few unresponsive nodes since the
     other queries can be issues concurrently.
     """
-    network.logger.debug("Recursive find nodes: %s", target.hex())
+    network.logger.debug2("Recursive find nodes: %s", target.hex())
     start_at = trio.current_time()
 
     # The set of NodeID values we have already queried.
@@ -320,12 +319,12 @@ async def common_network_stream_find_nodes(
 
 
 class Network(Service, NetworkAPI):
-    logger = logging.getLogger("ddht.Network")
-
     _bootnodes: Tuple[ENRAPI, ...]
     _talk_protocols: Dict[bytes, TalkProtocolAPI]
 
     def __init__(self, client: ClientAPI, bootnodes: Collection[ENRAPI],) -> None:
+        self.logger = get_extended_debug_logger("ddht.Network")
+
         self.client = client
 
         self._bootnodes = tuple(bootnodes)
@@ -387,7 +386,7 @@ class Network(Service, NetworkAPI):
     async def bond(
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
     ) -> bool:
-        self.logger.debug(
+        self.logger.debug2(
             "Bonding with %s", node_id.hex(),
         )
 


### PR DESCRIPTION
fixes https://github.com/ethereum/ddht/issues/234

## What was wrong?

The DEBUG logs were too noisy.

## How was it fixed

Leverage `ExtendedDebugLogger` from eth-utils

#### Cute Animal Picture

![animals-smelling-flowers-37__880](https://user-images.githubusercontent.com/824194/101993735-263ada80-3c7a-11eb-85af-2f833583455b.jpg)

