### PR TITLE
Portal network

### DIFF
--- a/ddht/v5_1/alexandria/client.py
+++ b/ddht/v5_1/alexandria/client.py
@@ -494,7 +494,9 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
                 try:
                     message = decode_message(request.message.payload)
                 except DecodingError:
-                    pass
+                    self.logger.debug(
+                        "TALKREQ failed to parse: %r", request, exc_info=True
+                    )
                 else:
                     if message.type != AlexandriaMessageType.REQUEST:
                         self.logger.debug(
@@ -527,7 +529,9 @@ class AlexandriaClient(Service, AlexandriaClientAPI):
                 try:
                     message = decode_message(response.message.payload)
                 except DecodingError:
-                    pass
+                    self.logger.debug(
+                        "TALKRESP failed to parse: %r", response, exc_info=True
+                    )
                 else:
                     if message.type != AlexandriaMessageType.RESPONSE:
                         self.logger.debug(

--- a/ddht/v5_1/alexandria/constants.py
+++ b/ddht/v5_1/alexandria/constants.py
@@ -2,7 +2,7 @@ from typing import Tuple
 
 from ddht.constants import DISCOVERY_MAX_PACKET_SIZE
 
-ALEXANDRIA_PROTOCOL_ID = b"alexandria"
+ALEXANDRIA_PROTOCOL_ID = b"portal"
 
 DEFAULT_BOOTNODES: Tuple[str, ...] = ()
 

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -128,7 +128,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         self, node_id: NodeID, *, endpoint: Optional[Endpoint] = None
     ) -> bool:
         self.logger.debug2(
-            "Bonding with %s", node_id.hex(),
+            "Bonding on Portal Network with %s...", node_id.hex(),
         )
 
         try:
@@ -155,7 +155,7 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
         self.routing_table.update(enr.node_id)
 
         self.logger.debug(
-            "Bonded with %s successfully", node_id.hex(),
+            "Bonded on Portal Network with %s successfully", node_id.hex(),
         )
 
         self._routing_table_ready.set()

--- a/ddht/v5_1/alexandria/sedes.py
+++ b/ddht/v5_1/alexandria/sedes.py
@@ -1,4 +1,4 @@
-from ssz.sedes import Container, List, uint8, uint16, uint32, uint256
+from ssz.sedes import Container, List, uint8, uint16, uint64, uint256
 
 
 class ByteList(List):  # type: ignore
@@ -15,8 +15,8 @@ class ByteList(List):  # type: ignore
 byte_list = ByteList(max_length=2048)
 
 
-PingSedes = Container(field_sedes=(uint32, uint256))
-PongSedes = Container(field_sedes=(uint32, uint256))
+PingSedes = Container(field_sedes=(uint64, uint256))
+PongSedes = Container(field_sedes=(uint64, uint256))
 
 FindNodesSedes = Container(field_sedes=(List(uint16, max_length=256),))
 FoundNodesSedes = Container(field_sedes=(uint8, List(byte_list, max_length=32)))

--- a/ddht/v5_1/network.py
+++ b/ddht/v5_1/network.py
@@ -794,6 +794,7 @@ class Network(Service, NetworkAPI):
         async with self.dispatcher.subscribe(TalkRequestMessage) as subscription:
             async for request in subscription:
                 if request.message.protocol not in self._talk_protocols:
+                    self.logger.debug("Unhandled TALKREQ: %s", request)
                     await self.client.send_talk_response(
                         request.sender_node_id,
                         request.sender_endpoint,

--- a/newsfragments/346.bugfix.rst
+++ b/newsfragments/346.bugfix.rst
@@ -1,0 +1,1 @@
+Encode ENR sequence number with 64 bits, as mentioned in ENR spec.

--- a/newsfragments/346.feature.rst
+++ b/newsfragments/346.feature.rst
@@ -1,0 +1,1 @@
+Update overlay network ID to "portal".


### PR DESCRIPTION
## What was wrong?

A few interop bugs with `trin`.

## How was it fixed?

- Update the network protocol name to "portal"
- Update the ENR sequence number to 64 bits
- Bonus logging improvements

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

[//]: # (See: https://ddht.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/ddht/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/29/f9/0c/29f90ce1d772a07704aada225447e170.jpg)