### PR TITLE
Use different approach for defensive timeouts

### DIFF
--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -261,7 +261,9 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
                             yield receive_channel
                         # Wrap EOC error with TSE to make the timeouts obvious
                         except trio.EndOfChannel as err:
-                            raise trio.TooSlowError from err
+                            raise trio.TooSlowError(
+                                f"Timeout: request={request}  request_id={request_id.hex()}"
+                            ) from err
                 finally:
                     nursery.cancel_scope.cancel()
 

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -315,12 +315,15 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         self, target: NodeID, concurrency: int = 3,
     ) -> AsyncIterator[trio.abc.ReceiveChannel[ENRAPI]]:
         explorer = Explorer(self, target, concurrency)
-        with trio.fail_after(300):
+        with trio.move_on_after(300) as scope:
             async with background_trio_service(explorer):
                 await explorer.ready()
 
                 async with explorer.stream() as receive_channel:
                     yield receive_channel
+
+        if scope.cancelled_caught:
+            self.logger.error("Timeout from explore")
 
     async def get_content_proof(
         self,
@@ -372,9 +375,12 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         content_retrieval = ContentRetrieval(
             self, content_key, hash_tree_root, concurrency=concurrency,
         )
-        with trio.fail_after(300):
+        with trio.move_on_after(300) as scope:
             async with background_trio_service(content_retrieval):
                 yield content_retrieval
+
+        if scope.cancelled_caught:
+            self.logger.error("Timeout from retrieve content")
 
     async def get_content(
         self, content_key: ContentKey, hash_tree_root: Hash32, *, concurrency: int = 3,
@@ -521,7 +527,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
 
         send_channel, receive_channel = trio.open_memory_channel[Advertisement](32)
 
-        with trio.fail_after(300):
+        with trio.move_on_after(300) as scope:
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(_feed_advertisements, send_channel)
 
@@ -529,6 +535,9 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                     yield receive_channel
 
                 nursery.cancel_scope.cancel()
+
+        if scope.cancelled_caught:
+            self.logger.error("Timeout from `stream_locate`")
 
     @asynccontextmanager
     async def stream_locations(
@@ -599,7 +608,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
             32
         )
 
-        with trio.fail_after(300):
+        with trio.move_on_after(300) as scope:
             async with trio.open_nursery() as nursery:
                 nursery.start_soon(
                     _feed_advertisements_from_db,
@@ -626,6 +635,9 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                     yield ad_receive_channel
 
                 nursery.cancel_scope.cancel()
+
+        if scope.cancelled_caught:
+            self.logger.error("Timeout from `stream_locate`")
 
     async def broadcast(
         self, advertisement: Advertisement, redundancy_factor: int = 3

--- a/ddht/v5_1/client.py
+++ b/ddht/v5_1/client.py
@@ -528,7 +528,7 @@ async def common_client_stream_find_nodes(
                 request,
                 reserved_request_id,
             )
-            raise trio.TooSlowError
+            raise trio.TooSlowError("Timeout in stream_find_nodes")
 
     async with trio.open_nursery() as nursery:
         send_channel, receive_channel = trio.open_memory_channel[
@@ -542,7 +542,7 @@ async def common_client_stream_find_nodes(
             try:
                 yield receive_channel
             except trio.EndOfChannel as err:
-                raise trio.TooSlowError from err
+                raise trio.TooSlowError("Timeout in stream_find_nodes") from err
             except (trio.ClosedResourceError, trio.ClosedResourceError):
                 pass
 


### PR DESCRIPTION
## What was wrong?

Still getting some timeout crashes I don't understand.

## How was it fixed?

Change some of the defensive long timeouts to instead log an error so that they won't crash the app.

Changed some of the places where we raise a `TooSlowError` to instantiate the exception with a message so it is clearer where it is coming from.

#### Cute Animal Picture

![animals-doing-human-things-26-1](https://user-images.githubusercontent.com/824194/102436646-45b56880-3fd6-11eb-9eaa-d3c74737d12d.jpg)

