### PR TITLE
ContentCollectorAPI should respect content limits

### DIFF
--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -48,6 +48,10 @@ from ddht.v5_1.alexandria.typing import ContentID, ContentKey
 
 class ContentStorageAPI(Sized):
     @abstractmethod
+    def total_size(self) -> int:
+        ...
+
+    @abstractmethod
     def has_content(self, content_key: ContentKey) -> bool:
         ...
 
@@ -83,10 +87,6 @@ class ContentStorageAPI(Sized):
 
     @abstractmethod
     def iter_closest(self, target: NodeID) -> Iterable[ContentKey]:
-        ...
-
-    @abstractmethod
-    def total_size(self) -> int:
         ...
 
 
@@ -181,6 +181,16 @@ class AdvertisementDatabaseAPI(ABC):
 
 class ContentManagerAPI(ServiceAPI):
     content_storage: ContentStorageAPI
+
+    @property
+    @abstractmethod
+    def content_radius(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def is_full(self) -> bool:
+        ...
 
     @abstractmethod
     async def process_content(self, content_key: ContentKey, content: bytes) -> None:


### PR DESCRIPTION
## What was wrong?

More patching up production stuff

## How was it fixed?

- ContentCollector now respects the max storage size
- AdvertisementManager now respects the max advertisement count
- Handling for a production exception when retrieving content that no longer exists in storage.

#### Cute Animal Picture

![animals-doing-human-things-25-1](https://user-images.githubusercontent.com/824194/102281679-9d77a500-3eec-11eb-98ea-28152de869d2.jpg)
