### PR TITLE
Laxer session timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,18 @@ clean-pyc:
 lint:
 	tox -elint
 
+# Some lint can be auto-corrected. This job will do that and warn about the
+# others. It doesn't use tox, because tox is slow and heavy. Because docs are
+# always stale, this is probably stale, and you should update it to match the
+# tox.ini section on the 'lint' job.
 lint-roll:
+	# Front-load the auto-correcting tools like isort and black
 	isort ddht tests
 	black ddht tests
-	$(MAKE) lint
+	# Back-load the warning-only tools
+	mypy -p ddht --config-file mypy.ini
+	flake8 ddht tests
+	pydocstyle ddht tests
 
 test:
 	pytest tests

--- a/ddht/v5_1/abc.py
+++ b/ddht/v5_1/abc.py
@@ -104,22 +104,12 @@ class SessionAPI(ABC):
 
     @property
     @abstractmethod
-    def stale_at(self) -> float:
+    def is_stale(self) -> bool:
         """
-        At what (trio) time will the session be "stale"?
+        Is the current session "stale"?
 
         A session becomes stale when the other peer has not sent any message
         for SESSION_IDLE_TIMEOUT.
-        """
-        ...
-
-    @property
-    @abstractmethod
-    def is_stale(self) -> bool:
-        """
-        Is the current session stale?
-
-        See :meth:`~stale_at` for definition of stale.
         """
         ...
 

--- a/newsfragments/344.feature.rst
+++ b/newsfragments/344.feature.rst
@@ -1,3 +1,2 @@
-Drop peer session if no messages received for 60 seconds. Fail immediately if you try to launch with
-127.0.0.1, because you can't send outbound messages away from your machine that way. (and get ugly
-stack traces and a crash)
+Fail immediately if you try to launch with 127.0.0.1, because you can't send outbound messages away
+from your machine that way. (and get ugly stack traces and a crash)

--- a/newsfragments/345.feature.rst
+++ b/newsfragments/345.feature.rst
@@ -1,0 +1,1 @@
+Drop peer session if no messages received for 60 seconds.


### PR DESCRIPTION
## What was wrong?

Session timeout was too aggressive. See #344 

## How was it fixed?

Only drop session if our pings are unponged

We were aggressively dropping all quiet sessions, even if we weren't
asking the peer for any info.

Bonus: a quick make target for a quick lint check. (too many to run manually)
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/65/e3/ae/65e3aeb92acb43e76069835fd91b723e.jpg)
