### PR TITLE
Replace encoded message cipher with empty bytes for WHOAREYOU packet

### DIFF
--- a/ddht/base_message.py
+++ b/ddht/base_message.py
@@ -15,6 +15,11 @@ class BaseMessage(rlp.Serializable):  # type: ignore
         return b"".join((int_to_big_endian(self.message_type), rlp.encode(self)))
 
 
+class EmptyMessage(BaseMessage):
+    def to_bytes(self) -> bytes:
+        return b""
+
+
 TMessage = TypeVar("TMessage")
 TBaseMessage = TypeVar("TBaseMessage", bound=BaseMessage)
 TResponseMessage = TypeVar("TResponseMessage", bound=BaseMessage)

--- a/ddht/v5_1/packets.py
+++ b/ddht/v5_1/packets.py
@@ -10,7 +10,7 @@ from eth_typing import NodeID
 from eth_utils.toolz import take
 import rlp
 
-from ddht.base_message import BaseMessage
+from ddht.base_message import BaseMessage, EmptyMessage
 from ddht.constants import UINT8_TO_BYTES
 from ddht.encryption import aesctr_decrypt_stream, aesctr_encrypt, aesgcm_encrypt
 from ddht.exceptions import DecodingError
@@ -244,16 +244,17 @@ class Packet(Generic[TAuthData]):
             auth_data_size,
         )
         authenticated_data = b"".join((iv, header.to_wire_bytes(), auth_data_bytes,))
-        # if empty, don't use an encrypted empty bytestring as the message_cipher_text field
-        if message.to_bytes():
+        # encrypted empty bytestring results in a bytestring,
+        # which we don't want if message is supposed to be empty
+        if type(message) is EmptyMessage:
+            message_cipher_text = b""
+        else:
             message_cipher_text = aesgcm_encrypt(
                 key=initiator_key,
                 nonce=aes_gcm_nonce,
                 plain_text=message.to_bytes(),
                 authenticated_data=authenticated_data,
             )
-        else:
-            message_cipher_text = b""
 
         return cls(
             iv=iv,

--- a/ddht/v5_1/packets.py
+++ b/ddht/v5_1/packets.py
@@ -244,12 +244,17 @@ class Packet(Generic[TAuthData]):
             auth_data_size,
         )
         authenticated_data = b"".join((iv, header.to_wire_bytes(), auth_data_bytes,))
-        message_cipher_text = aesgcm_encrypt(
-            key=initiator_key,
-            nonce=aes_gcm_nonce,
-            plain_text=message.to_bytes(),
-            authenticated_data=authenticated_data,
-        )
+        # if empty, don't use an encrypted empty bytestring as the message_cipher_text field
+        if message.to_bytes():
+            message_cipher_text = aesgcm_encrypt(
+                key=initiator_key,
+                nonce=aes_gcm_nonce,
+                plain_text=message.to_bytes(),
+                authenticated_data=authenticated_data,
+            )
+        else:
+            message_cipher_text = b""
+
         return cls(
             iv=iv,
             header=header,

--- a/ddht/v5_1/session.py
+++ b/ddht/v5_1/session.py
@@ -13,7 +13,12 @@ import trio
 
 from ddht._utils import humanize_node_id
 from ddht.abc import HandshakeSchemeAPI, HandshakeSchemeRegistryAPI
-from ddht.base_message import AnyInboundMessage, AnyOutboundMessage, BaseMessage
+from ddht.base_message import (
+    AnyInboundMessage,
+    AnyOutboundMessage,
+    BaseMessage,
+    EmptyMessage,
+)
 from ddht.endpoint import Endpoint
 from ddht.exceptions import DecryptionError, HandshakeFailure
 from ddht.message_registry import MessageTypeRegistry
@@ -203,11 +208,6 @@ class RandomMessage(BaseMessage):
 
     def to_bytes(self) -> bytes:
         return self.random_data
-
-
-class EmptyMessage(BaseMessage):
-    def to_bytes(self) -> bytes:
-        return b""
 
 
 #


### PR DESCRIPTION
## What was wrong?
Packets using `EmptyMessage` for the message data, when the packet is `aesgcm_encrypt`'ed would result with a populated `message_cipher_text` field rather than simply an empty bytestring. 

Summary of approach.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/112674250-97834f80-8e5d-11eb-8375-c0f1c983b4f9.png)

