### PR TITLE
Source nodes from content logarithmic distance instead of actual distance

### DIFF
--- a/ddht/v5_1/alexandria/content.py
+++ b/ddht/v5_1/alexandria/content.py
@@ -13,3 +13,7 @@ def compute_content_distance(node_id: NodeID, content_id: ContentID) -> int:
     node_id_int = int.from_bytes(node_id, "big")
     content_id_int = int.from_bytes(content_id, "big")
     return node_id_int ^ content_id_int
+
+
+def compute_content_log_distance(node_id: NodeID, content_id: ContentID) -> int:
+    return compute_content_distance(node_id, content_id).bit_length()

--- a/ddht/v5_1/alexandria/network.py
+++ b/ddht/v5_1/alexandria/network.py
@@ -28,7 +28,7 @@ from ddht.v5_1.alexandria.abc import AlexandriaNetworkAPI, ContentStorageAPI
 from ddht.v5_1.alexandria.client import AlexandriaClient
 from ddht.v5_1.alexandria.constants import MAX_RADIUS
 from ddht.v5_1.alexandria.content import (
-    compute_content_distance,
+    compute_content_log_distance,
     content_key_to_content_id,
 )
 from ddht.v5_1.alexandria.messages import (
@@ -376,12 +376,14 @@ class AlexandriaNetwork(Service, AlexandriaNetworkAPI):
                     )
                 else:
                     content_id = content_key_to_content_id(content_key)
-                    distance = compute_content_distance(self.local_node_id, content_id)
+                    distance = compute_content_log_distance(
+                        self.local_node_id, content_id
+                    )
                     try:
                         response_enrs = self._source_nodes((distance,))
                     except ValidationError as err:
                         self.logger.debug(
-                            "Ignoring invalid FindNodesMessage from %s@%s: %s",
+                            "Ignoring invalid FindContentMessage from %s@%s: %s",
                             request.sender_node_id.hex(),
                             request.sender_endpoint,
                             err,


### PR DESCRIPTION
## What was wrong?

Receiving a FindContent request would error out at https://github.com/ethereum/ddht/blob/12216c70e1411adf53f318b42800e9f1b2b11703/ddht/v5_1/alexandria/network.py#L318
This is because the regular distance is being passed: https://github.com/ethereum/ddht/blob/12216c70e1411adf53f318b42800e9f1b2b11703/ddht/v5_1/alexandria/network.py#L379
Noticed this issue when testing interopt with Nim implementation.

## How was it fixed?

Pass the logarithmic distance instead.  Calculation added similar like it is already being done here https://github.com/ethereum/ddht/blob/743f3f3eaabb3b864b70e1bf78d441b5f0bdad46/ddht/kademlia.py#L108

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/7857583/120701094-c0097480-c4b2-11eb-8ca1-9ad6fa41911a.png)

