### PR TITLE
Use separate databases for local and remote advertisements.

### DIFF
--- a/ddht/_utils.py
+++ b/ddht/_utils.py
@@ -275,3 +275,33 @@ def caboose(seq: Iterable[TItem], el: TElement) -> Iterable[Union[TElement, TIte
     """
     yield from seq
     yield el
+
+
+BYTE = 1
+KILOBYTE = 1024
+MEGABYTE = KILOBYTE * 1024
+GIGABYTE = MEGABYTE * 1024
+TERABYTE = GIGABYTE * 1024
+PETABYTE = TERABYTE * 1024
+
+BYTES_UNITS = (
+    (PETABYTE, "PB"),
+    (TERABYTE, "TB"),
+    (GIGABYTE, "GB"),
+    (MEGABYTE, "MB"),
+    (KILOBYTE, "KB"),
+    (BYTE, "B"),
+)
+
+
+def humanize_bytes(value: int) -> str:
+    if value == 0:
+        return "0B"
+
+    for bytes_per_unit, unit_display in BYTES_UNITS:
+        if value >= bytes_per_unit:
+            scaled_value = value / bytes_per_unit
+            value_display = f"{scaled_value:.2f}".rstrip("0").rstrip(".")
+            return f"{value_display}{unit_display}"
+    else:
+        raise Exception("Should be unreachable")

--- a/ddht/tools/driver/abc.py
+++ b/ddht/tools/driver/abc.py
@@ -30,7 +30,9 @@ from ddht.v5_1.packets import AnyPacket
 class AlexandriaNodeAPI(ABC):
     commons_content_storage: ContentStorageAPI
     pinned_content_storage: ContentStorageAPI
-    advertisement_db: AdvertisementDatabaseAPI
+
+    local_advertisement_db: AdvertisementDatabaseAPI
+    remote_advertisement_db: AdvertisementDatabaseAPI
 
     @property
     @abstractmethod

--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -29,7 +29,12 @@ class AlexandriaNode(AlexandriaNodeAPI):
         self.node = node
         self.commons_content_storage = MemoryContentStorage()
         self.pinned_content_storage = MemoryContentStorage()
-        self.advertisement_db = AdvertisementDatabase(sqlite3.connect(":memory:"),)
+        self.local_advertisement_db = AdvertisementDatabase(
+            sqlite3.connect(":memory:"),
+        )
+        self.remote_advertisement_db = AdvertisementDatabase(
+            sqlite3.connect(":memory:"),
+        )
         self._lock = NamedLock()
 
     @property
@@ -76,7 +81,8 @@ class AlexandriaNode(AlexandriaNodeAPI):
                     bootnodes=bootnodes,
                     commons_content_storage=self.commons_content_storage,
                     pinned_content_storage=self.pinned_content_storage,
-                    advertisement_db=self.advertisement_db,
+                    local_advertisement_db=self.local_advertisement_db,
+                    remote_advertisement_db=self.remote_advertisement_db,
                     max_advertisement_count=max_advertisement_count,
                 )
                 async with background_trio_service(alexandria_network):

--- a/ddht/v5_1/alexandria/_utils.py
+++ b/ddht/v5_1/alexandria/_utils.py
@@ -1,0 +1,16 @@
+from .constants import MAX_RADIUS
+
+
+def humanize_advertisement_radius(radius: int, max_radius: int = MAX_RADIUS) -> float:
+    if radius == MAX_RADIUS:
+        return 1.0 * MAX_RADIUS.bit_length()
+
+    display_whole = radius.bit_length() - 1
+
+    remainder = radius % 2 ** display_whole
+    remainder_max = 2 ** (display_whole + 1) - 2 ** display_whole
+
+    display_fraction = remainder / remainder_max
+
+    display_value = display_whole + display_fraction
+    return display_value  # type: ignore

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -181,6 +181,7 @@ class AdvertisementDatabaseAPI(ABC):
 
 class ContentManagerAPI(ServiceAPI):
     content_storage: ContentStorageAPI
+    max_size: Optional[int]
 
     @property
     @abstractmethod
@@ -197,7 +198,7 @@ class ContentManagerAPI(ServiceAPI):
         ...
 
 
-class AdvertisementManagerAPI(ServiceAPI):
+class AdvertisementCollectorAPI(ServiceAPI):
     new_advertisement: EventAPI[Advertisement]
 
     @abstractmethod
@@ -214,6 +215,28 @@ class AdvertisementManagerAPI(ServiceAPI):
 
     @abstractmethod
     async def handle_advertisement(self, advertisement: Advertisement) -> bool:
+        ...
+
+
+class AdvertisementManagerAPI(ServiceAPI):
+    advertisement_db: AdvertisementDatabaseAPI
+    max_advertisement_count: Optional[int]
+
+    @property
+    @abstractmethod
+    def advertisement_radius(self) -> int:
+        ...
+
+    @abstractmethod
+    async def purge_expired_ads(self) -> None:
+        ...
+
+    @abstractmethod
+    async def purge_distant_ads(self) -> None:
+        ...
+
+    @abstractmethod
+    async def ready(self) -> None:
         ...
 
 
@@ -466,9 +489,14 @@ class AlexandriaNetworkAPI(ServiceAPI, TalkProtocolAPI):
     radius_tracker: RadiusTrackerAPI
     broadcast_log: BroadcastLogAPI
 
-    advertisement_db: AdvertisementDatabaseAPI
+    local_advertisement_db: AdvertisementDatabaseAPI
+    local_advertisement_manager: AdvertisementManagerAPI
+
+    remote_advertisement_db: AdvertisementDatabaseAPI
+    remote_advertisement_manager: AdvertisementManagerAPI
+
     advertisement_provider: AdvertisementProviderAPI
-    advertisement_manager: AdvertisementManagerAPI
+    advertisement_collector: AdvertisementCollectorAPI
 
     content_validator: ContentValidatorAPI
 

--- a/ddht/v5_1/alexandria/advertisement_collector.py
+++ b/ddht/v5_1/alexandria/advertisement_collector.py
@@ -1,0 +1,318 @@
+import logging
+import secrets
+
+from async_service import Service
+from eth_typing import NodeID
+from eth_utils import ValidationError
+import ssz
+from ssz.constants import CHUNK_SIZE
+import trio
+
+from ddht.base_message import InboundMessage
+from ddht.event import Event
+from ddht.v5_1.alexandria.abc import (
+    AdvertisementCollectorAPI,
+    AdvertisementDatabaseAPI,
+    AdvertisementManagerAPI,
+    AlexandriaNetworkAPI,
+)
+from ddht.v5_1.alexandria.content import compute_content_distance
+from ddht.v5_1.alexandria.content_storage import ContentNotFound
+from ddht.v5_1.alexandria.messages import AdvertiseMessage
+from ddht.v5_1.alexandria.payloads import Advertisement
+from ddht.v5_1.alexandria.sedes import content_sedes
+
+
+class AdvertisementCollector(Service, AdvertisementCollectorAPI):
+    logger = logging.getLogger("ddht.AdvertisementCollector")
+
+    def __init__(
+        self,
+        network: AlexandriaNetworkAPI,
+        remote_advertisement_manager: AdvertisementManagerAPI,
+        local_advertisement_manager: AdvertisementManagerAPI,
+    ) -> None:
+        self._network = network
+
+        self.remote_advertisement_manager = remote_advertisement_manager
+        self.local_advertisement_manager = local_advertisement_manager
+
+        self.new_advertisement = Event("new-advertisement")
+
+        self._ready = trio.Event()
+
+    @property
+    def local_node_id(self) -> NodeID:
+        return self._network.local_node_id
+
+    @property
+    def local_advertisement_db(self) -> AdvertisementDatabaseAPI:
+        return self.local_advertisement_manager.advertisement_db
+
+    @property
+    def remote_advertisement_db(self) -> AdvertisementDatabaseAPI:
+        return self.remote_advertisement_manager.advertisement_db
+
+    async def ready(self) -> None:
+        await self._ready.wait()
+
+    #
+    # Long Running
+    #
+    async def run(self) -> None:
+        self.manager.run_daemon_task(self._handle_advertisement_requests)
+
+        await self.manager.wait_finished()
+
+    async def _handle_advertisement_requests(self) -> None:
+        async with trio.open_nursery() as nursery:
+            async with self._network.client.subscribe(AdvertiseMessage) as subscription:
+                self._ready.set()
+
+                async for request in subscription:
+                    if not request.message.payload:
+                        continue
+
+                    nursery.start_soon(self._handle_request, request)
+
+    async def _handle_request(self, request: InboundMessage[AdvertiseMessage]) -> None:
+        """
+        Process the advertisements.
+
+        Each advertisement goes through this process:
+
+        - If already present we assume validity
+        - Otherwise validate:
+            - Bond with node to check liveliness
+            - Check `content_key/hash_tree_root` against existing database entries.
+                - If there is a discrepancy we must determine canonical `hash_tree_root`.
+            - Proof of custody check.
+                - Request random chunk(s) of the data and verify against `hash_tree_root`
+
+        Once validated:
+
+        - Broadcast advertisement to logarithmic subset of peers for which the
+          advertisement falls within their ad radius
+        """
+        if not all(ad.is_valid for ad in request.message.payload):
+            # TODO: this is a place where we should consider blacklisting
+            self.logger.debug(
+                "Invalid advertisements: from=%s  advertisements=%s",
+                request.sender_node_id.hex(),
+                request.message.payload,
+            )
+            return
+
+        if any(ad.is_expired for ad in request.message.payload):
+            self.logger.debug(
+                "Expired advertisements: from=%s  advertisements=%s",
+                request.sender_node_id.hex(),
+                request.message.payload,
+            )
+            return
+
+        # We Ack
+        acked = tuple(
+            self.check_interest(advertisement)
+            for advertisement in request.message.payload
+        )
+        await self._network.client.send_ack(
+            request.sender_node_id,
+            request.sender_endpoint,
+            advertisement_radius=self.remote_advertisement_manager.advertisement_radius,
+            acked=acked,
+            request_id=request.request_id,
+        )
+
+        for advertisement, is_interesting in zip(request.message.payload, acked):
+            if not is_interesting:
+                continue
+
+            # Log the advertisements on the way in so that we don't try to
+            # rebroadcast back to this node.
+            self._network.broadcast_log.log(request.sender_node_id, advertisement)
+
+            await self.handle_advertisement(advertisement)
+
+    #
+    # External API
+    #
+    def check_interest(self, advertisement: Advertisement) -> bool:
+        if advertisement.node_id == self.local_node_id:
+            return self._check_interest(advertisement, self.local_advertisement_manager)
+        else:
+            return self._check_interest(
+                advertisement, self.remote_advertisement_manager
+            )
+
+    def _check_interest(
+        self,
+        advertisement: Advertisement,
+        advertisement_manager: AdvertisementManagerAPI,
+    ) -> bool:
+        if advertisement_manager.advertisement_db.exists(advertisement):
+            return False
+
+        distance_from_content = compute_content_distance(
+            self.local_node_id, advertisement.content_id,
+        )
+        if distance_from_content > advertisement_manager.advertisement_radius:
+            return False
+
+        return True
+
+    async def validate_advertisement(self, advertisement: Advertisement) -> None:
+        if not advertisement.is_valid:
+            raise ValidationError(
+                f"Advertisement has invalid signature: signature={advertisement.signature}"
+            )
+
+        if advertisement.is_expired:
+            raise ValidationError(
+                f"Advertisement expired: advertisement={advertisement}"
+            )
+
+        if not self.check_interest(advertisement):
+            raise ValidationError(
+                f"Advertisement already known: advertisement={advertisement}"
+            )
+
+        # Verify that the `hash_tree_root` matches the known roots.
+        known_hash_tree_roots = set(
+            self.local_advertisement_db.get_hash_tree_roots_for_content_id(
+                advertisement.content_id
+            )
+        ) | set(
+            self.remote_advertisement_db.get_hash_tree_roots_for_content_id(
+                advertisement.content_id
+            )
+        )
+        if len(known_hash_tree_roots) > 1:
+            self.logger.error(
+                "Multiple hash tree roots found: content_id=%s  roots=%s",
+                advertisement.content_id.hex(),
+                known_hash_tree_roots,
+            )
+
+        if (
+            known_hash_tree_roots
+            and advertisement.hash_tree_root not in known_hash_tree_roots
+        ):
+            # TODO: perform full validation of the content to determine the
+            # correct root.
+            raise NotImplementedError("TODO: resolve disccrepancy")
+
+        if advertisement.node_id == self._network.local_node_id:
+            await self._validate_local_advertisement(advertisement)
+        else:
+            await self._validate_remote_advertisement(advertisement)
+
+    async def _validate_local_advertisement(self, advertisement: Advertisement) -> None:
+        if not advertisement.node_id == self.local_node_id:
+            raise Exception(
+                "Must be called with an advertisement signed by the local node"
+            )
+
+        try:
+            try:
+                # First query "pinned" storage
+                content = self._network.pinned_content_storage.get_content(
+                    advertisement.content_key
+                )
+            except ContentNotFound:
+                # Fall back to "commons" storage
+                content = self._network.commons_content_storage.get_content(
+                    advertisement.content_key
+                )
+        except ContentNotFound as err:
+            raise ValidationError(
+                f"Content not found: advertisement={advertisement}"
+            ) from err
+
+        hash_tree_root = ssz.get_hash_tree_root(content, sedes=content_sedes)
+
+        if hash_tree_root != advertisement.hash_tree_root:
+            raise ValidationError(
+                f"Mismatched roots: local={hash_tree_root.hex()}  "
+                f"advertisement={advertisement.hash_tree_root.hex}"
+            )
+
+    async def _validate_remote_advertisement(
+        self, advertisement: Advertisement
+    ) -> None:
+        """
+        - valid signature
+        - not expired
+        - within local advertisement radius
+        - node is reachable
+        - proof of custody check
+        """
+        # Verify the liveliness of the node this advertisement is for.
+        did_bond = await self._network.bond(advertisement.node_id)
+        if not did_bond:
+            raise ValidationError(
+                f"Advertisement failed liveliness check: node_id={advertisement.node_id.hex()}"
+            )
+
+        # Perform a proof of custody check
+        try:
+            base_proof = await self._network.get_content_proof(
+                advertisement.node_id,
+                hash_tree_root=advertisement.hash_tree_root,
+                content_key=advertisement.content_key,
+                start_chunk_index=0,
+                max_chunks=2,
+            )
+        except trio.TooSlowError:
+            raise ValidationError(
+                f"Initial proof retrieval failed: advertisement={advertisement}"
+            )
+
+        if not base_proof.is_complete:
+            content_length = base_proof.get_content_length()
+            chunk_count = (content_length + 31) // CHUNK_SIZE
+            if chunk_count > 2:
+                # We avoid fetching the first two chunks since we already have
+                # them from the initial proof.
+                chunk_to_request = secrets.randbelow(chunk_count - 2) + 2
+                if not base_proof.has_chunk(chunk_to_request):
+                    try:
+                        custody_proof = await self._network.get_content_proof(
+                            advertisement.node_id,
+                            hash_tree_root=advertisement.hash_tree_root,
+                            content_key=advertisement.content_key,
+                            start_chunk_index=chunk_to_request,
+                            max_chunks=2,
+                        )
+                    except trio.TooSlowError:
+                        raise ValidationError(
+                            f"Proof of custody check failed: "
+                            f"advertisement={advertisement}"
+                        )
+                    else:
+                        if not custody_proof.has_chunk(chunk_to_request):
+                            # Failed proof of custody check
+                            raise ValidationError(
+                                f"Proof of custody check failed: "
+                                f"advertisement={advertisement}"
+                            )
+
+    async def handle_advertisement(self, advertisement: Advertisement) -> bool:
+        try:
+            await self.validate_advertisement(advertisement)
+        except ValidationError as err:
+            self.logger.debug(
+                "Advertisement failed validation: advertisement=%s err=%s",
+                advertisement,
+                err,
+            )
+            return False
+        else:
+            if advertisement.node_id == self.local_node_id:
+                self.local_advertisement_db.add(advertisement)
+            else:
+                self.remote_advertisement_db.add(advertisement)
+
+            await self._network.broadcast(advertisement)
+            await self.new_advertisement.trigger(advertisement)
+            return True

--- a/ddht/v5_1/alexandria/advertisement_manager.py
+++ b/ddht/v5_1/alexandria/advertisement_manager.py
@@ -1,322 +1,124 @@
 import itertools
 import logging
-import secrets
+from typing import Optional
 
 from async_service import Service
-from eth_utils import ValidationError
-from eth_utils.toolz import take
-import ssz
-from ssz.constants import CHUNK_SIZE
+from eth_utils.toolz import first, take
 import trio
 
-from ddht.base_message import InboundMessage
-from ddht.event import Event
 from ddht.v5_1.alexandria.abc import (
     AdvertisementDatabaseAPI,
     AdvertisementManagerAPI,
     AlexandriaNetworkAPI,
 )
+from ddht.v5_1.alexandria.constants import MAX_RADIUS
 from ddht.v5_1.alexandria.content import compute_content_distance
-from ddht.v5_1.alexandria.content_storage import ContentNotFound
-from ddht.v5_1.alexandria.messages import AdvertiseMessage
-from ddht.v5_1.alexandria.payloads import Advertisement
-from ddht.v5_1.alexandria.sedes import content_sedes
 
 
 class AdvertisementManager(Service, AdvertisementManagerAPI):
     logger = logging.getLogger("ddht.AdvertisementManager")
 
     def __init__(
-        self, network: AlexandriaNetworkAPI, advertisement_db: AdvertisementDatabaseAPI,
+        self,
+        network: AlexandriaNetworkAPI,
+        advertisement_db: AdvertisementDatabaseAPI,
+        max_advertisement_count: Optional[int] = None,
     ) -> None:
         self._network = network
-        self._advertisement_db = advertisement_db
+        self.advertisement_db = advertisement_db
         self._ready = trio.Event()
 
-        self.new_advertisement = Event("new-advertisement")
+        self.max_advertisement_count = max_advertisement_count
+
+    @property
+    def advertisement_radius(self) -> int:
+        if self.max_advertisement_count is None:
+            return MAX_RADIUS
+
+        advertisement_count = self.advertisement_db.count()
+
+        if advertisement_count < self.max_advertisement_count:
+            return MAX_RADIUS
+
+        try:
+            furthest_advertisement = first(
+                self.advertisement_db.furthest(self._network.local_node_id)
+            )
+        except StopIteration:
+            return MAX_RADIUS
+        else:
+            return compute_content_distance(
+                self._network.local_node_id, furthest_advertisement.content_id,
+            )
 
     async def ready(self) -> None:
         await self._ready.wait()
 
+    async def purge_expired_ads(self) -> None:
+        while self.manager.is_running:
+            await trio.lowlevel.checkpoint()
+
+            # Purge in chunks of 64 to avoid blocking too long
+            to_purge = tuple(take(64, self.advertisement_db.expired()))
+            if not to_purge:
+                break
+
+            self.logger.debug("Purging expired ads: count=%d", len(to_purge))
+
+            for advertisement in to_purge:
+                self.advertisement_db.remove(advertisement)
+
+    async def purge_distant_ads(self) -> None:
+        if self.max_advertisement_count is None:
+            raise Exception("Invalid")
+
+        while self.manager.is_running:
+            # Ensure that the inner loop here doesn't block the event loop
+            await trio.lowlevel.checkpoint()
+
+            # Check if we are over the limit
+            total_advertisements = self.advertisement_db.count()
+            if total_advertisements <= self.max_advertisement_count:
+                break
+
+            num_to_purge = total_advertisements - self.max_advertisement_count
+
+            # Purge in chunks of 64 to avoid blocking too long
+            to_purge = tuple(
+                take(
+                    min(64, num_to_purge),
+                    itertools.filterfalse(
+                        lambda ad: ad.node_id == self._network.local_node_id,
+                        self.advertisement_db.furthest(self._network.local_node_id),
+                    ),
+                )
+            )
+
+            self.logger.debug("Purging ads outside radius: count=%d", len(to_purge))
+
+            for advertisement in to_purge:
+                self.advertisement_db.remove(advertisement)
+
     async def run(self) -> None:
-        self.manager.run_daemon_task(self._enforce_max_advertisement_limit)
+        if self.max_advertisement_count is not None:
+            self.manager.run_daemon_task(self._enforce_max_advertisement_limit)
         self.manager.run_daemon_task(self._periodically_purge_expired)
-        self.manager.run_daemon_task(self._handle_advertisement_requests)
+
+        self._ready.set()
 
         await self.manager.wait_finished()
 
     async def _enforce_max_advertisement_limit(self) -> None:
+        if self.max_advertisement_count is None:
+            raise Exception("Invalid")
+
         while self.manager.is_running:
-            while self.manager.is_running:
-                await trio.lowlevel.checkpoint()
-                total_advertisements = self._advertisement_db.count()
-                num_to_purge = max(
-                    0, total_advertisements - self._network.max_advertisement_count
-                )
-
-                if not num_to_purge:
-                    break
-
-                to_purge = tuple(
-                    take(
-                        # Purge at most 64 at a time
-                        min(64, num_to_purge),
-                        itertools.filterfalse(
-                            lambda ad: ad.node_id == self._network.local_node_id,
-                            self._advertisement_db.furthest(
-                                self._network.local_node_id
-                            ),
-                        ),
-                    )
-                )
-
-                self.logger.debug("Purging ads outside radius: count=%d", len(to_purge))
-
-                for advertisement in to_purge:
-                    self._advertisement_db.remove(advertisement)
+            await self.purge_distant_ads()
 
             await trio.sleep(30)
 
     async def _periodically_purge_expired(self) -> None:
         while self.manager.is_running:
-            await trio.lowlevel.checkpoint()
+            await self.purge_expired_ads()
 
-            # Purge in *small* chunks to avoid blocking too long
-            to_purge = tuple(take(64, self._advertisement_db.expired()))
-            if not to_purge:
-                await trio.sleep(30)
-                continue
-
-            self.logger.debug("Purging expired ads: count=%d", len(to_purge))
-
-            for advertisement in to_purge:
-                self._advertisement_db.remove(advertisement)
-
-    async def _handle_advertisement_requests(self) -> None:
-        async with trio.open_nursery() as nursery:
-            async with self._network.client.subscribe(AdvertiseMessage) as subscription:
-                self._ready.set()
-                async for request in subscription:
-                    if not request.message.payload:
-                        continue
-
-                    nursery.start_soon(self._handle_request, request)
-
-    def check_interest(self, advertisement: Advertisement) -> bool:
-        if self._advertisement_db.exists(advertisement):
-            return False
-
-        distance_from_content = compute_content_distance(
-            self._network.local_node_id, advertisement.content_id,
-        )
-        if distance_from_content > self._network.local_advertisement_radius:
-            return False
-
-        return True
-
-    async def validate_advertisement(self, advertisement: Advertisement) -> None:
-        if not advertisement.is_valid:
-            raise ValidationError(
-                f"Advertisement has invalid signature: signature={advertisement.signature}"
-            )
-
-        if advertisement.is_expired:
-            raise ValidationError(
-                f"Advertisement expired: advertisement={advertisement}"
-            )
-
-        if self._advertisement_db.exists(advertisement):
-            raise ValidationError(
-                f"Advertisement already known: advertisement={advertisement}"
-            )
-
-        # Verify that the `hash_tree_root` matches the known roots.
-        known_hash_tree_roots = set(
-            self._advertisement_db.get_hash_tree_roots_for_content_id(
-                advertisement.content_id
-            )
-        )
-        if len(known_hash_tree_roots) > 1:
-            self.logger.error(
-                "Multiple hash tree roots found: content_id=%s  roots=%s",
-                advertisement.content_id.hex(),
-                known_hash_tree_roots,
-            )
-
-        if (
-            known_hash_tree_roots
-            and advertisement.hash_tree_root not in known_hash_tree_roots
-        ):
-            # TODO: perform full validation of the content to determine the
-            # correct root.
-            raise NotImplementedError("TODO: resolve disccrepancy")
-
-        if advertisement.node_id == self._network.local_node_id:
-            await self._validate_local_advertisement(advertisement)
-        else:
-            await self._validate_remote_advertisement(advertisement)
-
-    async def _validate_local_advertisement(self, advertisement: Advertisement) -> None:
-        if not advertisement.node_id == self._network.local_node_id:
-            raise Exception(
-                "Must be called with an advertisement signed by the local node"
-            )
-
-        try:
-            try:
-                # First query "pinned" storage
-                content = self._network.pinned_content_storage.get_content(
-                    advertisement.content_key
-                )
-            except ContentNotFound:
-                # Fall back to "commons" storage
-                content = self._network.commons_content_storage.get_content(
-                    advertisement.content_key
-                )
-        except ContentNotFound as err:
-            raise ValidationError(
-                f"Content not found: advertisement={advertisement}"
-            ) from err
-
-        hash_tree_root = ssz.get_hash_tree_root(content, sedes=content_sedes)
-
-        if hash_tree_root != advertisement.hash_tree_root:
-            raise ValidationError(
-                f"Mismatched roots: local={hash_tree_root.hex()}  "
-                f"advertisement={advertisement.hash_tree_root.hex}"
-            )
-
-    async def _validate_remote_advertisement(
-        self, advertisement: Advertisement
-    ) -> None:
-        """
-        - valid signature
-        - not expired
-        - within local advertisement radius
-        - node is reachable
-        - proof of custody check
-        """
-        # Verify the liveliness of the node this advertisement is for.
-        did_bond = await self._network.bond(advertisement.node_id)
-        if not did_bond:
-            raise ValidationError(
-                f"Advertisement failed liveliness check: node_id={advertisement.node_id.hex()}"
-            )
-
-        # Perform a proof of custody check
-        try:
-            base_proof = await self._network.get_content_proof(
-                advertisement.node_id,
-                hash_tree_root=advertisement.hash_tree_root,
-                content_key=advertisement.content_key,
-                start_chunk_index=0,
-                max_chunks=2,
-            )
-        except trio.TooSlowError:
-            raise ValidationError(
-                f"Initial proof retrieval failed: advertisement={advertisement}"
-            )
-
-        if not base_proof.is_complete:
-            content_length = base_proof.get_content_length()
-            chunk_count = (content_length + 31) // CHUNK_SIZE
-            if chunk_count > 2:
-                # We avoid fetching the first two chunks since we already have
-                # them from the initial proof.
-                chunk_to_request = secrets.randbelow(chunk_count - 2) + 2
-                if not base_proof.has_chunk(chunk_to_request):
-                    try:
-                        custody_proof = await self._network.get_content_proof(
-                            advertisement.node_id,
-                            hash_tree_root=advertisement.hash_tree_root,
-                            content_key=advertisement.content_key,
-                            start_chunk_index=chunk_to_request,
-                            max_chunks=2,
-                        )
-                    except trio.TooSlowError:
-                        raise ValidationError(
-                            f"Proof of custody check failed: "
-                            f"advertisement={advertisement}"
-                        )
-                    else:
-                        if not custody_proof.has_chunk(chunk_to_request):
-                            # Failed proof of custody check
-                            raise ValidationError(
-                                f"Proof of custody check failed: "
-                                f"advertisement={advertisement}"
-                            )
-
-    async def handle_advertisement(self, advertisement: Advertisement) -> bool:
-        try:
-            await self.validate_advertisement(advertisement)
-        except ValidationError as err:
-            self.logger.debug(
-                "Advertisement failed validation: advertisement=%s err=%s",
-                advertisement,
-                err,
-            )
-            return False
-        else:
-            self._advertisement_db.add(advertisement)
-            await self._network.broadcast(advertisement)
-            await self.new_advertisement.trigger(advertisement)
-            return True
-
-    async def _handle_request(self, request: InboundMessage[AdvertiseMessage]) -> None:
-        """
-        Process the advertisements.
-
-        Each advertisement goes through this process:
-
-        - If already present we assume validity
-        - Otherwise validate:
-            - Bond with node to check liveliness
-            - Check `content_key/hash_tree_root` against existing database entries.
-                - If there is a discrepancy we must determine canonical `hash_tree_root`.
-            - Proof of custody check.
-                - Request random chunk(s) of the data and verify against `hash_tree_root`
-
-        Once validated:
-
-        - Broadcast advertisement to logarithmic subset of peers for which the
-          advertisement falls within their ad radius
-        """
-        if not all(ad.is_valid for ad in request.message.payload):
-            # TODO: this is a place where we should consider blacklisting
-            self.logger.debug(
-                "Invalid advertisements: from=%s  advertisements=%s",
-                request.sender_node_id.hex(),
-                request.message.payload,
-            )
-            return
-
-        if any(ad.is_expired for ad in request.message.payload):
-            self.logger.debug(
-                "Expired advertisements: from=%s  advertisements=%s",
-                request.sender_node_id.hex(),
-                request.message.payload,
-            )
-            return
-
-        # We Ack
-        acked = tuple(
-            self.check_interest(advertisement)
-            for advertisement in request.message.payload
-        )
-        await self._network.client.send_ack(
-            request.sender_node_id,
-            request.sender_endpoint,
-            advertisement_radius=self._network.local_advertisement_radius,
-            acked=acked,
-            request_id=request.request_id,
-        )
-
-        for advertisement, is_interesting in zip(request.message.payload, acked):
-            if not is_interesting:
-                continue
-
-            # Log the advertisements on the way in so that we don't try to
-            # rebroadcast back to this node.
-            self._network.broadcast_log.log(request.sender_node_id, advertisement)
-
-            await self.handle_advertisement(advertisement)
+            await trio.sleep(30)

--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -42,3 +42,6 @@ DEFAULT_COMMONS_STORAGE_SIZE = 100 * MB
 
 # Default maximum number of advertisements
 DEFAULT_MAX_ADVERTISEMENTS = 65536
+
+
+MAX_RADIUS = 2 ** 256 - 1

--- a/ddht/v5_1/alexandria/content_collector.py
+++ b/ddht/v5_1/alexandria/content_collector.py
@@ -5,7 +5,7 @@ from eth_utils import ValidationError
 import trio
 
 from ddht.v5_1.alexandria.abc import (
-    AdvertisementManagerAPI,
+    AdvertisementCollectorAPI,
     AlexandriaNetworkAPI,
     ContentCollectorAPI,
     ContentManagerAPI,
@@ -36,8 +36,8 @@ class ContentCollector(Service, ContentCollectorAPI):
         return self.content_manager.content_storage
 
     @property
-    def _advertisement_manager(self) -> AdvertisementManagerAPI:
-        return self._network.advertisement_manager
+    def _advertisement_collector(self) -> AdvertisementCollectorAPI:
+        return self._network.advertisement_collector
 
     async def ready(self) -> None:
         await self._ready.wait()
@@ -74,7 +74,7 @@ class ContentCollector(Service, ContentCollectorAPI):
         send_channel, receive_channel = trio.open_memory_channel[Advertisement](
             self._concurrency
         )
-        async with self._advertisement_manager.new_advertisement.subscribe() as subscription:
+        async with self._advertisement_collector.new_advertisement.subscribe() as subscription:
             self._ready.set()
             async with trio.open_nursery() as nursery:
                 for worker_id in range(self._concurrency):

--- a/tests/core/test_humanize_bytes.py
+++ b/tests/core/test_humanize_bytes.py
@@ -1,0 +1,44 @@
+import pytest
+
+from ddht._utils import humanize_bytes
+
+KB = 1024
+MB = 1024 * 1024
+GB = 1024 * 1024 * 1024
+TB = 1024 * 1024 * 1024 * 1024
+PB = 1024 * 1024 * 1024 * 1024 * 1024
+
+
+@pytest.mark.parametrize(
+    "num_bytes,expected",
+    (
+        (0, "0B"),
+        (1, "1B"),
+        (10, "10B"),
+        (125, "125B"),
+        (1023, "1023B"),
+        (KB, "1KB"),
+        (MB, "1MB"),
+        (GB, "1GB"),
+        (TB, "1TB"),
+        (PB, "1PB"),
+        (int(KB * 1.25), "1.25KB"),
+        (int(MB * 1.25), "1.25MB"),
+        (int(GB * 1.25), "1.25GB"),
+        (int(TB * 1.25), "1.25TB"),
+        (int(PB * 1.25), "1.25PB"),
+        (int(KB * 1.2), "1.2KB"),
+        (int(MB * 1.2), "1.2MB"),
+        (int(GB * 1.2), "1.2GB"),
+        (int(TB * 1.2), "1.2TB"),
+        (int(PB * 1.2), "1.2PB"),
+        (int(KB * 125), "125KB"),
+        (int(MB * 125), "125MB"),
+        (int(GB * 125), "125GB"),
+        (int(TB * 125), "125TB"),
+        (int(PB * 125), "125PB"),
+    ),
+)
+def test_humanize_bytes(num_bytes, expected):
+    actual = humanize_bytes(num_bytes)
+    assert actual == expected

--- a/tests/core/v5_1/alexandria/test_advertisement_collector.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_collector.py
@@ -1,0 +1,418 @@
+from eth_utils import ValidationError
+import pytest
+import trio
+
+from ddht.tools.factories.alexandria import AdvertisementFactory
+from ddht.tools.factories.content import ContentFactory
+from ddht.v5_1.alexandria.content import compute_content_distance
+from ddht.v5_1.alexandria.messages import GetContentMessage
+from ddht.v5_1.alexandria.partials.proof import compute_proof
+from ddht.v5_1.alexandria.sedes import content_sedes
+
+
+#
+# AdvertisementManagerAPI.check_interest
+#
+@pytest.mark.trio
+async def test_advertisement_collector_check_interest_already_in_local_db(
+    alice, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=alice.private_key)
+
+    assert ad_collector.check_interest(advertisement) is True
+
+    alice_alexandria_network.local_advertisement_db.add(advertisement)
+
+    assert ad_collector.check_interest(advertisement) is False
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_check_interest_already_in_remote_db(
+    bob, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=bob.private_key)
+
+    assert ad_collector.check_interest(advertisement) is True
+
+    alice_alexandria_network.remote_advertisement_db.add(advertisement)
+
+    assert ad_collector.check_interest(advertisement) is False
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_check_interest_outside_radius(
+    alice, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement_db = alice_alexandria_network.remote_advertisement_db
+    assert alice_alexandria_network.max_advertisement_count <= 32
+
+    advertisements = tuple(
+        sorted(
+            (
+                AdvertisementFactory()
+                for _ in range(alice_alexandria_network.max_advertisement_count + 1)
+            ),
+            key=lambda ad: compute_content_distance(ad.content_id, alice.node_id),
+        )
+    )
+    furthest = advertisements[-1]
+
+    assert alice_alexandria_network.local_advertisement_radius == 2 ** 256 - 1
+    assert ad_collector.check_interest(furthest) is True
+
+    for ad in advertisements[: alice_alexandria_network.max_advertisement_count]:
+        advertisement_db.add(ad)
+
+    expected_radius = compute_content_distance(
+        advertisements[-2].content_id, alice.node_id
+    )
+    assert expected_radius < 2 ** 256 - 1
+
+    assert alice_alexandria_network.local_advertisement_radius == expected_radius
+    assert ad_collector.check_interest(furthest) is False
+
+
+#
+# Generic validation checks
+#
+@pytest.mark.trio
+async def test_advertisement_collector_validate_already_in_local_database(
+    alice, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=alice.private_key)
+    alice_alexandria_network.local_advertisement_db.add(advertisement)
+
+    with pytest.raises(ValidationError, match="known"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_already_in_remote_database(
+    bob, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=bob.private_key)
+    alice_alexandria_network.remote_advertisement_db.add(advertisement)
+
+    with pytest.raises(ValidationError, match="known"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_invalid_signature(
+    alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(
+        signature_v=1, signature_r=1357924680, signature_s=2468013579,
+    )
+
+    with pytest.raises(ValidationError, match="signature"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_unknown_node_id(
+    alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+
+    with pytest.raises(ValidationError, match="liveliness"):
+        await ad_collector.validate_advertisement(AdvertisementFactory())
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_mismatched_hash_tree_roots(
+    bob, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+
+    advertisement_a = AdvertisementFactory(private_key=bob.private_key)
+    advertisement_b = AdvertisementFactory(
+        private_key=bob.private_key, content_key=advertisement_a.content_key,
+    )
+    assert advertisement_a.hash_tree_root != advertisement_b.hash_tree_root
+
+    advertisement_db = alice_alexandria_network.remote_advertisement_db
+
+    advertisement_db.add(advertisement_a)
+
+    with pytest.raises(NotImplementedError):
+        await ad_collector.validate_advertisement(advertisement_b)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_multiple_mismatched_hash_tree_roots(
+    bob, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+
+    advertisement_a = AdvertisementFactory(private_key=bob.private_key)
+    advertisement_b = AdvertisementFactory(
+        private_key=bob.private_key, content_key=advertisement_a.content_key,
+    )
+    advertisement_c = AdvertisementFactory(
+        private_key=bob.private_key, content_key=advertisement_a.content_key,
+    )
+
+    assert advertisement_a.hash_tree_root != advertisement_b.hash_tree_root
+    assert advertisement_b.hash_tree_root != advertisement_c.hash_tree_root
+
+    advertisement_db = alice_alexandria_network.remote_advertisement_db
+
+    advertisement_db.add(advertisement_a)
+    advertisement_db.add(advertisement_b)
+
+    with pytest.raises(NotImplementedError):
+        await ad_collector.validate_advertisement(advertisement_c)
+
+
+#
+# Validation checks against *remote* ads
+#
+@pytest.mark.trio
+async def test_advertisement_collector_validate_remote_expired(
+    bob, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory.expired(private_key=bob.private_key)
+
+    with pytest.raises(ValidationError, match="expired"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_remote_node_unreachable(
+    bob, alice_alexandria_network, autojump_clock
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=bob.private_key)
+
+    with pytest.raises(ValidationError, match="liveliness"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_remote_fail_initial_proof_check(
+    bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=bob.private_key)
+
+    with pytest.raises(ValidationError, match="proof retrieval"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_remote_fail_custody_proof_check(
+    bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+
+    async with bob_alexandria_network.client.subscribe(
+        GetContentMessage
+    ) as subscription:
+        did_serve_initial_proof = False
+
+        async with trio.open_nursery() as nursery:
+            did_serve_initial_proof = True
+
+            async def _respond():
+                request = await subscription.receive()
+                partial = proof.to_partial(0, 64)
+                await bob_alexandria_network.client.send_content(
+                    request.sender_node_id,
+                    request.sender_endpoint,
+                    is_proof=True,
+                    payload=partial.serialize(),
+                    request_id=request.request_id,
+                )
+
+            nursery.start_soon(_respond)
+
+            with pytest.raises(ValidationError, match="Proof of custody check failed"):
+                await ad_collector.validate_advertisement(advertisement)
+
+            assert did_serve_initial_proof is True
+
+
+#
+# Validation checks against *local* ads
+#
+@pytest.mark.trio
+async def test_advertisement_collector_validate_local_expired(
+    alice, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory.expired(private_key=alice.private_key)
+
+    with pytest.raises(ValidationError, match="expired"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_local_content_not_found(
+    alice, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=alice.private_key)
+
+    content_storage = alice_alexandria_network.commons_content_storage
+    assert not content_storage.has_content(advertisement.content_key)
+
+    with pytest.raises(ValidationError, match="not found"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_validate_local_hash_tree_root_mismatch(
+    alice, alice_alexandria_network,
+):
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(private_key=alice.private_key)
+
+    content_storage = alice_alexandria_network.commons_content_storage
+    content_storage.set_content(advertisement.content_key, ContentFactory())
+
+    with pytest.raises(ValidationError, match="Mismatched roots"):
+        await ad_collector.validate_advertisement(advertisement)
+
+
+#
+# Tests against actual handling
+#
+@pytest.mark.trio
+async def test_advertisement_collector_handle_new_valid_local_advertisement(
+    alice, alice_alexandria_network, bob_alexandria_network,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(
+        private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    alice_alexandria_network.commons_content_storage.set_content(
+        advertisement.content_key, content,
+    )
+
+    assert not alice_alexandria_network.local_advertisement_db.exists(advertisement)
+
+    with trio.fail_after(5):
+        await ad_collector.handle_advertisement(advertisement)
+
+    assert alice_alexandria_network.local_advertisement_db.exists(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_handle_new_valid_remote_advertisement(
+    alice, bob, alice_alexandria_network, bob_alexandria_network,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    bob_alexandria_network.commons_content_storage.set_content(
+        advertisement.content_key, content,
+    )
+
+    assert not alice_alexandria_network.remote_advertisement_db.exists(advertisement)
+
+    with trio.fail_after(5):
+        async with ad_collector.new_advertisement.subscribe_and_wait():
+            await ad_collector.handle_advertisement(advertisement)
+
+    assert alice_alexandria_network.remote_advertisement_db.exists(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_handle_existing_valid_local_advertisement(
+    alice, alice_alexandria_network, bob_alexandria_network,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(
+        private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    alice_alexandria_network.commons_content_storage.set_content(
+        advertisement.content_key, content,
+    )
+    alice_alexandria_network.local_advertisement_db.add(advertisement)
+
+    assert alice_alexandria_network.local_advertisement_db.exists(advertisement)
+
+    async with ad_collector.new_advertisement.subscribe() as subscription:
+        with trio.fail_after(5):
+            await ad_collector.handle_advertisement(advertisement)
+        with pytest.raises(trio.TooSlowError):
+            with trio.fail_after(5):
+                await subscription.receive()
+
+    assert alice_alexandria_network.local_advertisement_db.exists(advertisement)
+
+
+@pytest.mark.trio
+async def test_advertisement_collector_handle_existing_valid_remote_advertisement(
+    alice, bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    ad_collector = alice_alexandria_network.advertisement_collector
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    bob_alexandria_network.commons_content_storage.set_content(
+        advertisement.content_key, content,
+    )
+
+    alice_alexandria_network.remote_advertisement_db.add(advertisement)
+
+    assert alice_alexandria_network.remote_advertisement_db.exists(advertisement)
+
+    async with ad_collector.new_advertisement.subscribe() as subscription:
+        with trio.fail_after(5):
+            await ad_collector.handle_advertisement(advertisement)
+        with pytest.raises(trio.TooSlowError):
+            with trio.fail_after(5):
+                await subscription.receive()
+
+    assert alice_alexandria_network.remote_advertisement_db.exists(advertisement)
+
+
+#
+# Actual request handling
+#
+@pytest.mark.trio
+async def test_advertisement_collector_acks_false_if_advertisements_already_known(
+    alice, bob, alice_alexandria_client, bob_alexandria_network, autojump_clock,
+):
+    content = ContentFactory(2048)
+    proof = compute_proof(content, sedes=content_sedes)
+    advertisement = AdvertisementFactory(
+        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
+    )
+    bob_alexandria_network.commons_content_storage.set_content(
+        advertisement.content_key, content,
+    )
+    bob_alexandria_network.local_advertisement_db.add(advertisement)
+
+    with pytest.raises(trio.TooSlowError):
+        with trio.fail_after(10):
+            async with bob_alexandria_network.advertisement_collector.new_advertisement.subscribe_and_wait():  # noqa: E501
+                ack_message = await alice_alexandria_client.advertise(
+                    bob.node_id, bob.endpoint, advertisements=(advertisement,),
+                )
+
+    assert len(ack_message.payload.acked) == 1
+    assert ack_message.payload.acked[0] is False

--- a/tests/core/v5_1/alexandria/test_advertisement_manager.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_manager.py
@@ -1,38 +1,29 @@
-from eth_utils import ValidationError
 import pytest
-import trio
 
 from ddht.tools.factories.alexandria import AdvertisementFactory
-from ddht.tools.factories.content import ContentFactory
-from ddht.tools.factories.keys import PrivateKeyFactory
+from ddht.v5_1.alexandria.constants import MAX_RADIUS
 from ddht.v5_1.alexandria.content import compute_content_distance
-from ddht.v5_1.alexandria.messages import GetContentMessage
-from ddht.v5_1.alexandria.partials.proof import compute_proof
-from ddht.v5_1.alexandria.sedes import content_sedes
 
 
 #
 # AdvertisementManagerAPI.check_interest
 #
 @pytest.mark.trio
-async def test_advertisement_manager_check_interest_already_in_db(
+async def test_local_advertisement_manager_advertisement_radius(
     bob, alice_alexandria_network,
 ):
-    ad_manager = alice_alexandria_network.advertisement_manager
-
-    advertisement = AdvertisementFactory(private_key=PrivateKeyFactory())
-    alice_alexandria_network.advertisement_db.add(advertisement)
-
-    assert ad_manager.check_interest(advertisement) is False
+    ad_manager = alice_alexandria_network.local_advertisement_manager
+    assert ad_manager.max_advertisement_count is None
+    assert ad_manager.advertisement_radius == MAX_RADIUS
 
 
 @pytest.mark.trio
-async def test_advertisement_manager_check_interest_outside_radius(
-    alice, alice_alexandria_network,
+async def test_remote_advertisement_manager_advertisement_radius(
+    alice, alice_alexandria_network, autojump_clock,
 ):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement_db = alice_alexandria_network.advertisement_db
-    assert alice_alexandria_network.max_advertisement_count <= 32
+    ad_manager = alice_alexandria_network.remote_advertisement_manager
+    assert ad_manager.max_advertisement_count <= 32
+    assert ad_manager.advertisement_radius == MAX_RADIUS
 
     advertisements = tuple(
         sorted(
@@ -40,351 +31,16 @@ async def test_advertisement_manager_check_interest_outside_radius(
                 AdvertisementFactory()
                 for _ in range(alice_alexandria_network.max_advertisement_count + 1)
             ),
-            key=lambda ad: compute_content_distance(ad.content_id, alice.node_id),
+            key=lambda ad: compute_content_distance(alice.node_id, ad.content_id),
         )
     )
-    furthest = advertisements[-1]
+    for advertisement in advertisements:
+        ad_manager.advertisement_db.add(advertisement)
 
-    assert alice_alexandria_network.local_advertisement_radius == 2 ** 256 - 1
-    assert ad_manager.check_interest(furthest) is True
-
-    for ad in advertisements[: alice_alexandria_network.max_advertisement_count]:
-        advertisement_db.add(ad)
+    await ad_manager.purge_distant_ads()
 
     expected_radius = compute_content_distance(
         advertisements[-2].content_id, alice.node_id
     )
-    assert expected_radius < 2 ** 256 - 1
-
-    assert alice_alexandria_network.local_advertisement_radius == expected_radius
-    assert ad_manager.check_interest(furthest) is False
-
-
-#
-# Generic validation checks
-#
-@pytest.mark.trio
-async def test_advertisement_manager_validate_already_in_database(
-    alice, bob, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(private_key=bob.private_key)
-    alice_alexandria_network.advertisement_db.add(advertisement)
-
-    with pytest.raises(ValidationError, match="known"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_invalid_signature(
-    alice, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(
-        signature_v=1, signature_r=1357924680, signature_s=2468013579,
-    )
-
-    with pytest.raises(ValidationError, match="signature"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_unknown_node_id(
-    alice, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-
-    with pytest.raises(ValidationError, match="liveliness"):
-        await ad_manager.validate_advertisement(AdvertisementFactory())
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_mismatched_hash_tree_roots(
-    alice, bob, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-
-    advertisement_a = AdvertisementFactory(private_key=bob.private_key)
-    advertisement_b = AdvertisementFactory(
-        private_key=bob.private_key, content_key=advertisement_a.content_key,
-    )
-    assert advertisement_a.hash_tree_root != advertisement_b.hash_tree_root
-
-    advertisement_db = alice_alexandria_network.advertisement_db
-
-    advertisement_db.add(advertisement_a)
-
-    with pytest.raises(NotImplementedError):
-        await ad_manager.validate_advertisement(advertisement_b)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_multiple_mismatched_hash_tree_roots(
-    alice, bob, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-
-    advertisement_a = AdvertisementFactory(private_key=bob.private_key)
-    advertisement_b = AdvertisementFactory(
-        private_key=bob.private_key, content_key=advertisement_a.content_key,
-    )
-    advertisement_c = AdvertisementFactory(
-        private_key=bob.private_key, content_key=advertisement_a.content_key,
-    )
-
-    assert advertisement_a.hash_tree_root != advertisement_b.hash_tree_root
-    assert advertisement_b.hash_tree_root != advertisement_c.hash_tree_root
-
-    advertisement_db = alice_alexandria_network.advertisement_db
-
-    advertisement_db.add(advertisement_a)
-    advertisement_db.add(advertisement_b)
-
-    with pytest.raises(NotImplementedError):
-        await ad_manager.validate_advertisement(advertisement_c)
-
-
-#
-# Validation checks against *remote* ads
-#
-@pytest.mark.trio
-async def test_advertisement_manager_validate_remote_expired(
-    alice, bob, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory.expired(private_key=bob.private_key)
-
-    with pytest.raises(ValidationError, match="expired"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_remote_node_unreachable(
-    alice, bob, alice_alexandria_network, autojump_clock
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(private_key=bob.private_key)
-
-    with pytest.raises(ValidationError, match="liveliness"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_remote_fail_initial_proof_check(
-    alice, bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(private_key=bob.private_key)
-
-    with pytest.raises(ValidationError, match="proof retrieval"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_remote_fail_custody_proof_check(
-    alice, bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
-):
-    content = ContentFactory(2048)
-    proof = compute_proof(content, sedes=content_sedes)
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(
-        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
-    )
-
-    async with bob_alexandria_network.client.subscribe(
-        GetContentMessage
-    ) as subscription:
-        did_serve_initial_proof = False
-
-        async with trio.open_nursery() as nursery:
-            did_serve_initial_proof = True
-
-            async def _respond():
-                request = await subscription.receive()
-                partial = proof.to_partial(0, 64)
-                await bob_alexandria_network.client.send_content(
-                    request.sender_node_id,
-                    request.sender_endpoint,
-                    is_proof=True,
-                    payload=partial.serialize(),
-                    request_id=request.request_id,
-                )
-
-            nursery.start_soon(_respond)
-
-            with pytest.raises(ValidationError, match="Proof of custody check failed"):
-                await ad_manager.validate_advertisement(advertisement)
-
-            assert did_serve_initial_proof is True
-
-
-#
-# Validation checks against *local* ads
-#
-@pytest.mark.trio
-async def test_advertisement_manager_validate_local_expired(
-    alice, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory.expired(private_key=alice.private_key)
-
-    with pytest.raises(ValidationError, match="expired"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_local_content_not_found(
-    alice, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(private_key=alice.private_key)
-
-    content_storage = alice_alexandria_network.commons_content_storage
-    assert not content_storage.has_content(advertisement.content_key)
-
-    with pytest.raises(ValidationError, match="not found"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_validate_local_hash_tree_root_mismatch(
-    alice, alice_alexandria_network,
-):
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(private_key=alice.private_key)
-
-    content_storage = alice_alexandria_network.commons_content_storage
-    content_storage.set_content(advertisement.content_key, ContentFactory())
-
-    with pytest.raises(ValidationError, match="Mismatched roots"):
-        await ad_manager.validate_advertisement(advertisement)
-
-
-#
-# Tests against actual handling
-#
-@pytest.mark.trio
-async def test_advertisement_manager_handle_new_valid_local_advertisement(
-    alice, alice_alexandria_network, bob_alexandria_network,
-):
-    content = ContentFactory(2048)
-    proof = compute_proof(content, sedes=content_sedes)
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(
-        private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
-    )
-    alice_alexandria_network.commons_content_storage.set_content(
-        advertisement.content_key, content,
-    )
-
-    assert not alice_alexandria_network.advertisement_db.exists(advertisement)
-
-    with trio.fail_after(5):
-        await ad_manager.handle_advertisement(advertisement)
-
-    assert alice_alexandria_network.advertisement_db.exists(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_handle_new_valid_remote_advertisement(
-    alice, bob, alice_alexandria_network, bob_alexandria_network,
-):
-    content = ContentFactory(2048)
-    proof = compute_proof(content, sedes=content_sedes)
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(
-        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
-    )
-    bob_alexandria_network.commons_content_storage.set_content(
-        advertisement.content_key, content,
-    )
-
-    assert not alice_alexandria_network.advertisement_db.exists(advertisement)
-
-    with trio.fail_after(5):
-        async with ad_manager.new_advertisement.subscribe_and_wait():
-            await ad_manager.handle_advertisement(advertisement)
-
-    assert alice_alexandria_network.advertisement_db.exists(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_handle_existing_valid_local_advertisement(
-    alice, alice_alexandria_network, bob_alexandria_network,
-):
-    content = ContentFactory(2048)
-    proof = compute_proof(content, sedes=content_sedes)
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(
-        private_key=alice.private_key, hash_tree_root=proof.get_hash_tree_root(),
-    )
-    alice_alexandria_network.commons_content_storage.set_content(
-        advertisement.content_key, content,
-    )
-    alice_alexandria_network.advertisement_db.add(advertisement)
-
-    assert alice_alexandria_network.advertisement_db.exists(advertisement)
-
-    async with ad_manager.new_advertisement.subscribe() as subscription:
-        with trio.fail_after(5):
-            await ad_manager.handle_advertisement(advertisement)
-        with pytest.raises(trio.TooSlowError):
-            with trio.fail_after(5):
-                await subscription.receive()
-
-    assert alice_alexandria_network.advertisement_db.exists(advertisement)
-
-
-@pytest.mark.trio
-async def test_advertisement_manager_handle_existing_valid_remote_advertisement(
-    alice, bob, alice_alexandria_network, bob_alexandria_network, autojump_clock,
-):
-    content = ContentFactory(2048)
-    proof = compute_proof(content, sedes=content_sedes)
-    ad_manager = alice_alexandria_network.advertisement_manager
-    advertisement = AdvertisementFactory(
-        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
-    )
-    bob_alexandria_network.commons_content_storage.set_content(
-        advertisement.content_key, content,
-    )
-    alice_alexandria_network.advertisement_db.add(advertisement)
-
-    assert alice_alexandria_network.advertisement_db.exists(advertisement)
-
-    async with ad_manager.new_advertisement.subscribe() as subscription:
-        with trio.fail_after(5):
-            await ad_manager.handle_advertisement(advertisement)
-        with pytest.raises(trio.TooSlowError):
-            with trio.fail_after(5):
-                await subscription.receive()
-
-    assert alice_alexandria_network.advertisement_db.exists(advertisement)
-
-
-#
-# Actual request handling
-#
-@pytest.mark.trio
-async def test_advertisement_manager_does_not_ack_if_advertisements_already_known(
-    alice, bob, alice_alexandria_client, bob_alexandria_network, autojump_clock,
-):
-    content = ContentFactory(2048)
-    proof = compute_proof(content, sedes=content_sedes)
-    advertisement = AdvertisementFactory(
-        private_key=bob.private_key, hash_tree_root=proof.get_hash_tree_root(),
-    )
-    bob_alexandria_network.commons_content_storage.set_content(
-        advertisement.content_key, content,
-    )
-    bob_alexandria_network.advertisement_db.add(advertisement)
-
-    with pytest.raises(trio.TooSlowError):
-        with trio.fail_after(10):
-            async with bob_alexandria_network.advertisement_manager.new_advertisement.subscribe_and_wait():  # noqa: E501
-                ack_message = await alice_alexandria_client.advertise(
-                    bob.node_id, bob.endpoint, advertisements=(advertisement,),
-                )
-
-    assert len(ack_message.payload.acked) == 1
-    assert ack_message.payload.acked[0] is False
+    assert expected_radius < MAX_RADIUS
+    assert ad_manager.advertisement_radius == expected_radius

--- a/tests/core/v5_1/alexandria/test_advertisement_provider.py
+++ b/tests/core/v5_1/alexandria/test_advertisement_provider.py
@@ -22,7 +22,7 @@ async def test_content_provider_serves_advertisements(
         advertisement_db.add(advertisement)
 
     advertisement_provider = AdvertisementProvider(
-        bob_alexandria_client, advertisement_db
+        bob_alexandria_client, (advertisement_db,),
     )
     async with background_trio_service(advertisement_provider):
         # this ensures that the subscription is in place.
@@ -42,7 +42,7 @@ async def test_content_provider_serves_unknown_content_key_request(
     advertisement_db = AdvertisementDatabase(sqlite3.connect(":memory:"))
 
     advertisement_provider = AdvertisementProvider(
-        bob_alexandria_client, advertisement_db
+        bob_alexandria_client, (advertisement_db,),
     )
     async with background_trio_service(advertisement_provider):
         # this ensures that the subscription is in place.

--- a/tests/core/v5_1/alexandria/test_alexandria_client.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_client.py
@@ -605,7 +605,7 @@ async def test_alexandria_client_locate_multi_response(
     advertisements = tuple(
         AdvertisementFactory(private_key=alice.private_key) for i in range(32)
     )
-    batches = partition_advertisements(advertisements, MAX_PAYLOAD_SIZE)
+    batches = partition_advertisements(advertisements, MAX_PAYLOAD_SIZE - 8)
     num_responses = len(batches)
     assert num_responses > 1
 

--- a/tests/core/v5_1/alexandria/test_alexandria_network.py
+++ b/tests/core/v5_1/alexandria/test_alexandria_network.py
@@ -511,7 +511,7 @@ async def test_alexandria_network_stream_locations(
         )
 
         for advertisement, network in zip(advertisements, networks):
-            network.advertisement_db.add(advertisement)
+            network.remote_advertisement_db.add(advertisement)
 
         # give the the network some time to interconnect.
         with trio.fail_after(30):
@@ -559,7 +559,7 @@ async def test_alexandria_network_stream_locations_early_exit(
         )
 
         for advertisement, network in zip(advertisements, networks):
-            network.advertisement_db.add(advertisement)
+            network.remote_advertisement_db.add(advertisement)
 
         # give the the network some time to interconnect.
         with trio.fail_after(30):
@@ -610,7 +610,7 @@ async def test_alexandria_network_get_content(
                 hash_tree_root=hash_tree_root,
                 private_key=network.client.local_private_key,
             )
-            network.advertisement_db.add(advertisement)
+            network.local_advertisement_db.add(advertisement)
             network.pinned_content_storage.set_content(content_key, content)
 
         # give the the network some time to interconnect.

--- a/tests/core/v5_1/alexandria/test_content_manager.py
+++ b/tests/core/v5_1/alexandria/test_content_manager.py
@@ -28,7 +28,7 @@ async def test_content_manager_enumerates_and_broadcasts_content(
         for idx in range(12)
     )
 
-    advertisement_db = alice.alexandria.advertisement_db
+    advertisement_db = alice.alexandria.local_advertisement_db
     pinned_storage = alice.alexandria.pinned_content_storage
 
     for content_key, content in contents[0:13:3]:

--- a/tests/core/v5_1/alexandria/test_content_storage.py
+++ b/tests/core/v5_1/alexandria/test_content_storage.py
@@ -6,7 +6,7 @@ import sqlite3
 import tempfile
 from typing import Optional
 
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 import pytest
 
@@ -413,6 +413,7 @@ content_key_st = st.binary(min_size=4, max_size=8)
 content_st = st.binary(min_size=8, max_size=8)
 
 
+@settings(deadline=500)
 @given(data=st.data(),)
 def test_content_storage_atomic_batch_fuzzy(data):
     """

--- a/tests/core/v5_1/alexandria/test_humanize_advertisement_radius.py
+++ b/tests/core/v5_1/alexandria/test_humanize_advertisement_radius.py
@@ -1,0 +1,11 @@
+import pytest
+
+from ddht.v5_1.alexandria._utils import humanize_advertisement_radius
+
+
+@pytest.mark.parametrize(
+    "radius,expected", ((16, 4.00), (14, 3.75), (12, 3.50), (10, 3.25), (8, 3.00),),
+)
+def test_humanize_max_radius(radius, expected):
+    actual = humanize_advertisement_radius(radius, 16)
+    assert actual == expected


### PR DESCRIPTION
fixes #323

## What was wrong?

Mixing local and remote advertisements proved problematic.  When considering our `advertisement_radius` we should not include local advertisements.  When purging advertisements we should not purge local advertisements.

## How was it fixed?

Split into a `local_advertisement_db` and `remote_advertisement_db`.

Lots of trickle down changes happened as well.

#### Cute Animal Picture

![funny-animals-doing-human-things-8](https://user-images.githubusercontent.com/824194/102397601-51d00480-3f9b-11eb-9850-86b88f6bc980.jpg)

