### PR TITLE
Formalize concurrency for ContentCollector

### DIFF
--- a/ddht/v5_1/alexandria/content_collector.py
+++ b/ddht/v5_1/alexandria/content_collector.py
@@ -18,10 +18,15 @@ class ContentCollector(Service, ContentCollectorAPI):
     logger = logging.getLogger("ddht.ContentCollector")
 
     def __init__(
-        self, network: AlexandriaNetworkAPI, content_manager: ContentManagerAPI
+        self,
+        network: AlexandriaNetworkAPI,
+        content_manager: ContentManagerAPI,
+        concurrency: int = 3,
     ) -> None:
         self._network = network
         self.content_manager = content_manager
+
+        self._concurrency = concurrency
 
         self._ready = trio.Event()
 
@@ -41,30 +46,40 @@ class ContentCollector(Service, ContentCollectorAPI):
 
         await self.manager.wait_finished()
 
+    async def _worker(
+        self, worker_id: int, receive_channel: trio.abc.ReceiveChannel[Advertisement]
+    ) -> None:
+        async for advertisement in receive_channel:
+            with trio.move_on_after(30) as scope:
+                await self._gather_advertisement_content(advertisement)
+
+            if scope.cancelled_caught:
+                self.logger.debug(
+                    f"Unable to retrieve advertised content: "
+                    f"content_key={advertisement.content_key.hex()}"
+                )
+
     async def _monitor_new_advertisements(self) -> None:
+        send_channel, receive_channel = trio.open_memory_channel[Advertisement](
+            self._concurrency
+        )
         async with self._advertisement_manager.new_advertisement.subscribe() as subscription:
             self._ready.set()
             async with trio.open_nursery() as nursery:
+                for worker_id in range(self._concurrency):
+                    nursery.start_soon(self._worker, worker_id, receive_channel)
+
                 async for advertisement in subscription:
                     if self.content_storage.has_content(advertisement.content_key):
                         continue
 
-                    nursery.start_soon(
-                        self._gather_advertisement_content, advertisement
-                    )
+                    await send_channel.send(advertisement)
 
     async def _gather_advertisement_content(self, advertisement: Advertisement) -> None:
-        try:
-            proof = await self._network.get_content(
-                content_key=advertisement.content_key,
-                hash_tree_root=advertisement.hash_tree_root,
-            )
-        except trio.TooSlowError:
-            self.logger.debug(
-                f"Unable to retrieve advertised content: "
-                f"content_key={advertisement.content_key.hex()}"
-            )
-            return
+        proof = await self._network.get_content(
+            content_key=advertisement.content_key,
+            hash_tree_root=advertisement.hash_tree_root,
+        )
 
         content = proof.get_content()
 
@@ -73,12 +88,15 @@ class ContentCollector(Service, ContentCollectorAPI):
                 content_key=advertisement.content_key, content=content,
             )
         except ValidationError:
-            self.logger.info(
-                f"Content validation failed: "
-                f"content_key={advertisement.content_key.hex()}  "
-                f"content={content.hex()}"
+            self.logger.debug(
+                "Content validation failed: content_key=%s  content=%s",
+                advertisement.content_key.hex(),
+                content.hex(),
             )
         else:
             await self.content_manager.process_content(
                 advertisement.content_key, content
+            )
+            self.logger.debug(
+                "Collected content: content_key=%s", advertisement.content_key.hex(),
             )


### PR DESCRIPTION
## What was wrong?

The `ContentCollector` could end up spawning huge numbers of background tasks.

## How was it fixed?

Formalized the concurrency model.

#### Cute Animal Picture

![340cef62f004a6388cb6354ca8e719f3](https://user-images.githubusercontent.com/824194/102128458-24ece780-3e0b-11eb-9072-dc513c8272fc.jpg)
