### PR TITLE
Extend Ack message to include which advertisements were acked

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -324,6 +324,7 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         endpoint: Endpoint,
         *,
         advertisement_radius: int,
+        acked: Tuple[bool, ...],
         request_id: bytes,
     ) -> None:
         ...
@@ -395,7 +396,7 @@ class AlexandriaClientAPI(ServiceAPI, TalkProtocolAPI):
         endpoint: Endpoint,
         *,
         advertisements: Collection[Advertisement],
-    ) -> Tuple[AckMessage, ...]:
+    ) -> AckMessage:
         ...
 
     @abstractmethod
@@ -564,7 +565,7 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
         *,
         advertisements: Collection[Advertisement],
         endpoint: Optional[Endpoint] = None,
-    ) -> Tuple[AckPayload, ...]:
+    ) -> AckPayload:
         ...
 
     @abstractmethod

--- a/ddht/v5_1/alexandria/messages.py
+++ b/ddht/v5_1/alexandria/messages.py
@@ -210,6 +210,16 @@ class AckMessage(AlexandriaMessage[AckPayload]):
 
     payload: AckPayload
 
+    @classmethod
+    def from_payload_args(
+        cls: Type[TAlexandriaMessage], payload_args: Any
+    ) -> TAlexandriaMessage:
+        # py-ssz uses an internal type for decoded `ssz.sedes.List` types that
+        # we don't need or want so we force it to a normal tuple type here.
+        advertisement_radius, raw_acked = payload_args
+        payload = cls.payload_type(advertisement_radius, tuple(raw_acked))
+        return cls(payload)
+
 
 @register
 class LocateMessage(AlexandriaMessage[LocatePayload]):

--- a/ddht/v5_1/alexandria/payloads.py
+++ b/ddht/v5_1/alexandria/payloads.py
@@ -53,6 +53,7 @@ AdvertisePayload = Tuple[Advertisement, ...]
 
 class AckPayload(NamedTuple):
     advertisement_radius: int
+    acked: Tuple[bool, ...]
 
 
 class LocatePayload(NamedTuple):

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -42,7 +42,7 @@ AdvertisementSedes = Container(
     field_sedes=(byte_list, bytes32, uint40, uint8, uint256, uint256)
 )
 AdvertiseSedes = List(AdvertisementSedes, max_length=32)
-AckSedes = Container(field_sedes=(uint256,))
+AckSedes = Container(field_sedes=(uint256, List(boolean, max_length=32)))
 
 LocateSedes = Container(field_sedes=(content_key_sedes,))
 LocationsSedes = Container(field_sedes=(uint8, List(AdvertisementSedes, max_length=32)))

--- a/tests/core/test_resource_queue.py
+++ b/tests/core/test_resource_queue.py
@@ -48,7 +48,7 @@ async def test_resource_queue_fuzzy():
         for _ in range(10):
             nursery.start_soon(worker, seen_resources)
 
-        await _yield(1, 200)
+        await _yield(1, 500)
 
         assert seen_resources == queue.resources
 
@@ -63,14 +63,14 @@ async def test_resource_queue_fuzzy():
         assert "e" in queue
         assert "f" in queue
 
-        await _yield(1, 200)
+        await _yield(1, 500)
 
         seen_resources_after_add = set()
 
         for _ in range(10):
             nursery.start_soon(worker, seen_resources_after_add)
 
-        await _yield(1, 200)
+        await _yield(1, 500)
 
         assert seen_resources_after_add == queue.resources
 

--- a/tests/core/v5_1/alexandria/test_advertisement_manager.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_manager.py
@@ -382,7 +382,9 @@ async def test_advertisement_manager_does_not_ack_if_advertisements_already_know
     with pytest.raises(trio.TooSlowError):
         with trio.fail_after(10):
             async with bob_alexandria_network.advertisement_manager.new_advertisement.subscribe_and_wait():  # noqa: E501
-                with pytest.raises(trio.TooSlowError):
-                    await alice_alexandria_client.advertise(
-                        bob.node_id, bob.endpoint, advertisements=(advertisement,),
-                    )
+                ack_payload = await alice_alexandria_client.advertise(
+                    bob.node_id, bob.endpoint, advertisements=(advertisement,),
+                )
+
+    assert len(ack_payload.acked) == 1
+    assert ack_payload.acked[0] is False

--- a/tests/core/v5_1/alexandria/test_advertisement_manager.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_manager.py
@@ -382,9 +382,9 @@ async def test_advertisement_manager_does_not_ack_if_advertisements_already_know
     with pytest.raises(trio.TooSlowError):
         with trio.fail_after(10):
             async with bob_alexandria_network.advertisement_manager.new_advertisement.subscribe_and_wait():  # noqa: E501
-                ack_payload = await alice_alexandria_client.advertise(
+                ack_message = await alice_alexandria_client.advertise(
                     bob.node_id, bob.endpoint, advertisements=(advertisement,),
                 )
 
-    assert len(ack_payload.acked) == 1
-    assert ack_payload.acked[0] is False
+    assert len(ack_message.payload.acked) == 1
+    assert ack_message.payload.acked[0] is False

--- a/tests/core/v5_1/alexandria/test_content_manager.py
+++ b/tests/core/v5_1/alexandria/test_content_manager.py
@@ -87,6 +87,7 @@ async def test_content_manager_enumerates_and_broadcasts_content(
                     request.sender_node_id,
                     request.sender_endpoint,
                     advertisement_radius=2 ** 256 - 1,
+                    acked=tuple(True for _ in request.message.payload),
                     request_id=request.request_id,
                 )
 

--- a/tests/core/v5_1/alexandria/test_message_encoding.py
+++ b/tests/core/v5_1/alexandria/test_message_encoding.py
@@ -92,7 +92,7 @@ def test_advertisement_message_encoding_round_trip(advertisements):
 
 @given(advertisement_radius=st.integers(min_value=0, max_value=2 ** 256 - 1),)
 def test_ack_message_encoding_round_trip(advertisement_radius):
-    payload = AckPayload(advertisement_radius)
+    payload = AckPayload(advertisement_radius, (True, False))
     message = AckMessage(payload)
     encoded = message.to_wire_bytes()
     result = decode_message(encoded)

--- a/tests/core/v5_1/alexandria/test_radius_tracker.py
+++ b/tests/core/v5_1/alexandria/test_radius_tracker.py
@@ -120,6 +120,7 @@ async def test_radius_tracker_tracks_via_ack(
                     request.sender_node_id,
                     request.sender_endpoint,
                     advertisement_radius=1234,
+                    acked=(True,),
                     request_id=request.request_id,
                 )
                 did_respond.set()


### PR DESCRIPTION
## What was wrong?

The `Advertise > Ack` request/response pair was broken.  The `Ack` message was only sent if *all* messages were considered "interesting".  This means that clients end up having to endure waiting for a timeout when they incidentally send a duplicate advertisement.

## How was it fixed?

The `Ack` message now contains a list of booleans that indicate which advertisements were accepted.

#### Cute Animal Picture

![animals-smelling-flowers-26__880](https://user-images.githubusercontent.com/824194/102138274-55d41900-3e19-11eb-9f98-c673e1c7faeb.jpg)

