### PR TITLE
Enforce total commons content size

### DIFF
--- a/ddht/cli_parser.py
+++ b/ddht/cli_parser.py
@@ -213,7 +213,27 @@ alexandria_bootnodes_parser_group.add_argument(
 )
 
 #
-# Alexandria[CommonsStorage]
+# Alexandria[max_advertisement_count]
+#
+alexandria_parser.add_argument(
+    "--max-advertisement-count",
+    help=("Maximum number of advertisements to store"),
+    dest="alexandria_max_advertisement_count",
+    type=int,
+)
+
+#
+# Alexandria[CommonsStorage-size]
+#
+alexandria_parser.add_argument(
+    "--commons-storage-size",
+    help=("Total number of bytes to allocate towards 'commons' storage."),
+    dest="alexandria_commons_storage_size",
+    type=int,
+)
+
+#
+# Alexandria[CommonsStorage-dir]
 #
 alexandria_commons_storage_parser_group = (
     alexandria_parser.add_mutually_exclusive_group()
@@ -235,7 +255,7 @@ alexandria_commons_storage_parser_group.add_argument(
 )
 
 #
-# Alexandria[PinnedStorage]
+# Alexandria[PinnedStorage-dir]
 #
 alexandria_pinned_storage_parser_group = (
     alexandria_parser.add_mutually_exclusive_group()

--- a/ddht/v5_1/alexandria/app.py
+++ b/ddht/v5_1/alexandria/app.py
@@ -32,6 +32,12 @@ class AlexandriaApplication(BaseApplication):
         xdg_alexandria_root = get_xdg_alexandria_root()
         xdg_alexandria_root.mkdir(parents=True, exist_ok=True)
 
+        max_advertisement_count = self._alexandria_boot_info.max_advertisement_count
+
+        commons_content_storage_max_size = (
+            self._alexandria_boot_info.commons_storage_size
+        )
+
         commons_content_storage: ContentStorageAPI
         commons_storage_display: str
 
@@ -97,6 +103,8 @@ class AlexandriaApplication(BaseApplication):
             commons_content_storage=commons_content_storage,
             pinned_content_storage=pinned_content_storage,
             advertisement_db=advertisement_db,
+            commons_content_storage_max_size=commons_content_storage_max_size,
+            max_advertisement_count=max_advertisement_count,
         )
 
         self.manager.run_daemon_child_service(alexandria_network)
@@ -104,19 +112,23 @@ class AlexandriaApplication(BaseApplication):
         self.logger.info("Starting Alexandria...")
         self.logger.info("Root Directory         : %s", xdg_alexandria_root)
         self.logger.info(
-            "ContentStorage[Commons]: storage=%s  items=%d",
+            "ContentStorage[Commons]: storage=%s  items=%d  size=%d  max_size=%d",
             commons_storage_display,
             len(commons_content_storage),
+            commons_content_storage.total_size(),
+            commons_content_storage_max_size,
         )
         self.logger.info(
-            "ContentStorage[Pinned] : storage=%s  items=%d",
+            "ContentStorage[Pinned] : storage=%s  items=%d  size=%d",
             pinned_storage_display,
             len(pinned_content_storage),
+            pinned_content_storage.total_size(),
         )
         self.logger.info(
-            "AdvertisementDB        : storage=%s  total=%d",
+            "AdvertisementDB        : storage=%s  total=%d  max=%d",
             advertisement_db_path,
             advertisement_db.count(),
+            max_advertisement_count,
         )
 
         await self.manager.wait_finished()

--- a/ddht/v5_1/alexandria/boot_info.py
+++ b/ddht/v5_1/alexandria/boot_info.py
@@ -6,12 +6,21 @@ from typing import Literal, Optional, Sequence, Tuple, TypedDict, Union
 from eth_enr import ENR
 from eth_enr.abc import ENRAPI
 
-from ddht.v5_1.alexandria.constants import DEFAULT_BOOTNODES
+from ddht.v5_1.alexandria.constants import (
+    DEFAULT_BOOTNODES,
+    DEFAULT_COMMONS_STORAGE_SIZE,
+    DEFAULT_MAX_ADVERTISEMENTS,
+)
 
 
 class AlexandriaBootInfoKwargs(TypedDict, total=False):
     bootnodes: Tuple[ENRAPI, ...]
+
+    max_advertisement_count: int
+
+    commons_storage_size: int
     commons_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
+
     pinned_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
 
 
@@ -20,6 +29,20 @@ def _cli_args_to_boot_info_kwargs(args: argparse.Namespace) -> AlexandriaBootInf
         bootnodes = tuple(ENR.from_repr(enr_repr) for enr_repr in DEFAULT_BOOTNODES)
     else:
         bootnodes = args.alexandria_bootnodes
+
+    max_advertisement_count: int
+
+    if args.alexandria_max_advertisement_count is None:
+        max_advertisement_count = DEFAULT_MAX_ADVERTISEMENTS
+    else:
+        max_advertisement_count = args.alexandria_max_advertisement_count
+
+    commons_storage_size: int
+
+    if args.alexandria_commons_storage_size is None:
+        commons_storage_size = DEFAULT_COMMONS_STORAGE_SIZE
+    else:
+        commons_storage_size = args.alexandria_commons_storage_size
 
     commons_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
 
@@ -45,6 +68,8 @@ def _cli_args_to_boot_info_kwargs(args: argparse.Namespace) -> AlexandriaBootInf
 
     return AlexandriaBootInfoKwargs(
         bootnodes=bootnodes,
+        max_advertisement_count=max_advertisement_count,
+        commons_storage_size=commons_storage_size,
         commons_storage=commons_storage,
         pinned_storage=pinned_storage,
     )
@@ -53,7 +78,12 @@ def _cli_args_to_boot_info_kwargs(args: argparse.Namespace) -> AlexandriaBootInf
 @dataclass(frozen=True)
 class AlexandriaBootInfo:
     bootnodes: Tuple[ENRAPI, ...]
+
+    max_advertisement_count: int
+
+    commons_storage_size: int
     commons_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
+
     pinned_storage: Optional[Union[Literal[":memory:"], pathlib.Path]]
 
     @classmethod

--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -30,3 +30,15 @@ MAX_PAYLOAD_SIZE = DISCOVERY_MAX_PACKET_SIZE - 90
 
 # One hour in seconds
 ONE_HOUR = 60 * 60
+
+
+# One Megabyte
+MB = 1024 * 1024
+
+
+# Default max bytes for "commons" storage
+DEFAULT_COMMONS_STORAGE_SIZE = 100 * MB
+
+
+# Default maximum number of advertisements
+DEFAULT_MAX_ADVERTISEMENTS = 65536

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -37,7 +37,11 @@ from ddht.v5_1.alexandria.advertisement_provider import AdvertisementProvider
 from ddht.v5_1.alexandria.advertisements import Advertisement, partition_advertisements
 from ddht.v5_1.alexandria.broadcast_log import BroadcastLog
 from ddht.v5_1.alexandria.client import AlexandriaClient
-from ddht.v5_1.alexandria.constants import MAX_PAYLOAD_SIZE
+from ddht.v5_1.alexandria.constants import (
+    DEFAULT_COMMONS_STORAGE_SIZE,
+    DEFAULT_MAX_ADVERTISEMENTS,
+    MAX_PAYLOAD_SIZE,
+)
 from ddht.v5_1.alexandria.content import (
     compute_content_distance,
     content_key_to_content_id,
@@ -69,7 +73,8 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         commons_content_storage: ContentStorageAPI,
         pinned_content_storage: ContentStorageAPI,
         advertisement_db: AdvertisementDatabaseAPI,
-        max_advertisement_count: int = 65536,
+        max_advertisement_count: int = DEFAULT_MAX_ADVERTISEMENTS,
+        commons_content_storage_max_size: int = DEFAULT_COMMONS_STORAGE_SIZE,
     ) -> None:
         self.logger = get_extended_debug_logger("ddht.Alexandria")
 
@@ -87,7 +92,12 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         )
 
         self.commons_content_storage = commons_content_storage
-        self.commons_content_manager = ContentManager(self, commons_content_storage)
+        self.commons_content_storage_max_size = commons_content_storage_max_size
+        self.commons_content_manager = ContentManager(
+            self,
+            commons_content_storage,
+            max_size=self.commons_content_storage_max_size,
+        )
         self.commons_content_collector = ContentCollector(
             self, self.commons_content_manager
         )


### PR DESCRIPTION
## What was wrong?

We need to enforce an upper bound on the total stored content size

## How was it fixed?

The `ContentManagerAPI` now monitors the total size of the content and removes the furthest content when the total size exceeds this limit.

#### Cute Animal Picture

![09a3fd6fb923829b7aad3b50b8466972](https://user-images.githubusercontent.com/824194/102263995-449b1300-3ed2-11eb-949f-4ad3320db780.jpg)
