### PR TITLE
Allow enumerating ContentStorageAPI by proximity to a node.

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -77,6 +77,14 @@ class ContentStorageAPI(Sized):
     def atomic(self) -> ContextManager["ContentStorageAPI"]:
         ...
 
+    @abstractmethod
+    def iter_furthest(self, target: NodeID) -> Iterable[ContentKey]:
+        ...
+
+    @abstractmethod
+    def iter_closest(self, target: NodeID) -> Iterable[ContentKey]:
+        ...
+
 
 class BroadcastLogAPI(ABC):
     @abstractmethod


### PR DESCRIPTION
## What was wrong?

In order to enforce an upper bound on stored content we need to be able to find the content with the key that is furthest from our node id.

## How was it fixed?

Added two new APIs to the `ContentStorageAPI`.

- `iter_furthest(target: NodeID)`
- `iter_closest(target: NodeID)`

#### Cute Animal Picture

![20-Cute-Pictures-Of-Animals-Smelling-Flowers-15-550x366](https://user-images.githubusercontent.com/824194/102248703-b10c1700-3ebe-11eb-802b-77fd43006e7a.jpg)

