### PR TITLE
Add lru sql dict tooling

### DIFF
--- a/ddht/tools/driver/alexandria.py
+++ b/ddht/tools/driver/alexandria.py
@@ -17,6 +17,7 @@ from ddht.tools.driver.abc import (
 from ddht.v5_1.abc import NetworkAPI
 from ddht.v5_1.alexandria.abc import AlexandriaClientAPI, AlexandriaNetworkAPI
 from ddht.v5_1.alexandria.advertisement_db import AdvertisementDatabase
+from ddht.v5_1.alexandria.broadcast_log import BroadcastLog
 from ddht.v5_1.alexandria.client import AlexandriaClient
 from ddht.v5_1.alexandria.content_storage import MemoryContentStorage
 from ddht.v5_1.alexandria.network import AlexandriaNetwork
@@ -35,6 +36,7 @@ class AlexandriaNode(AlexandriaNodeAPI):
         self.remote_advertisement_db = AdvertisementDatabase(
             sqlite3.connect(":memory:"),
         )
+        self.broadcast_log = BroadcastLog(sqlite3.connect(":memory:"))
         self._lock = NamedLock()
 
     @property
@@ -82,6 +84,7 @@ class AlexandriaNode(AlexandriaNodeAPI):
                     commons_content_storage=self.commons_content_storage,
                     pinned_content_storage=self.pinned_content_storage,
                     local_advertisement_db=self.local_advertisement_db,
+                    broadcast_log=self.broadcast_log,
                     remote_advertisement_db=self.remote_advertisement_db,
                     max_advertisement_count=max_advertisement_count,
                 )

--- a/ddht/tools/lru_sql_dict.py
+++ b/ddht/tools/lru_sql_dict.py
@@ -1,0 +1,271 @@
+import pickle
+import sqlite3
+from typing import Any, Iterator, MutableMapping, NamedTuple, Tuple, Union
+
+from eth_utils.toolz import first
+
+CREATE_CACHE_QUERY = """
+    CREATE TABLE IF NOT EXISTS cache (
+        id INTEGER NOT NULL PRIMARY KEY,
+        key BLOB NOT NULL UNIQUE,
+        value BLOB NOT NULL,
+        pref INTEGER UNIQUE,
+        nref INTEGER UNIQUE
+    )
+"""
+
+CREATE_MAP_QUERY = """
+    CREATE TABLE IF NOT EXISTS map (
+        key BLOB NOT NULL PRIMARY KEY,
+        pointer INTEGER NOT NULL UNIQUE
+    )
+"""
+
+DEFAULT_CACHE_SIZE = 100000
+
+
+class Node(NamedTuple):
+    id: int
+    key: Union[str, bytes]
+    value: Any
+    pref: int
+    nref: int
+
+
+class LRUSQLDict(MutableMapping[Union[str, bytes], Any]):
+    """
+    SQLite3-backed dictionary that implements an LRU cache.
+    """
+
+    def __init__(
+        self, conn: sqlite3.Connection, cache_size: int = DEFAULT_CACHE_SIZE
+    ) -> None:
+        self._conn = conn
+        self._execute(CREATE_CACHE_QUERY)
+        self._execute(CREATE_MAP_QUERY)
+        self.cache_size = cache_size
+
+    def __iter__(self) -> Iterator[Union[str, bytes]]:
+        with self._conn:
+            for key in self._conn.execute("SELECT key FROM cache"):
+                yield first(key)
+
+    def __len__(self) -> int:
+        result = self._fetch_single_query("SELECT COUNT(*) FROM cache;")
+        return int(first(result))
+
+    def __setitem__(self, key: Union[str, bytes], value: Any) -> None:
+        # updates LRU cache
+        try:
+            self.__getitem__(key)
+        except KeyError:
+            self._insert_item(key, value)
+        else:
+            self._update_item(key, value)
+
+    def __getitem__(self, key: Union[str, bytes]) -> Any:
+        # updates LRU cache
+        pointer_result = self._fetch_single_query(
+            "SELECT pointer FROM map WHERE key=?;", (key,),
+        )
+
+        if not pointer_result:
+            raise KeyError(f"Key ({str(key)}) not found in db.")
+
+        (map_pointer,) = pointer_result
+
+        lookup_result = self._fetch_single_query(
+            "SELECT value FROM cache WHERE id=?;", (map_pointer,),
+        )
+
+        (value,) = lookup_result
+
+        unpickled_value = self._unpickle(value)
+
+        # update cache
+        self.__delitem__(key)
+        self._insert_item(key, unpickled_value)
+
+        return unpickled_value
+
+    def __delitem__(self, key: Union[str, bytes]) -> None:
+        result = self._fetch_single_query(
+            "SELECT id,key,value,pref,nref FROM cache WHERE key=?;", (key,),
+        )
+
+        if not result:
+            raise KeyError(f"Cannot delete key. Key: {str(key)} not found in db.")
+
+        node = Node(*result)
+
+        # delete key from cache & map
+        self._execute(
+            "DELETE FROM map WHERE pointer=?;", (node.id,),
+        )
+        self._execute(
+            "DELETE FROM cache WHERE id=?;", (node.id,),
+        )
+
+        # update any nrefs/prefs in cache
+        nref_node = self._fetch_single_query(
+            "SELECT id,key,value,pref,nref FROM cache WHERE nref=?;", (node.id,),
+        )
+        pref_node = self._fetch_single_query(
+            "SELECT id,key,value,pref,nref FROM cache WHERE pref=?;", (node.id,),
+        )
+
+        if nref_node and pref_node:
+            nref = Node(*nref_node)
+            pref = Node(*pref_node)
+            self._execute(
+                "UPDATE cache SET nref=? WHERE id=?;", (pref.id, nref.id),
+            )
+            self._execute(
+                "UPDATE cache SET pref=? WHERE id=?;", (nref.id, pref.id),
+            )
+        elif nref_node:
+            nref = Node(*nref_node)
+            self._execute(
+                "UPDATE cache SET nref=? WHERE id=?;", (None, nref.id),
+            )
+        elif pref_node:
+            pref = Node(*pref_node)
+            self._execute(
+                "UPDATE cache SET pref=? WHERE id=?;", (None, pref.id),
+            )
+
+    def _insert_item(self, key: Union[str, bytes], value: Any) -> None:
+        # insert new item into map and cache
+        pickled_value = self._pickle(value)
+        if self.is_empty:
+            new_pref = None
+            new_nref = None
+            new_pkey = 0
+
+            self._execute(
+                "INSERT INTO cache VALUES (?, ?, ?, ?, ?);",
+                (new_pkey, key, pickled_value, new_pref, new_nref),
+            )
+
+            self._execute("INSERT INTO map VALUES (?, ?);", (key, new_pkey))
+
+        else:
+            # evict least recently used key/value
+            if self.is_full:
+                self.__delitem__(self.tail.key)
+
+            # get old head
+            old_head_pkey, _, _, old_head_pref, _ = self.head
+
+            # get attributes for new head
+            (max_pkey,) = self._fetch_single_query(
+                "SELECT id FROM cache ORDER BY id DESC LIMIT 1;"
+            )
+            new_pkey = max_pkey + 1
+            new_pref = None
+            new_nref = old_head_pkey
+
+            # add new head to cache
+            self._execute(
+                "INSERT INTO cache VALUES (?, ?, ?, ?, ?);",
+                (new_pkey, key, pickled_value, new_pref, new_nref),
+            )
+
+            # add new head to map
+            self._execute(
+                "INSERT INTO map VALUES (?, ?);", (key, new_pkey),
+            )
+
+            # update old head in cache
+            self._execute(
+                "UPDATE cache SET pref=? WHERE id=?;", (new_pkey, old_head_pkey),
+            )
+
+    def _update_item(self, key: Union[str, bytes], value: Any) -> None:
+        pickled_value = self._pickle(value)
+        self._execute("UPDATE cache SET value=? WHERE key=?;", (pickled_value, key))
+
+    def _fetch_single_query(self, query: str, args: Tuple[Any, ...] = None) -> Any:
+        with self._conn:
+            if args:
+                cursor = self._conn.execute(query, args).fetchall()
+            else:
+                cursor = self._conn.execute(query).fetchall()
+        if len(cursor) > 1:
+            raise Exception(
+                f"Invalid db state. More than one result found for query: {query}."
+            )
+        if not cursor:
+            return None
+        return first(cursor)
+
+    def _execute(self, query: str, args: Tuple[Any, ...] = None) -> None:
+        with self._conn:
+            if args:
+                self._conn.execute(query, args)
+            else:
+                self._conn.execute(query)
+
+    def _pickle(self, value: Any) -> bytes:
+        return sqlite3.Binary(pickle.dumps(value, -1))
+
+    def _unpickle(self, value: bytes) -> Any:
+        return pickle.loads(value)
+
+    @property
+    def is_full(self) -> bool:
+        return self.__len__() >= self.cache_size
+
+    @property
+    def is_empty(self) -> bool:
+        return self.__len__() == 0
+
+    @property
+    def head(self) -> Node:
+        head = self._fetch_single_query(
+            "SELECT id,key,value,pref,nref FROM cache WHERE pref IS NULL;"
+        )
+        if not head:
+            raise Exception("No head found.")
+        return Node(*head)
+
+    @property
+    def tail(self) -> Node:
+        tail = self._fetch_single_query(
+            "SELECT id,key,value,pref,nref FROM cache WHERE nref IS NULL;"
+        )
+        if not tail:
+            raise Exception("No tail found.")
+        return Node(*tail)
+
+    # custom iterator type not compatible with supertype
+    def values(self) -> Iterator[Any]:  # type: ignore
+        for key in self.__iter__():
+            result = self._fetch_single_query(
+                "SELECT value FROM cache WHERE key=?;", (key,)
+            )
+            yield self._unpickle(first(result))
+
+    # custom iterator type not compatible with supertype
+    def items(self) -> Iterator[Tuple[Union[str, bytes], Any]]:  # type: ignore
+        for key in self.__iter__():
+            result = self._fetch_single_query(
+                "SELECT value FROM cache WHERE key=?;", (key,)
+            )
+            yield key, self._unpickle(first(result))
+
+    def iter_lru_cache(self) -> Iterator[Any]:
+        if self.is_empty:
+            raise Exception("Cannot iterate over empty dict.")
+
+        head = self.head
+        yield (head.key, self._unpickle(head.value))
+        nref = head.nref
+
+        for _ in range(self.__len__() - 1):
+            result = self._fetch_single_query(
+                "SELECT id,key,value,pref,nref FROM cache WHERE id=?;", (nref,),
+            )
+            node = Node(*result)
+            yield (node.key, self._unpickle(node.value))
+            nref = node.nref

--- a/ddht/tools/lru_sql_dict.py
+++ b/ddht/tools/lru_sql_dict.py
@@ -1,60 +1,81 @@
-import pickle
 import sqlite3
-from typing import Any, Iterator, MutableMapping, NamedTuple, Tuple, Union
+from typing import (
+    AbstractSet,
+    Any,
+    Callable,
+    Iterator,
+    MutableMapping,
+    NamedTuple,
+    Tuple,
+    TypeVar,
+    ValuesView,
+)
 
 from eth_utils.toolz import first
 
+#
+# SQL Schema
+#
+# key (primary key): bytes
+# value: bytes
+# pref: bytes - None if node is head, else points to the previous node's key
+# nref: bytes - None if node is tail, else points to the next node's key
+
+
 CREATE_CACHE_QUERY = """
     CREATE TABLE IF NOT EXISTS cache (
-        id INTEGER NOT NULL PRIMARY KEY,
-        key BLOB NOT NULL UNIQUE,
-        value BLOB NOT NULL,
-        pref INTEGER UNIQUE,
-        nref INTEGER UNIQUE
-    )
-"""
-
-CREATE_MAP_QUERY = """
-    CREATE TABLE IF NOT EXISTS map (
         key BLOB NOT NULL PRIMARY KEY,
-        pointer INTEGER NOT NULL UNIQUE
+        value BLOB NOT NULL,
+        pref BLOB UNIQUE,
+        nref BLOB UNIQUE
     )
 """
 
-DEFAULT_CACHE_SIZE = 100000
+TKey = TypeVar("TKey")
+TValue = TypeVar("TValue")
 
 
 class Node(NamedTuple):
-    id: int
-    key: Union[str, bytes]
-    value: Any
-    pref: int
-    nref: int
+    key: bytes
+    value: bytes
+    pref: bytes
+    nref: bytes
 
 
-class LRUSQLDict(MutableMapping[Union[str, bytes], Any]):
+class LRUSQLDict(MutableMapping[TKey, TValue]):
     """
     SQLite3-backed dictionary that implements an LRU cache.
     """
 
     def __init__(
-        self, conn: sqlite3.Connection, cache_size: int = DEFAULT_CACHE_SIZE
+        self,
+        conn: sqlite3.Connection,
+        key_encoder: Callable[[TKey], bytes],
+        key_decoder: Callable[[bytes], TKey],
+        value_encoder: Callable[[TValue], bytes],
+        value_decoder: Callable[[bytes], TValue],
+        cache_size: int = None,
     ) -> None:
         self._conn = conn
-        self._execute(CREATE_CACHE_QUERY)
-        self._execute(CREATE_MAP_QUERY)
         self.cache_size = cache_size
+        self.key_encoder = key_encoder
+        self.key_decoder = key_decoder
+        self.value_encoder = value_encoder
+        self.value_decoder = value_decoder
 
-    def __iter__(self) -> Iterator[Union[str, bytes]]:
+        self._execute(CREATE_CACHE_QUERY)
+
+    def __iter__(self) -> Iterator[TKey]:
         with self._conn:
             for key in self._conn.execute("SELECT key FROM cache"):
-                yield first(key)
+                yield self.key_decoder(first(key))
 
     def __len__(self) -> int:
         result = self._fetch_single_query("SELECT COUNT(*) FROM cache;")
-        return int(first(result))
+        # ignore b/c mypy cannot interpret the result as an integer
+        return first(result)  # type: ignore
 
-    def __setitem__(self, key: Union[str, bytes], value: Any) -> None:
+    def __setitem__(self, key: TKey, value: TValue) -> None:
         # updates LRU cache
         try:
             self.__getitem__(key)
@@ -63,127 +84,108 @@ class LRUSQLDict(MutableMapping[Union[str, bytes], Any]):
         else:
             self._update_item(key, value)
 
-    def __getitem__(self, key: Union[str, bytes]) -> Any:
+    def __getitem__(self, key: TKey) -> TValue:
         # updates LRU cache
-        pointer_result = self._fetch_single_query(
-            "SELECT pointer FROM map WHERE key=?;", (key,),
-        )
-
-        if not pointer_result:
-            raise KeyError(f"Key ({str(key)}) not found in db.")
-
-        (map_pointer,) = pointer_result
-
+        serialized_key = self.key_encoder(key)
         lookup_result = self._fetch_single_query(
-            "SELECT value FROM cache WHERE id=?;", (map_pointer,),
+            "SELECT value FROM cache WHERE key=?;", (serialized_key,),
         )
+
+        if not lookup_result:
+            raise KeyError(str(key))
 
         (value,) = lookup_result
 
-        unpickled_value = self._unpickle(value)
+        deserialized_value = self.value_decoder(value)
 
         # update cache
         self.__delitem__(key)
-        self._insert_item(key, unpickled_value)
+        self._insert_item(key, deserialized_value)
 
-        return unpickled_value
+        return deserialized_value
 
-    def __delitem__(self, key: Union[str, bytes]) -> None:
+    def __delitem__(self, key: TKey) -> None:
+        serialized_key = self.key_encoder(key)
         result = self._fetch_single_query(
-            "SELECT id,key,value,pref,nref FROM cache WHERE key=?;", (key,),
+            "SELECT key,value,pref,nref FROM cache WHERE key=?;", (serialized_key,),
         )
 
         if not result:
-            raise KeyError(f"Cannot delete key. Key: {str(key)} not found in db.")
+            raise KeyError(str(key))
 
         node = Node(*result)
 
-        # delete key from cache & map
+        # delete key from cache
         self._execute(
-            "DELETE FROM map WHERE pointer=?;", (node.id,),
-        )
-        self._execute(
-            "DELETE FROM cache WHERE id=?;", (node.id,),
+            "DELETE FROM cache WHERE key=?;", (node.key,),
         )
 
         # update any nrefs/prefs in cache
         nref_node = self._fetch_single_query(
-            "SELECT id,key,value,pref,nref FROM cache WHERE nref=?;", (node.id,),
+            "SELECT key,value,pref,nref FROM cache WHERE nref=?;", (node.key,),
         )
         pref_node = self._fetch_single_query(
-            "SELECT id,key,value,pref,nref FROM cache WHERE pref=?;", (node.id,),
+            "SELECT key,value,pref,nref FROM cache WHERE pref=?;", (node.key,),
         )
 
         if nref_node and pref_node:
             nref = Node(*nref_node)
             pref = Node(*pref_node)
             self._execute(
-                "UPDATE cache SET nref=? WHERE id=?;", (pref.id, nref.id),
+                "UPDATE cache SET nref=? WHERE key=?;", (pref.key, nref.key),
             )
             self._execute(
-                "UPDATE cache SET pref=? WHERE id=?;", (nref.id, pref.id),
+                "UPDATE cache SET pref=? WHERE key=?;", (nref.key, pref.key),
             )
         elif nref_node:
             nref = Node(*nref_node)
             self._execute(
-                "UPDATE cache SET nref=? WHERE id=?;", (None, nref.id),
+                "UPDATE cache SET nref=? WHERE key=?;", (None, nref.key),
             )
         elif pref_node:
             pref = Node(*pref_node)
             self._execute(
-                "UPDATE cache SET pref=? WHERE id=?;", (None, pref.id),
+                "UPDATE cache SET pref=? WHERE key=?;", (None, pref.key),
             )
 
-    def _insert_item(self, key: Union[str, bytes], value: Any) -> None:
+    def _insert_item(self, key: TKey, value: TValue) -> None:
         # insert new item into map and cache
-        pickled_value = self._pickle(value)
+        serialized_key = self.key_encoder(key)
+        serialized_value = self.value_encoder(value)
         if self.is_empty:
             new_pref = None
             new_nref = None
-            new_pkey = 0
 
             self._execute(
-                "INSERT INTO cache VALUES (?, ?, ?, ?, ?);",
-                (new_pkey, key, pickled_value, new_pref, new_nref),
+                "INSERT INTO cache VALUES (?, ?, ?, ?);",
+                (serialized_key, serialized_value, new_pref, new_nref),
             )
-
-            self._execute("INSERT INTO map VALUES (?, ?);", (key, new_pkey))
 
         else:
             # evict least recently used key/value
             if self.is_full:
-                self.__delitem__(self.tail.key)
+                self.__delitem__(self.key_decoder(self.tail.key))
 
             # get old head
-            old_head_pkey, _, _, old_head_pref, _ = self.head
-
-            # get attributes for new head
-            (max_pkey,) = self._fetch_single_query(
-                "SELECT id FROM cache ORDER BY id DESC LIMIT 1;"
-            )
-            new_pkey = max_pkey + 1
-            new_pref = None
-            new_nref = old_head_pkey
+            old_head_key, _, old_head_pref, _ = self.head
 
             # add new head to cache
             self._execute(
-                "INSERT INTO cache VALUES (?, ?, ?, ?, ?);",
-                (new_pkey, key, pickled_value, new_pref, new_nref),
-            )
-
-            # add new head to map
-            self._execute(
-                "INSERT INTO map VALUES (?, ?);", (key, new_pkey),
+                "INSERT INTO cache VALUES (?, ?, ?, ?);",
+                (serialized_key, serialized_value, None, old_head_key),
             )
 
             # update old head in cache
             self._execute(
-                "UPDATE cache SET pref=? WHERE id=?;", (new_pkey, old_head_pkey),
+                "UPDATE cache SET pref=? WHERE key=?;", (serialized_key, old_head_key),
             )
 
-    def _update_item(self, key: Union[str, bytes], value: Any) -> None:
-        pickled_value = self._pickle(value)
-        self._execute("UPDATE cache SET value=? WHERE key=?;", (pickled_value, key))
+    def _update_item(self, key: TKey, value: TValue) -> None:
+        serialized_key = self.key_encoder(key)
+        serialized_value = self.value_encoder(value)
+        self._execute(
+            "UPDATE cache SET value=? WHERE key=?;", (serialized_value, serialized_key)
+        )
 
     def _fetch_single_query(self, query: str, args: Tuple[Any, ...] = None) -> Any:
         with self._conn:
@@ -206,14 +208,10 @@ class LRUSQLDict(MutableMapping[Union[str, bytes], Any]):
             else:
                 self._conn.execute(query)
 
-    def _pickle(self, value: Any) -> bytes:
-        return sqlite3.Binary(pickle.dumps(value, -1))
-
-    def _unpickle(self, value: bytes) -> Any:
-        return pickle.loads(value)
-
     @property
     def is_full(self) -> bool:
+        if not self.cache_size:
+            return False
         return self.__len__() >= self.cache_size
 
     @property
@@ -223,7 +221,7 @@ class LRUSQLDict(MutableMapping[Union[str, bytes], Any]):
     @property
     def head(self) -> Node:
         head = self._fetch_single_query(
-            "SELECT id,key,value,pref,nref FROM cache WHERE pref IS NULL;"
+            "SELECT key,value,pref,nref FROM cache WHERE pref IS NULL;"
         )
         if not head:
             raise Exception("No head found.")
@@ -232,40 +230,40 @@ class LRUSQLDict(MutableMapping[Union[str, bytes], Any]):
     @property
     def tail(self) -> Node:
         tail = self._fetch_single_query(
-            "SELECT id,key,value,pref,nref FROM cache WHERE nref IS NULL;"
+            "SELECT key,value,pref,nref FROM cache WHERE nref IS NULL;"
         )
         if not tail:
             raise Exception("No tail found.")
         return Node(*tail)
 
     # custom iterator type not compatible with supertype
-    def values(self) -> Iterator[Any]:  # type: ignore
+    def values(self) -> ValuesView[TValue]:  # type: ignore
         for key in self.__iter__():
             result = self._fetch_single_query(
                 "SELECT value FROM cache WHERE key=?;", (key,)
             )
-            yield self._unpickle(first(result))
+            yield self.value_decoder(first(result))
 
     # custom iterator type not compatible with supertype
-    def items(self) -> Iterator[Tuple[Union[str, bytes], Any]]:  # type: ignore
+    def items(self) -> AbstractSet[Tuple[TKey, TValue]]:  # type: ignore
         for key in self.__iter__():
             result = self._fetch_single_query(
                 "SELECT value FROM cache WHERE key=?;", (key,)
             )
-            yield key, self._unpickle(first(result))
+            yield key, self.value_decoder(first(result))
 
-    def iter_lru_cache(self) -> Iterator[Any]:
+    def iter_lru_cache(self) -> Iterator[Tuple[TKey, TValue]]:
         if self.is_empty:
             raise Exception("Cannot iterate over empty dict.")
 
         head = self.head
-        yield (head.key, self._unpickle(head.value))
+        yield self.key_decoder(head.key), self.value_decoder(head.value)
         nref = head.nref
 
         for _ in range(self.__len__() - 1):
             result = self._fetch_single_query(
-                "SELECT id,key,value,pref,nref FROM cache WHERE id=?;", (nref,),
+                "SELECT key,value,pref,nref FROM cache WHERE key=?;", (nref,),
             )
             node = Node(*result)
-            yield (node.key, self._unpickle(node.value))
+            yield self.key_decoder(node.key), self.value_decoder(node.value)
             nref = node.nref

--- a/ddht/tools/lru_sql_dict.py
+++ b/ddht/tools/lru_sql_dict.py
@@ -1,8 +1,9 @@
 import sqlite3
 from typing import (
-    AbstractSet,
     Any,
     Callable,
+    Generic,
+    ItemsView,
     Iterator,
     MutableMapping,
     NamedTuple,
@@ -35,11 +36,11 @@ TKey = TypeVar("TKey")
 TValue = TypeVar("TValue")
 
 
-class Node(NamedTuple):
-    key: bytes
-    value: bytes
-    pref: bytes
-    nref: bytes
+class Node(Generic[TKey, TValue], NamedTuple):
+    key: TKey
+    value: TValue
+    pref: TKey
+    nref: TKey
 
 
 class LRUSQLDict(MutableMapping[TKey, TValue]):
@@ -58,25 +59,30 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
     ) -> None:
         self._conn = conn
         self.cache_size = cache_size
-        self.key_encoder = key_encoder
-        self.key_decoder = key_decoder
-        self.value_encoder = value_encoder
-        self.value_decoder = value_decoder
+        self._key_encoder = key_encoder
+        self._key_decoder = key_decoder
+        self._value_encoder = value_encoder
+        self._value_decoder = value_decoder
 
         self._execute(CREATE_CACHE_QUERY)
+
+        # evict lru key/value if local db size > current cache size
+        if self.cache_size:
+            while self.__len__() > self.cache_size:
+                self.__delitem__(self.tail.key)
 
     def __iter__(self) -> Iterator[TKey]:
         with self._conn:
             for key in self._conn.execute("SELECT key FROM cache"):
-                yield self.key_decoder(first(key))
+                yield self._key_decoder(first(key))
 
     def __len__(self) -> int:
-        result = self._fetch_single_query("SELECT COUNT(*) FROM cache;")
+        (result,) = self._fetch_single_query("SELECT COUNT(*) FROM cache;")
         # ignore b/c mypy cannot interpret the result as an integer
-        return first(result)  # type: ignore
+        return result  # type: ignore
 
     def __setitem__(self, key: TKey, value: TValue) -> None:
-        # updates LRU cache
+        # setting / updating a key/value will move the pair to the head of the lru cache
         try:
             self.__getitem__(key)
         except KeyError:
@@ -85,73 +91,73 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
             self._update_item(key, value)
 
     def __getitem__(self, key: TKey) -> TValue:
-        # updates LRU cache
-        serialized_key = self.key_encoder(key)
+        # accessing a key/value will move the pair to the head of the lru cache
+        serialized_key = self._key_encoder(key)
         lookup_result = self._fetch_single_query(
             "SELECT value FROM cache WHERE key=?;", (serialized_key,),
         )
 
         if not lookup_result:
-            raise KeyError(str(key))
+            raise KeyError(key)
 
         (value,) = lookup_result
 
-        deserialized_value = self.value_decoder(value)
+        deserialized_value = self._value_decoder(value)
 
         # update cache
+        # TODO: rather than move kv pair to head by deleting and re-inserting,
+        # change this to update all outdated references directly
         self.__delitem__(key)
         self._insert_item(key, deserialized_value)
 
         return deserialized_value
 
     def __delitem__(self, key: TKey) -> None:
-        serialized_key = self.key_encoder(key)
+        serialized_key = self._key_encoder(key)
         result = self._fetch_single_query(
-            "SELECT key,value,pref,nref FROM cache WHERE key=?;", (serialized_key,),
+            "SELECT key FROM cache WHERE key=?;", (serialized_key,),
         )
 
         if not result:
-            raise KeyError(str(key))
+            raise KeyError(key)
 
-        node = Node(*result)
+        node_key = first(result)
 
         # delete key from cache
         self._execute(
-            "DELETE FROM cache WHERE key=?;", (node.key,),
+            "DELETE FROM cache WHERE key=?;", (node_key,),
         )
 
         # update any nrefs/prefs in cache
-        nref_node = self._fetch_single_query(
-            "SELECT key,value,pref,nref FROM cache WHERE nref=?;", (node.key,),
+        nref_result = self._fetch_single_query(
+            "SELECT key FROM cache WHERE nref=?;", (node_key,),
         )
-        pref_node = self._fetch_single_query(
-            "SELECT key,value,pref,nref FROM cache WHERE pref=?;", (node.key,),
+        pref_result = self._fetch_single_query(
+            "SELECT key FROM cache WHERE pref=?;", (node_key,),
         )
 
-        if nref_node and pref_node:
-            nref = Node(*nref_node)
-            pref = Node(*pref_node)
+        if nref_result and pref_result:
+            nref_key = first(nref_result)
+            pref_key = first(pref_result)
             self._execute(
-                "UPDATE cache SET nref=? WHERE key=?;", (pref.key, nref.key),
+                "UPDATE cache SET nref=? WHERE key=?;", (pref_key, nref_key),
             )
             self._execute(
-                "UPDATE cache SET pref=? WHERE key=?;", (nref.key, pref.key),
+                "UPDATE cache SET pref=? WHERE key=?;", (nref_key, pref_key),
             )
-        elif nref_node:
-            nref = Node(*nref_node)
+        elif nref_result:
             self._execute(
-                "UPDATE cache SET nref=? WHERE key=?;", (None, nref.key),
+                "UPDATE cache SET nref=? WHERE key=?;", (None, first(nref_result)),
             )
-        elif pref_node:
-            pref = Node(*pref_node)
+        elif pref_result:
             self._execute(
-                "UPDATE cache SET pref=? WHERE key=?;", (None, pref.key),
+                "UPDATE cache SET pref=? WHERE key=?;", (None, first(pref_result)),
             )
 
     def _insert_item(self, key: TKey, value: TValue) -> None:
         # insert new item into map and cache
-        serialized_key = self.key_encoder(key)
-        serialized_value = self.value_encoder(value)
+        serialized_key = self._key_encoder(key)
+        serialized_value = self._value_encoder(value)
         if self.is_empty:
             new_pref = None
             new_nref = None
@@ -162,12 +168,12 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
             )
 
         else:
-            # evict least recently used key/value
-            if self.is_full:
-                self.__delitem__(self.key_decoder(self.tail.key))
+            # evict lru key/value if local db size >= current cache size
+            while self.is_full:
+                self.__delitem__(self.tail.key)
 
             # get old head
-            old_head_key, _, old_head_pref, _ = self.head
+            old_head_key = self._key_encoder(self.head.key)
 
             # add new head to cache
             self._execute(
@@ -181,18 +187,15 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
             )
 
     def _update_item(self, key: TKey, value: TValue) -> None:
-        serialized_key = self.key_encoder(key)
-        serialized_value = self.value_encoder(value)
+        serialized_key = self._key_encoder(key)
+        serialized_value = self._value_encoder(value)
         self._execute(
             "UPDATE cache SET value=? WHERE key=?;", (serialized_value, serialized_key)
         )
 
-    def _fetch_single_query(self, query: str, args: Tuple[Any, ...] = None) -> Any:
+    def _fetch_single_query(self, query: str, args: Tuple[Any, ...] = ()) -> Any:
         with self._conn:
-            if args:
-                cursor = self._conn.execute(query, args).fetchall()
-            else:
-                cursor = self._conn.execute(query).fetchall()
+            cursor = self._conn.execute(query, args).fetchall()
         if len(cursor) > 1:
             raise Exception(
                 f"Invalid db state. More than one result found for query: {query}."
@@ -201,12 +204,9 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
             return None
         return first(cursor)
 
-    def _execute(self, query: str, args: Tuple[Any, ...] = None) -> None:
+    def _execute(self, query: str, args: Tuple[Any, ...] = ()) -> None:
         with self._conn:
-            if args:
-                self._conn.execute(query, args)
-            else:
-                self._conn.execute(query)
+            self._conn.execute(query, args)
 
     @property
     def is_full(self) -> bool:
@@ -224,8 +224,10 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
             "SELECT key,value,pref,nref FROM cache WHERE pref IS NULL;"
         )
         if not head:
-            raise Exception("No head found.")
-        return Node(*head)
+            raise KeyError("No head found.")
+        deserialized_key = self._key_decoder(head[0])
+        deserialized_value = self._value_decoder(head[1])
+        return Node(deserialized_key, deserialized_value, head[2], head[3])
 
     @property
     def tail(self) -> Node:
@@ -233,8 +235,10 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
             "SELECT key,value,pref,nref FROM cache WHERE nref IS NULL;"
         )
         if not tail:
-            raise Exception("No tail found.")
-        return Node(*tail)
+            raise KeyError("No tail found.")
+        deserialized_key = self._key_decoder(tail[0])
+        deserialized_value = self._value_decoder(tail[1])
+        return Node(deserialized_key, deserialized_value, tail[2], tail[3])
 
     # custom iterator type not compatible with supertype
     def values(self) -> ValuesView[TValue]:  # type: ignore
@@ -242,28 +246,30 @@ class LRUSQLDict(MutableMapping[TKey, TValue]):
             result = self._fetch_single_query(
                 "SELECT value FROM cache WHERE key=?;", (key,)
             )
-            yield self.value_decoder(first(result))
+            yield self._value_decoder(first(result))
 
     # custom iterator type not compatible with supertype
-    def items(self) -> AbstractSet[Tuple[TKey, TValue]]:  # type: ignore
+    def items(self) -> ItemsView[TKey, TValue]:  # type: ignore
         for key in self.__iter__():
             result = self._fetch_single_query(
                 "SELECT value FROM cache WHERE key=?;", (key,)
             )
-            yield key, self.value_decoder(first(result))
+            yield key, self._value_decoder(first(result))
 
     def iter_lru_cache(self) -> Iterator[Tuple[TKey, TValue]]:
         if self.is_empty:
-            raise Exception("Cannot iterate over empty dict.")
+            raise IndexError("Cannot iterate over empty dict.")
 
         head = self.head
-        yield self.key_decoder(head.key), self.value_decoder(head.value)
+        yield head.key, head.value
         nref = head.nref
 
         for _ in range(self.__len__() - 1):
             result = self._fetch_single_query(
                 "SELECT key,value,pref,nref FROM cache WHERE key=?;", (nref,),
             )
-            node = Node(*result)
-            yield self.key_decoder(node.key), self.value_decoder(node.value)
+            deserialized_key = self._key_decoder(result[0])
+            deserialized_value = self._value_decoder(result[1])
+            node = Node(deserialized_key, deserialized_value, result[2], result[3])
+            yield node.key, node.value
             nref = node.nref

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -103,7 +103,7 @@ class BroadcastLogAPI(ABC):
 
     @property
     @abstractmethod
-    def cache_size(self) -> int:
+    def cache_size(self) -> Optional[int]:
         ...
 
     @property

--- a/ddht/v5_1/alexandria/abc.py
+++ b/ddht/v5_1/alexandria/abc.py
@@ -101,6 +101,16 @@ class BroadcastLogAPI(ABC):
     ) -> bool:
         ...
 
+    @property
+    @abstractmethod
+    def cache_size(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def count(self) -> int:
+        ...
+
 
 class ContentValidatorAPI(ABC):
     @abstractmethod

--- a/ddht/v5_1/alexandria/app.py
+++ b/ddht/v5_1/alexandria/app.py
@@ -8,6 +8,7 @@ from ddht.boot_info import BootInfo
 from ddht.v5_1.alexandria.abc import AdvertisementDatabaseAPI, ContentStorageAPI
 from ddht.v5_1.alexandria.advertisement_db import AdvertisementDatabase
 from ddht.v5_1.alexandria.boot_info import AlexandriaBootInfo
+from ddht.v5_1.alexandria.broadcast_log import BroadcastLog
 from ddht.v5_1.alexandria.content_storage import (
     FileSystemContentStorage,
     MemoryContentStorage,
@@ -108,6 +109,9 @@ class AlexandriaApplication(BaseApplication):
             sqlite3.connect(str(remote_advertisement_db_path)),
         )
 
+        broadcast_log_db_path = xdg_alexandria_root / "broadcast_log.sqlite3"
+        broadcast_log = BroadcastLog(sqlite3.connect(str(broadcast_log_db_path)))
+
         alexandria_network = AlexandriaNetwork(
             network=self.base_protocol_app.network,
             bootnodes=self._alexandria_boot_info.bootnodes,
@@ -115,6 +119,7 @@ class AlexandriaApplication(BaseApplication):
             pinned_content_storage=pinned_content_storage,
             local_advertisement_db=local_advertisement_db,
             remote_advertisement_db=remote_advertisement_db,
+            broadcast_log=broadcast_log,
             commons_content_storage_max_size=commons_content_storage_max_size,
             max_advertisement_count=max_advertisement_count,
         )
@@ -146,6 +151,12 @@ class AlexandriaApplication(BaseApplication):
             remote_advertisement_db_path,
             remote_advertisement_db.count(),
             max_advertisement_count,
+        )
+        self.logger.info(
+            "BroadcastLog: storage=%s  total=%d  max=%d",
+            broadcast_log_db_path,
+            broadcast_log.count,
+            broadcast_log.cache_size,
         )
 
         await alexandria_network.ready()

--- a/ddht/v5_1/alexandria/broadcast_log.py
+++ b/ddht/v5_1/alexandria/broadcast_log.py
@@ -1,10 +1,10 @@
 import hashlib
+import sqlite3
 import time
-from typing import Dict
 
 from eth_typing import Hash32, NodeID
-from lru import LRU
 
+from ddht.tools.lru_sql_dict import LRUSQLDict
 from ddht.v5_1.alexandria.abc import BroadcastLogAPI
 from ddht.v5_1.alexandria.advertisements import Advertisement
 from ddht.v5_1.alexandria.constants import ONE_HOUR
@@ -15,8 +15,16 @@ class BroadcastLog(BroadcastLogAPI):
     Tracks the last time each advertisement was broadcast to each peer.
     """
 
-    def __init__(self, max_records: int = 8192):
-        self._log: Dict[Hash32, int] = LRU(max_records)
+    def __init__(self, conn: sqlite3.Connection, max_records: int = 8192):
+        self._log = LRUSQLDict(conn, max_records)
+
+    @property
+    def count(self) -> int:
+        return len(self._log)
+
+    @property
+    def cache_size(self) -> int:
+        return self._log.cache_size
 
     def log(self, node_id: NodeID, advertisement: Advertisement) -> None:
         key = Hash32(
@@ -31,7 +39,7 @@ class BroadcastLog(BroadcastLogAPI):
             hashlib.sha256(node_id + advertisement.signature.to_bytes()).digest()
         )
         try:
-            last_logged_at = self._log[key]
+            last_logged_at = int(self._log[key])
         except KeyError:
             return False
         else:

--- a/ddht/v5_1/alexandria/broadcast_log.py
+++ b/ddht/v5_1/alexandria/broadcast_log.py
@@ -1,13 +1,31 @@
 import hashlib
 import sqlite3
 import time
+from typing import Optional
 
 from eth_typing import Hash32, NodeID
+from eth_utils import to_bytes, to_int
 
 from ddht.tools.lru_sql_dict import LRUSQLDict
 from ddht.v5_1.alexandria.abc import BroadcastLogAPI
 from ddht.v5_1.alexandria.advertisements import Advertisement
 from ddht.v5_1.alexandria.constants import ONE_HOUR
+
+
+def key_encoder(key: bytes) -> bytes:
+    return key
+
+
+def key_decoder(key: bytes) -> bytes:
+    return key
+
+
+def value_encoder(value: int) -> bytes:
+    return to_bytes(value)
+
+
+def value_decoder(value: bytes) -> int:
+    return to_int(value)
 
 
 class BroadcastLog(BroadcastLogAPI):
@@ -16,14 +34,16 @@ class BroadcastLog(BroadcastLogAPI):
     """
 
     def __init__(self, conn: sqlite3.Connection, max_records: int = 8192):
-        self._log = LRUSQLDict(conn, max_records)
+        self._log = LRUSQLDict(
+            conn, key_encoder, key_decoder, value_encoder, value_decoder, max_records
+        )
 
     @property
     def count(self) -> int:
         return len(self._log)
 
     @property
-    def cache_size(self) -> int:
+    def cache_size(self) -> Optional[int]:
         return self._log.cache_size
 
     def log(self, node_id: NodeID, advertisement: Advertisement) -> None:

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -77,6 +77,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         pinned_content_storage: ContentStorageAPI,
         local_advertisement_db: AdvertisementDatabaseAPI,
         remote_advertisement_db: AdvertisementDatabaseAPI,
+        broadcast_log: BroadcastLog,
         max_advertisement_count: int = DEFAULT_MAX_ADVERTISEMENTS,
         commons_content_storage_max_size: int = DEFAULT_COMMONS_STORAGE_SIZE,
     ) -> None:
@@ -89,7 +90,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         self.client = AlexandriaClient(network)
 
         self.radius_tracker = RadiusTracker(self)
-        self.broadcast_log = BroadcastLog()
+        self.broadcast_log = broadcast_log
 
         self.routing_table = KademliaRoutingTable(
             self.enr_manager.enr.node_id, ROUTING_TABLE_BUCKET_SIZE,

--- a/tests/core/tools/test_lru_sql_dict.py
+++ b/tests/core/tools/test_lru_sql_dict.py
@@ -1,5 +1,6 @@
 import sqlite3
 
+from eth_utils import is_text, to_bytes, to_int
 from hypothesis import given
 from hypothesis import strategies as st
 import pytest
@@ -7,14 +8,40 @@ import pytest
 from ddht.tools.lru_sql_dict import LRUSQLDict
 
 
+def key_encoder(key) -> bytes:
+    if is_text(key):
+        return to_bytes(text=key)
+    return key
+
+
+def key_decoder(key) -> bytes:
+    return key
+
+
+def value_encoder(value) -> bytes:
+    # int to bytes
+    return to_bytes(value)
+
+
+def value_decoder(value) -> int:
+    # bytes to int
+    return to_int(value)
+
+
 @pytest.fixture
 def sqldict():
-    return LRUSQLDict(sqlite3.connect(":memory:"), cache_size=3)
+    return LRUSQLDict(
+        sqlite3.connect(":memory:"),
+        key_encoder,
+        key_decoder,
+        value_encoder,
+        value_decoder,
+        3,
+    )
 
 
 @given(
-    key=st.text(),
-    value=st.integers(min_value=(-(2 ** 63) - 1), max_value=(2 ** 63 - 1)),
+    key=st.text(), value=st.integers(min_value=0, max_value=(2 ** 63 - 1)),
 )
 def test_sqldict_with_string_keys(key, value, sqldict):
     sqldict[key] = value
@@ -22,70 +49,67 @@ def test_sqldict_with_string_keys(key, value, sqldict):
 
 
 @given(
-    key=st.binary(),
-    value=st.integers(min_value=(-(2 ** 63) - 1), max_value=(2 ** 63 - 1)),
+    key=st.binary(), value=st.integers(min_value=0, max_value=(2 ** 63 - 1)),
 )
 def test_sqldict_with_byte_keys(key, value, sqldict):
     sqldict[key] = value
     assert sqldict[key] == value
 
 
-@pytest.mark.parametrize(
-    "value",
-    (None, True, False, 1, 1.2, "string", b"bytes", ("tuple",), ["list"], set("set"),),
-)
-def test_sqldict_set_accepts_picklable_items(sqldict, value):
-    sqldict["key"] = value
-    assert sqldict["key"] == value
-
-
 def test_add_item_to_sqldict(sqldict):
-    sqldict["one"] = "abc"
+    sqldict["one"] = 1
 
-    assert sqldict["one"] == "abc"
-    assert sqldict.head.key == "one"
-    assert sqldict.tail.key == "one"
+    assert sqldict["one"] == 1
+    assert sqldict.head.key == b"one"
+    assert sqldict.tail.key == b"one"
     assert len(sqldict) == 1
 
-    sqldict["two"] = "xyz"
+    sqldict["two"] = 2
 
-    assert sqldict["two"] == "xyz"
-    assert sqldict.head.key == "two"
-    assert sqldict.tail.key == "one"
+    assert sqldict["two"] == 2
+    assert sqldict.head.key == b"two"
+    assert sqldict.tail.key == b"one"
     assert len(sqldict) == 2
 
-    sqldict["three"] = "def"
+    sqldict["three"] = 3
 
-    assert sqldict["three"] == "def"
-    assert sqldict.head.key == "three"
-    assert sqldict.tail.key == "one"
+    assert sqldict["three"] == 3
+    assert sqldict.head.key == b"three"
+    assert sqldict.tail.key == b"one"
     assert len(sqldict) == 3
     assert sqldict.is_full
 
     # test update
-    sqldict["two"] = "xyz-1"
+    sqldict["two"] = 20
 
-    assert sqldict["two"] == "xyz-1"
-    assert sqldict.head.key == "two"
-    assert sqldict.tail.key == "one"
+    assert sqldict["two"] == 20
+    assert sqldict.head.key == b"two"
+    assert sqldict.tail.key == b"one"
     assert len(sqldict) == 3
     assert sqldict.is_full
 
-    sqldict["four"] = "ghi"
+    sqldict["four"] = 4
 
-    assert sqldict["four"] == "ghi"
+    assert sqldict["four"] == 4
     assert sqldict.is_full
-    assert sqldict.head.key == "four"
-    assert sqldict.tail.key == "three"
+    assert sqldict.head.key == b"four"
+    assert sqldict.tail.key == b"three"
     assert len(sqldict) == 3
 
 
 def test_delete_item_from_sqldict():
-    sqldict = LRUSQLDict(sqlite3.connect(":memory:"), cache_size=4)
-    sqldict["one"] = "abc"
-    sqldict["two"] = "def"
-    sqldict["three"] = "ghi"
-    sqldict["four"] = "jkl"
+    sqldict = LRUSQLDict(
+        sqlite3.connect(":memory:"),
+        key_encoder,
+        key_decoder,
+        value_encoder,
+        value_decoder,
+        4,
+    )
+    sqldict["one"] = 1
+    sqldict["two"] = 2
+    sqldict["three"] = 3
+    sqldict["four"] = 4
 
     assert sqldict.is_full
     assert not sqldict.is_empty
@@ -94,24 +118,24 @@ def test_delete_item_from_sqldict():
     del sqldict["two"]
 
     assert not sqldict.is_full
-    assert sqldict.head.key == "four"
-    assert sqldict.tail.key == "one"
+    assert sqldict.head.key == b"four"
+    assert sqldict.tail.key == b"one"
     assert len(sqldict) == 3
 
     # delete head
     del sqldict["four"]
 
     assert not sqldict.is_full
-    assert sqldict.head.key == "three"
-    assert sqldict.tail.key == "one"
+    assert sqldict.head.key == b"three"
+    assert sqldict.tail.key == b"one"
     assert len(sqldict) == 2
 
     # delete tail
     del sqldict["one"]
 
     assert not sqldict.is_full
-    assert sqldict.head.key == "three"
-    assert sqldict.tail.key == "three"
+    assert sqldict.head.key == b"three"
+    assert sqldict.tail.key == b"three"
     assert len(sqldict) == 1
 
     # empty dict
@@ -122,45 +146,45 @@ def test_delete_item_from_sqldict():
 
 
 def test_lru_cache(sqldict):
-    sqldict["one"] = "abc"
-    sqldict["two"] = "def"
-    sqldict["three"] = "ghi"
+    sqldict["one"] = 1
+    sqldict["two"] = 2
+    sqldict["three"] = 3
 
-    assert sqldict.head.key == "three"
-    assert sqldict.tail.key == "one"
+    assert sqldict.head.key == b"three"
+    assert sqldict.tail.key == b"one"
     assert (list(sqldict.iter_lru_cache())) == [
-        ("three", "ghi"),
-        ("two", "def"),
-        ("one", "abc"),
+        (b"three", 3),
+        (b"two", 2),
+        (b"one", 1),
     ]
 
     # test lru cache updates with getitem
     sqldict["one"]
 
-    assert sqldict.head.key == "one"
-    assert sqldict.tail.key == "two"
+    assert sqldict.head.key == b"one"
+    assert sqldict.tail.key == b"two"
     assert list(sqldict.iter_lru_cache()) == [
-        ("one", "abc"),
-        ("three", "ghi"),
-        ("two", "def"),
+        (b"one", 1),
+        (b"three", 3),
+        (b"two", 2),
     ]
 
     # test lru cache updates with updateitem
-    sqldict["two"] = "xyz"
+    sqldict["two"] = 20
 
-    assert sqldict.head.key == "two"
-    assert sqldict.tail.key == "three"
+    assert sqldict.head.key == b"two"
+    assert sqldict.tail.key == b"three"
     assert list(sqldict.iter_lru_cache()) == [
-        ("two", "xyz"),
-        ("one", "abc"),
-        ("three", "ghi"),
+        (b"two", 20),
+        (b"one", 1),
+        (b"three", 3),
     ]
 
 
 def test_dict_properties(sqldict):
-    sqldict["one"] = "abc"
-    sqldict["two"] = "def"
-    sqldict["three"] = "ghi"
+    sqldict["one"] = 1
+    sqldict["two"] = 2
+    sqldict["three"] = 3
 
     assert sqldict
     assert sqldict.keys()
@@ -169,7 +193,7 @@ def test_dict_properties(sqldict):
     assert len(list(sqldict.items())) == 3
 
     key = sqldict.pop("one")
-    assert key == "abc"
+    assert key == 1
     assert len(sqldict) == 2
 
 

--- a/tests/core/tools/test_lru_sql_dict.py
+++ b/tests/core/tools/test_lru_sql_dict.py
@@ -1,0 +1,203 @@
+import sqlite3
+
+from hypothesis import given
+from hypothesis import strategies as st
+import pytest
+
+from ddht.tools.lru_sql_dict import LRUSQLDict
+
+
+@pytest.fixture
+def sqldict():
+    return LRUSQLDict(sqlite3.connect(":memory:"), cache_size=3)
+
+
+@given(
+    key=st.text(),
+    value=st.integers(min_value=(-(2 ** 63) - 1), max_value=(2 ** 63 - 1)),
+)
+def test_sqldict_with_string_keys(key, value, sqldict):
+    sqldict[key] = value
+    assert sqldict[key] == value
+
+
+@given(
+    key=st.binary(),
+    value=st.integers(min_value=(-(2 ** 63) - 1), max_value=(2 ** 63 - 1)),
+)
+def test_sqldict_with_byte_keys(key, value, sqldict):
+    sqldict[key] = value
+    assert sqldict[key] == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    (None, True, False, 1, 1.2, "string", b"bytes", ("tuple",), ["list"], set("set"),),
+)
+def test_sqldict_set_accepts_picklable_items(sqldict, value):
+    sqldict["key"] = value
+    assert sqldict["key"] == value
+
+
+def test_add_item_to_sqldict(sqldict):
+    sqldict["one"] = "abc"
+
+    assert sqldict["one"] == "abc"
+    assert sqldict.head.key == "one"
+    assert sqldict.tail.key == "one"
+    assert len(sqldict) == 1
+
+    sqldict["two"] = "xyz"
+
+    assert sqldict["two"] == "xyz"
+    assert sqldict.head.key == "two"
+    assert sqldict.tail.key == "one"
+    assert len(sqldict) == 2
+
+    sqldict["three"] = "def"
+
+    assert sqldict["three"] == "def"
+    assert sqldict.head.key == "three"
+    assert sqldict.tail.key == "one"
+    assert len(sqldict) == 3
+    assert sqldict.is_full
+
+    # test update
+    sqldict["two"] = "xyz-1"
+
+    assert sqldict["two"] == "xyz-1"
+    assert sqldict.head.key == "two"
+    assert sqldict.tail.key == "one"
+    assert len(sqldict) == 3
+    assert sqldict.is_full
+
+    sqldict["four"] = "ghi"
+
+    assert sqldict["four"] == "ghi"
+    assert sqldict.is_full
+    assert sqldict.head.key == "four"
+    assert sqldict.tail.key == "three"
+    assert len(sqldict) == 3
+
+
+def test_delete_item_from_sqldict():
+    sqldict = LRUSQLDict(sqlite3.connect(":memory:"), cache_size=4)
+    sqldict["one"] = "abc"
+    sqldict["two"] = "def"
+    sqldict["three"] = "ghi"
+    sqldict["four"] = "jkl"
+
+    assert sqldict.is_full
+    assert not sqldict.is_empty
+
+    # delete middle item
+    del sqldict["two"]
+
+    assert not sqldict.is_full
+    assert sqldict.head.key == "four"
+    assert sqldict.tail.key == "one"
+    assert len(sqldict) == 3
+
+    # delete head
+    del sqldict["four"]
+
+    assert not sqldict.is_full
+    assert sqldict.head.key == "three"
+    assert sqldict.tail.key == "one"
+    assert len(sqldict) == 2
+
+    # delete tail
+    del sqldict["one"]
+
+    assert not sqldict.is_full
+    assert sqldict.head.key == "three"
+    assert sqldict.tail.key == "three"
+    assert len(sqldict) == 1
+
+    # empty dict
+    del sqldict["three"]
+
+    assert sqldict.is_empty
+    assert len(sqldict) == 0
+
+
+def test_lru_cache(sqldict):
+    sqldict["one"] = "abc"
+    sqldict["two"] = "def"
+    sqldict["three"] = "ghi"
+
+    assert sqldict.head.key == "three"
+    assert sqldict.tail.key == "one"
+    assert (list(sqldict.iter_lru_cache())) == [
+        ("three", "ghi"),
+        ("two", "def"),
+        ("one", "abc"),
+    ]
+
+    # test lru cache updates with getitem
+    sqldict["one"]
+
+    assert sqldict.head.key == "one"
+    assert sqldict.tail.key == "two"
+    assert list(sqldict.iter_lru_cache()) == [
+        ("one", "abc"),
+        ("three", "ghi"),
+        ("two", "def"),
+    ]
+
+    # test lru cache updates with updateitem
+    sqldict["two"] = "xyz"
+
+    assert sqldict.head.key == "two"
+    assert sqldict.tail.key == "three"
+    assert list(sqldict.iter_lru_cache()) == [
+        ("two", "xyz"),
+        ("one", "abc"),
+        ("three", "ghi"),
+    ]
+
+
+def test_dict_properties(sqldict):
+    sqldict["one"] = "abc"
+    sqldict["two"] = "def"
+    sqldict["three"] = "ghi"
+
+    assert sqldict
+    assert sqldict.keys()
+    assert len(list(sqldict.keys())) == 3
+    assert len(list(sqldict.values())) == 3
+    assert len(list(sqldict.items())) == 3
+
+    key = sqldict.pop("one")
+    assert key == "abc"
+    assert len(sqldict) == 2
+
+
+def test_get_keyerror_with_empty_dict(sqldict):
+    assert sqldict.is_empty
+    with pytest.raises(KeyError):
+        sqldict["one"]
+
+
+def test_delete_keyerror_with_empty_dict(sqldict):
+    assert sqldict.is_empty
+    with pytest.raises(KeyError):
+        del sqldict["one"]
+
+
+def test_iter_lru_cache_raises_exception_with_empty_dict(sqldict):
+    assert sqldict.is_empty
+    with pytest.raises(Exception):
+        list(sqldict.iter_lru_cache())
+
+
+def test_head_raises_exception_with_empty_dict(sqldict):
+    assert sqldict.is_empty
+    with pytest.raises(Exception):
+        sqldict.head
+
+
+def test_tail_raises_exception_with_empty_dict(sqldict):
+    assert sqldict.is_empty
+    with pytest.raises(Exception):
+        sqldict.tail

--- a/tests/core/v5_1/alexandria/test_broadcast_log.py
+++ b/tests/core/v5_1/alexandria/test_broadcast_log.py
@@ -5,7 +5,7 @@ from ddht.v5_1.alexandria.broadcast_log import BroadcastLog
 
 
 @pytest.mark.trio
-async def test_broadcast_log(alice, bob):
+async def test_broadcast_log(alice, bob, conn):
     ad_a = AdvertisementFactory(private_key=alice.private_key)
     ad_b = AdvertisementFactory(private_key=alice.private_key)
     ad_c = AdvertisementFactory(private_key=alice.private_key)
@@ -14,7 +14,7 @@ async def test_broadcast_log(alice, bob):
 
     all_ads = (ad_a, ad_b, ad_c, ad_d, ad_e)
 
-    broadcast_log = BroadcastLog(max_records=8)
+    broadcast_log = BroadcastLog(conn, max_records=8)
 
     # not logged when empty
     for ad in all_ads:


### PR DESCRIPTION
## What was wrong?
Fixes #283 

## How was it fixed?
Update `BroadcastLog` to use a sql-backed LRU dict.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/102792447-d1e5d800-43a8-11eb-9baf-4511497ea168.png)

