### PR TITLE
Fix ResourceQueue error

### DIFF
--- a/ddht/abc.py
+++ b/ddht/abc.py
@@ -320,9 +320,7 @@ class ResourceQueueAPI(Sized, Container[TResource]):
     resources: Set[TResource]
 
     @abstractmethod
-    def __init__(
-        self, resources: Collection[TResource], max_resource_count: int = None,
-    ) -> None:
+    def __init__(self, resources: Collection[TResource],) -> None:
         ...
 
     @abstractmethod
@@ -330,7 +328,7 @@ class ResourceQueueAPI(Sized, Container[TResource]):
         ...
 
     @abstractmethod
-    def remove(self, resource: TResource) -> None:
+    async def remove(self, resource: TResource) -> None:
         ...
 
     def reserve(self) -> AsyncContextManager[TResource]:

--- a/tests/core/test_resource_queue.py
+++ b/tests/core/test_resource_queue.py
@@ -79,7 +79,7 @@ async def test_resource_queue_fuzzy():
 
 @pytest.mark.trio
 async def test_resource_queue_add_idempotent():
-    queue = ResourceQueue(("a", "b", "c"), max_resource_count=4)
+    queue = ResourceQueue(("a", "b", "c"))
 
     assert len(queue) == 3
 
@@ -93,27 +93,13 @@ async def test_resource_queue_add_idempotent():
 
 
 @pytest.mark.trio
-async def test_resource_queue_add_blocks_when_queue_full(autojump_clock):
-    queue = ResourceQueue(("a", "b", "c"), max_resource_count=3)
-
-    await queue.add("a")
+async def test_resource_queue_remove_idempotent():
+    queue = ResourceQueue(("a", "b", "c"))
 
     assert len(queue) == 3
 
-    with pytest.raises(trio.TooSlowError):
-        with trio.fail_after(1):
-            await queue.add("d")
-
-
-@pytest.mark.trio
-async def test_resource_queue_remove():
-    queue = ResourceQueue(("a", "b", "c"), max_resource_count=10)
-
-    assert len(queue) == 3
-
-    queue.remove("a")
+    await queue.remove("a")
 
     assert len(queue) == 2
 
-    with pytest.raises(KeyError):
-        queue.remove("a")
+    await queue.remove("a")


### PR DESCRIPTION
fixes #310

## What was wrong?

Failing test due to invalid initialization of the `ResourceQueue`

## How was it fixed?

The `ResourceQueue` used for the segments for content retrieval was incorrectly being initialized with all of the segments duplicated 4x.

I both fixed this simple error and re-designed the queue to remove the complexity of having to define an upper bound on the number of elements in the queue.

#### Cute Animal Picture

![animals-smelling-flowers-35__880](https://user-images.githubusercontent.com/824194/102131243-2b7d5e00-3e0f-11eb-8d42-65c5cf5ce272.jpg)

