### PR TITLE
Implement ContentStorageAPI.total_size

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -85,6 +85,10 @@ class ContentStorageAPI(Sized):
     def iter_closest(self, target: NodeID) -> Iterable[ContentKey]:
         ...
 
+    @abstractmethod
+    def total_size(self) -> int:
+        ...
+
 
 class BroadcastLogAPI(ABC):
     @abstractmethod

--- a/tests/core/v5_1/alexandria/test_content_storage.py
+++ b/tests/core/v5_1/alexandria/test_content_storage.py
@@ -75,6 +75,20 @@ def test_content_storage_sized(base_storage):
     assert len(base_storage) == 1
 
 
+def test_content_storage_disk_usage(base_storage):
+    content_keys = tuple(bytes([i]) for i in range(32))
+    content_values = tuple(b"\x00" * 32 for i in range(32))
+    expected = 32 * 32
+
+    assert base_storage.total_size() == 0
+
+    for content_key, content in zip(content_keys, content_values):
+        base_storage.set_content(content_key, content)
+
+    actual_size = base_storage.total_size()
+    assert actual_size == expected
+
+
 def test_content_storage_closest_and_furthest_iteration(base_storage):
     content_keys = tuple(b"key-" + bytes([i]) for i in range(32))
     for idx, content_key in enumerate(content_keys):


### PR DESCRIPTION
## What was wrong?

Need to be able to enforce total content size.

## How was it fixed?

Added `ContentStorageAPI.total_size`

#### Cute Animal Picture


![animals-smelling-flowers-291__880](https://user-images.githubusercontent.com/824194/102251747-773d0f80-3ec2-11eb-86c4-497adcd44f42.jpg)
