### PR TITLE
Drop old sessions

### DIFF
--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     AsyncContextManager,
     Collection,
+    Container,
     NamedTuple,
     Optional,
     Protocol,
@@ -101,6 +102,27 @@ class SessionAPI(ABC):
     def timeout_at(self) -> float:
         ...
 
+    @property
+    @abstractmethod
+    def stale_at(self) -> float:
+        """
+        At what (trio) time will the session be "stale"?
+
+        A session becomes stale when the other peer has not sent any message
+        for SESSION_IDLE_TIMEOUT.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def is_stale(self) -> bool:
+        """
+        Is the current session stale?
+
+        See :meth:`~stale_at` for definition of stale.
+        """
+        ...
+
     #
     # Handshake Status
     #
@@ -183,7 +205,7 @@ class EventsAPI(ABC):
     topic_query_received: EventAPI[InboundMessage[TopicQueryMessage]]
 
 
-class PoolAPI(ABC):
+class PoolAPI(ABC, Container[uuid.UUID]):
     local_private_key: keys.PrivateKey
     local_node_id: NodeID
 

--- a/ddht/v5_1/app.py
+++ b/ddht/v5_1/app.py
@@ -102,6 +102,9 @@ class Application(BaseApplication):
             # Update the ENR if an explicit listening address was provided
             enr_manager.update((IP_V4_ADDRESS_ENR_KEY, listen_on_ip_address.packed))
 
+        if listen_on_ip_address.is_loopback:
+            raise Exception("Cannot bind to localhost. Must choose a different IP")
+
         listen_on = Endpoint(listen_on_ip_address.packed, self._boot_info.port)
 
         if self._boot_info.is_upnp_enabled:

--- a/ddht/v5_1/pool.py
+++ b/ddht/v5_1/pool.py
@@ -57,6 +57,9 @@ class Pool(PoolAPI):
         # callback to remove LRU evicted session from _sessions_by_endpoint
         self._sessions_by_endpoint[value.remote_endpoint].remove(value)
 
+    def __contains__(self, session_id: object) -> bool:
+        return session_id in self._sessions
+
     def remove_session(self, session_id: uuid.UUID) -> SessionAPI:
         try:
             session = self._sessions[session_id]

--- a/newsfragments/344.feature.rst
+++ b/newsfragments/344.feature.rst
@@ -1,0 +1,3 @@
+Drop peer session if no messages received for 60 seconds. Fail immediately if you try to launch with
+127.0.0.1, because you can't send outbound messages away from your machine that way. (and get ugly
+stack traces and a crash)


### PR DESCRIPTION
## What was wrong?

Old sessions never got dropped. Also, when binding to loopback addresses, ddht would crash when trying to send to non-local addresses.

## How was it fixed?

Track session activity, and time out if peer doesn't send any messages for a while.

Explicitly warn the user about the localhost issue, instead of failing spectacularly later.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/5967800320/hE2361575/hush-deer)
